### PR TITLE
Remove some hard-coded default callables

### DIFF
--- a/mimic/canned_responses/auth.py
+++ b/mimic/canned_responses/auth.py
@@ -3,7 +3,6 @@
 Canned response for get auth token
 """
 from datetime import datetime, timedelta
-from mimic.catalog import Entry
 
 
 GLOBAL_MUTABLE_AUTH_STORE = {}
@@ -15,22 +14,6 @@ HARD_CODED_USER_NAME = "autoscaleaus"
 HARD_CODED_ROLES = [{"id": "1", "description": "Admin", "name": "Identity"}]
 
 
-def HARD_CODED_PREFIX(entry):
-    """
-    Temporary hack.
-    """
-    # ugly hack corresponding to hard-coding in mimic.tap, eliminate as soon as
-    # that is gone.  note that the responsibility here is correct though; URI
-    # generation belongs in the auth system.
-    port_offset_by_service = {
-        "compute": 2,
-        "rax:load-balancer": 3,
-    }
-    return "http://localhost:{port}/".format(
-        port=8900 + port_offset_by_service[entry.type]
-    )
-
-
 def format_timestamp(dt):
     """
     Format the given timestamp.
@@ -40,28 +23,14 @@ def format_timestamp(dt):
     return dt.strftime('%Y-%m-%dT%H:%M:%S.999-05:00')
 
 
-def canned_entries(tenant_id):
-    """
-    Some canned catalog entries.
-    """
-    return [
-        Entry.with_regions(
-            tenant_id, "compute", "cloudServersOpenStack", ["ORD"]
-        ),
-        Entry.with_regions(
-            tenant_id, "rax:load-balancer", "cloudLoadBalancers", ["ORD"]
-        ),
-    ]
-
-
 def get_token(tenant_id,
+              entry_generator,
+              prefix_for_entry,
               timestamp=format_timestamp,
-              entry_generator=canned_entries,
               response_token=HARD_CODED_TOKEN,
               response_user_id=HARD_CODED_USER_ID,
               response_user_name=HARD_CODED_USER_NAME,
-              response_roles=HARD_CODED_ROLES,
-              prefix_for_entry=HARD_CODED_PREFIX):
+              response_roles=HARD_CODED_ROLES):
     """
     Canned response for authentication, with service catalog containing
     endpoints only for services implemented by Mimic.
@@ -112,8 +81,7 @@ def get_token(tenant_id,
     }
 
 
-def get_endpoints(tenant_id, entry_generator=canned_entries,
-                  prefix_for_entry=HARD_CODED_PREFIX):
+def get_endpoints(tenant_id, entry_generator, prefix_for_entry):
     """
     Canned response for Identity's get endpoints call.  This returns endpoints
     only for the services implemented by Mimic.

--- a/mimic/test/test_auth.py
+++ b/mimic/test/test_auth.py
@@ -81,7 +81,8 @@ class CatalogGenerationTests(SynchronousTestCase):
         self.assertEqual(
             get_token(
                 tenant_id=tenant_id, timestamp=lambda dt: "<<<timestamp>>>",
-                entry_generator=example_endpoints(lambda: 1)
+                entry_generator=example_endpoints(lambda: 1),
+                prefix_for_entry=lambda e: 'prefix'
             ),
             {
                 "access": {
@@ -161,6 +162,7 @@ class CatalogGenerationTests(SynchronousTestCase):
             get_endpoints(
                 tenant_id=tenant_id,
                 entry_generator=example_endpoints(counter),
+                prefix_for_entry=lambda e: 'prefix'
             ),
             {
                 "endpoints": [


### PR DESCRIPTION
Previously, get_token and get_endpoints provided default hardcoded entry generators and prefix callables.  Just make those required, rather than provide confusing default dummy ones, which never get used anyway.
