### PR TITLE
fix for #35

### DIFF
--- a/mimic/canned_responses/nova.py
+++ b/mimic/canned_responses/nova.py
@@ -78,7 +78,7 @@ def server_template(tenant_id, server_info, server_id, status):
                 "rel": "bookmark"
             }
         ],
-        "metadata": server_info.get('metadata'),
+        "metadata": server_info.get('metadata') or {},
         "name": server_info['name'],
         "progress": 100,
         "status": status,


### PR DESCRIPTION
Creating a server without metadata and then trying to delete it results in error 500. 

On create server we are setting the metadata to 'None' if not provided by the user, where as `delete_server` in the canned responses for nova is looking for a key in the metadata dict, hence resulting in TypeError.  

Also, Openstack Nova sets the metadata to be {} when not provided.
