### PR TITLE
fixed create server without metadata

### DIFF
--- a/mimic/canned_responses/nova.py
+++ b/mimic/canned_responses/nova.py
@@ -75,7 +75,7 @@ def server_template(tenant_id, server_info, server_id, status):
                 "rel": "bookmark"
             }
         ],
-        "metadata": server_info.get('metadata') or None,
+        "metadata": server_info.get('metadata'),
         "name": server_info['name'],
         "progress": 100,
         "status": status,
@@ -91,7 +91,7 @@ def create_server(tenant_id, server_info, server_id):
     Canned response for create server and adds the server to the server cache.
     """
     status = "ACTIVE"
-    if server_info.get('metadata'):
+    if 'metadata' in server_info:
         if 'create_server_failure' in server_info['metadata']:
             dict_meta = json.loads(server_info['metadata']['create_server_failure'])
             return invalid_resource(dict_meta['message'], dict_meta['code']), dict_meta['code']


### PR DESCRIPTION
Create server was failing with a 500 if metadata was not provided. 
