### PR TITLE
Return a json body response for 404's for nova get and delete server (ready for review)

### DIFF
--- a/mimic/canned_responses/nova.py
+++ b/mimic/canned_responses/nova.py
@@ -2,6 +2,28 @@ from random import randrange
 server_addresses_cache = {}
 
 
+def not_found_response(resource='servers'):
+    """
+    Return a 404 response body for Nova, depending on the resource.  Expects
+    resource to be one of "servers", "images", or "flavors".
+
+    If the resource is unrecognized, defaults to
+    "The resource culd not be found."
+    """
+    message = {
+        'servers': "Instance could not be found",
+        'images': "Image not found.",
+        'flavors': "The resource could not be found."
+    }
+
+    return {
+        "itemNotFound": {
+            "message": message.get(resource, "The resource could not be found."),
+            "code": 404
+        }
+    }
+
+
 def get_server(tenant_id, server_info):
     """
     Canned response for get server.

--- a/mimic/rest/nova_api.py
+++ b/mimic/rest/nova_api.py
@@ -6,7 +6,8 @@ import json
 from twisted.web.server import Request
 from mimic.canned_responses.nova import (get_server, get_limit,
                                          create_server_example,
-                                         get_image, get_flavor, list_addresses)
+                                         get_image, get_flavor, list_addresses,
+                                         not_found_response)
 from mimic.rest.mimicapp import MimicApp
 
 Request.defaultContentType = 'application/json'
@@ -41,7 +42,8 @@ class NovaApi():
             request.setResponseCode(200)
             return json.dumps(get_server(tenant_id, self.s_cache[server_id]))
         else:
-            return request.setResponseCode(404)
+            request.setResponseCode(404)
+            return json.dumps(not_found_response())
 
     @app.route('/v2/<string:tenant_id>/servers', methods=['GET'])
     def list_servers(self, request, tenant_id):
@@ -75,7 +77,8 @@ class NovaApi():
             log.msg(self.s_cache)
             return request.setResponseCode(204)
         else:
-            return request.setResponseCode(404)
+            request.setResponseCode(404)
+            return json.dumps(not_found_response())
 
     @app.route('/v2/<string:tenant_id>/images/<string:image_id>', methods=['GET'])
     def get_image(self, request, tenant_id, image_id):


### PR DESCRIPTION
Apologies, this is probably not the best way to do it.  I did look up the 404 responses for nova for servers/images/flavors though, and these are the responses. 
