### PR TITLE
slightly nicer test setup: use trial, allow for posargs to set trial arguments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,17 +4,15 @@ envlist = py26, py27, pypy, docs, lint
 [testenv]
 deps =
     coverage
-    unittest2
-    discover
 commands =
     coverage erase
-    coverage run -m unittest discover
+    coverage run {envbindir}/trial --rterrors {posargs:mimic}
     coverage report -m
 
 [testenv:py26]
 commands =
     coverage erase
-    coverage run -m discover
+    coverage run {envbindir}/trial --rterrors {posargs:mimic}
     coverage report -m
 
 [testenv:docs]


### PR DESCRIPTION
You can now run individual tests with `tox -- mimic.test.test_something_specific`.
