### PR TITLE
RFR: Rackconnect v3 Load Balancer Pool support

### DIFF
--- a/mimic/plugins/rackconnect_v3_plugin.py
+++ b/mimic/plugins/rackconnect_v3_plugin.py
@@ -1,5 +1,5 @@
 """
-Plugin for Rackspace cloud load balancer mock.
+Plugin for Rackspace RackConnect V3
 """
 from mimic.rest.rackconnect_v3_api import RackConnectV3
 

--- a/mimic/plugins/rackconnect_v3_plugin.py
+++ b/mimic/plugins/rackconnect_v3_plugin.py
@@ -1,0 +1,6 @@
+"""
+Plugin for Rackspace cloud load balancer mock.
+"""
+from mimic.rest.rackconnect_v3_api import RackConnectV3
+
+rackconnect = RackConnectV3()

--- a/mimic/rest/rackconnect_v3_api.py
+++ b/mimic/rest/rackconnect_v3_api.py
@@ -2,7 +2,7 @@
 
 """
 API mock for the Rackspace RackConnect v3 API, which is documented at:
-http://http://docs.rcv3.apiary.io/
+http://docs.rcv3.apiary.io/
 """
 from collections import defaultdict
 import json
@@ -44,7 +44,7 @@ class RackConnectV3(object):
 
     def catalog_entries(self, tenant_id):
         """
-        Catalog entry for Swift endpoints.
+        Catalog entry for RackConnect V3 endpoints.
         """
         #TODO: figure out the correct type and name for RackConnect
         return [
@@ -56,7 +56,8 @@ class RackConnectV3(object):
 
     def resource_for_region(self, region, uri_prefix, session_store):
         """
-        Return an IResource implementing a public Swift region endpoint.
+        Return an IResource implementing a public RackConnect V3 region
+        endpoint.
         """
         return RackConnectV3Region(
             iapi=self,

--- a/mimic/rest/rackconnect_v3_api.py
+++ b/mimic/rest/rackconnect_v3_api.py
@@ -73,9 +73,9 @@ class RackConnectV3(object):
 
 lb_pool_attrs = [
     Attribute("id", default_factory=lambda: text_type(uuid4())),
-    Attribute("name", default_value="default", instance_of=basestring),
+    Attribute("name", default_value=u"default", instance_of=text_type),
     Attribute("port", default_value=80, instance_of=int),
-    Attribute("status", default_value="ACTIVE", instance_of=basestring),
+    Attribute("status", default_value=u"ACTIVE", instance_of=text_type),
     Attribute("status_detail", default_value=None),
     Attribute("virtual_ip", default_factory=random_ipv4),
     Attribute('nodes', default_factory=list, instance_of=list)]

--- a/mimic/rest/rackconnect_v3_api.py
+++ b/mimic/rest/rackconnect_v3_api.py
@@ -12,7 +12,7 @@ from characteristic import attributes, Attribute
 from six import text_type
 
 from twisted.plugin import IPlugin
-from twisted.web.http import NOT_FOUND
+from twisted.web.http import NOT_FOUND, NOT_IMPLEMENTED
 from twisted.web.server import Request
 from zope.interface import implementer
 
@@ -282,3 +282,28 @@ class OneLoadBalancerPool(object):
         List all the nodes for the load balancer pool
         """
         return json.dumps([node.short_json() for node in self.pool.nodes])
+
+    @app.route("/nodes/details", methods=["GET"])
+    def get_node_collection_details_information(self, request):
+        """
+        Get detailed information about all the nodes, including the cloud
+        server network information.  This is unimplemented as it might
+        need to be hooked up to the nova api.
+        """
+        request.setResponseCode(NOT_IMPLEMENTED)
+
+    @app.route("/nodes", methods=["POST"])
+    def add_single_pool_node(self, request):
+        """
+        Add a single pool node to the load balancer pool is not implemented
+        yet.
+        """
+        request.setResponseCode(NOT_IMPLEMENTED)
+
+    @app.route("/nodes/<string:node_id>", branch=True)
+    def handle_single_node_requests(self, request, node_id):
+        """
+        Catchall to specify that single node operations (GET, DELETE,
+        GET details) are not implemented yet
+        """
+        request.setResponseCode(NOT_IMPLEMENTED)

--- a/mimic/rest/rackconnect_v3_api.py
+++ b/mimic/rest/rackconnect_v3_api.py
@@ -31,13 +31,16 @@ Request.defaultContentType = 'application/json'
 class RackConnectV3(object):
     """
     API mock object for RackConnect V3.
+
+    :ivar regions: The regions for which endpoints should be produced
+    :type regions: `iterable`
     """
 
-    def __init__(self, regions=None):
+    def __init__(self, regions=("ORD",)):
         """
         Construct a :class:`RackConnectV3` object.
         """
-        self._regions = regions or ["ORD"]
+        self.regions = regions
 
     def catalog_entries(self, tenant_id):
         """
@@ -47,7 +50,7 @@ class RackConnectV3(object):
         return [
             Entry(tenant_id, "rax:rackconnect", "rackConnect", [
                 Endpoint(tenant_id, region, text_type(uuid4()), prefix="v3")
-                for region in self._regions
+                for region in self.regions
             ])
         ]
 

--- a/mimic/rest/rackconnect_v3_api.py
+++ b/mimic/rest/rackconnect_v3_api.py
@@ -78,11 +78,7 @@ lb_pool_attrs = [
     Attribute("status", default_value="ACTIVE", instance_of=basestring),
     Attribute("status_detail", default_value=None),
     Attribute("virtual_ip", default_factory=random_ipv4),
-    Attribute('nodes', default_factory=list, instance_of=list,
-              # since this is mutable, it's unhashable, and should be
-              # excluded from cmp because it may cause other hard-to-diagnose
-              # errors
-              exclude_from_cmp=True)]
+    Attribute('nodes', default_factory=list, instance_of=list)]
 
 
 @attributes(lb_pool_attrs, apply_with_cmp=False)

--- a/mimic/rest/rackconnect_v3_api.py
+++ b/mimic/rest/rackconnect_v3_api.py
@@ -240,8 +240,18 @@ class LoadBalancerPoolsInRegion(object):
         """
         API call to list all load balancer pools for the tenant and region
         correspoding to this handler.  Returns 200 always.
+
+        http://docs.rcv3.apiary.io/#get-%2Fv3%2F%7Btenant_id%7D%2Fload_balancer_pools
         """
         return json.dumps([pool.as_json() for pool in self.lbpools])
+
+    @app.route("/nodes", methods=["POST"])
+    def bulk_add_nodes_to_load_balancer_pools(self, request):
+        """
+        Add multiple nodes to multiple load balancer pools.
+
+        http://docs.rcv3.apiary.io/#post-%2Fv3%2F%7Btenant_id%7D%2Fload_balancer_pools%2Fnodes
+        """
 
     @app.route("/<string:id>", branch=True)
     def delegate_to_one_pool_handler(self, request, id):
@@ -280,13 +290,19 @@ class OneLoadBalancerPool(object):
 
         Returns a 200 because the pool definitely exists by the time this
         handler is invoked.
+
+        http://docs.rcv3.apiary.io/#get-%2Fv3%2F%7Btenant_id%7D%2Fload_balancer_pools%2F%7Bid%7D
         """
         return json.dumps(self.pool.as_json())
 
     @app.route("/nodes", methods=["GET"])
     def get_node_collection_information(self, request):
         """
-        List all the nodes for the load balancer pool
+        List all the nodes for the load balancer pool.
+
+        Returns a 200 always.
+
+        http://docs.rcv3.apiary.io/#get-%2Fv3%2F%7Btenant_id%7D%2Fload_balancer_pools%2F%7Bload_balancer_pool_id%7D%2Fnodes
         """
         return json.dumps([node.short_json() for node in self.pool.nodes])
 
@@ -296,6 +312,8 @@ class OneLoadBalancerPool(object):
         Get detailed information about all the nodes, including the cloud
         server network information.  This is unimplemented as it might
         need to be hooked up to the nova api.
+
+        http://docs.rcv3.apiary.io/#get-%2Fv3%2F%7Btenant_id%7D%2Fload_balancer_pools%2F%7Bload_balancer_pool_id%7D%2Fnodes%2Fdetails
         """
         request.setResponseCode(NOT_IMPLEMENTED)
 
@@ -304,6 +322,8 @@ class OneLoadBalancerPool(object):
         """
         Add a single pool node to the load balancer pool is not implemented
         yet.
+
+        http://docs.rcv3.apiary.io/#post-%2Fv3%2F%7Btenant_id%7D%2Fload_balancer_pools%2F%7Bload_balancer_pool_id%7D%2Fnodes
         """
         request.setResponseCode(NOT_IMPLEMENTED)
 

--- a/mimic/rest/rackconnect_v3_api.py
+++ b/mimic/rest/rackconnect_v3_api.py
@@ -1,0 +1,136 @@
+# -*- test-case-name: mimic.test.test_rackconnect_v3 -*-
+
+"""
+API mock for the Rackspace RackConnect v3 API, which is documented at:
+http://http://docs.rcv3.apiary.io/
+"""
+
+from json import dumps
+from uuid import uuid4, uuid5, NAMESPACE_URL
+
+from characteristic import attributes, Attribute
+from six import text_type
+
+from twisted.plugin import IPlugin
+from twisted.web.http import CREATED, ACCEPTED, OK
+from twisted.web.resource import NoResource
+from zope.interface import implementer
+
+from mimic.catalog import Entry
+from mimic.catalog import Endpoint
+from mimic.imimic import IAPIMock
+from mimic.rest.mimicapp import MimicApp
+from mimic.util.helper import attribute_names, random_ipv4
+
+
+lb_pool_attrs = [
+    Attribute("id", default_factory=lambda: text_type(uuid4()),
+              instance_of=str),
+    Attribute("name", default_value="default", instance_of=str),
+    Attribute("port", default_value=80, instance_of=int),
+    Attribute("status", default_value="ACTIVE", instance_of=str),
+    Attribute("status_detail", default_value=None),
+    Attribute("virtual_ip", default_factory=random_ipv4, instance_of=str),
+    Attribute('nodes', default_factory=list, instance_of=list)]
+
+
+@attributes(lb_pool_attrs)
+class LoadBalancerPool(object):
+    """
+    Represents a Load Balancer Pool, which cannot be created via the API.
+
+    :param str id: The ID of the load balancer pool - is randomly generated
+        if not provided
+    :param str name: The name of the load balancer pool - defaults to
+        'default'
+    :param int port: The incoming port of the load balancer - defaults to 80
+    :param str status: The status of the load balancer - defaults to "ACTIVE"
+    :param str status_detail: Any details about the status - defaults to None
+    :param list nodes: :class:`LoadBalancerPoolNode`s
+    """
+    def as_json(self):
+        """
+        Create a JSON-serializable representation of the contents of this
+        object, which can be used in a REST response for a request for the
+        details of this particular object
+        """
+        response = {attr: getattr(self, attr) for attr in
+                    attribute_names(lb_pool_attrs) if attr != "nodes"}
+        response['node_counts'] = {
+            "cloud_servers": len(self.nodes),
+            "external": 0,
+            "total": len(self.nodes)
+        }
+        return response
+
+    def node_by_cloud_server(self, cloud_server_id):
+        """
+        Find a node by it's cloud server ID.
+        """
+        return next((node for node in self.nodes
+                     if node.cloud_server == cloud_server_id),
+                    None)
+
+    def node_by_id(self, node_id):
+        """
+        Find a node by it's node_id.
+        """
+        return next((node for node in self.nodes if node.id == node_id), None)
+
+
+
+# XXX: External nodes are not currently supported in RackConnectV3
+lb_node_attrs = [
+    "created", "load_balancer_pool", "cloud_server",
+    Attribute("id", default_factory=lambda: text_type(uuid4()),
+              instance_of=str),
+    Attribute("updated", default_value=None),
+    Attribute("status", default_value="ACTIVE", instance_of=str),
+    Attribute("status_detail", default_value=None)]
+
+
+@attributes(lb_node_attrs)
+class LoadBalancerPoolNode(object):
+    """
+    Represents a Load Balancer Pool Node.
+
+    :param str id: The ID of the load balancer pool node - is randomly
+        generated if not provided
+    :param str created: The timestamp of when the load balancer node was
+        created
+    :param str updated: The timestamp of when the load balancer node was
+        updated.  Can be None.
+    :param load_balancer_pool: :class:`LoadBalancerPool` to which
+        this node belongs
+    :param str status: The status of the load balancer - defaults to "ACTIVE"
+    :param str status_detail: Any details about the status - defaults to None
+    :param str cloud_server: The ID of the cloud server corresponding to
+        this node (not the same as the instance's ``id``).  Note - a node
+        in theory can also be some external resource (not a cloud server),
+        but that is not supported yet.
+    """
+    def short_json(self):
+        """
+        Create a short JSON-serializable representation of the contents of
+        this object (not detailed), which can be used in a REST response.
+
+        Should match the JSON documented in the response for
+        POST /v3/{tenant_id}/load_balancer_pools/{load_balancer_pool_id}/nodes
+        (add load balancer pool node) or as part of the response for
+        GET /v3/{tenant_id}/load_balancer_pools/{load_balancer_pool_id}/nodes
+        (list load balancer pool nodes)
+        """
+        response = {attr: getattr(self, attr) for attr in
+                    attribute_names(lb_node_attrs)
+                    if attr not in ('load_balancer_pool', 'cloud_server')}
+        response['load_balancer_pool'] = {'id': self.load_balancer_pool.id}
+        response['cloud_server'] = {'id': self.cloud_server}
+        return response
+
+    def update(self, now, status, status_detail=None):
+        """
+        Changes the status of the node.
+        """
+        self.updated = now
+        self.status = status
+        self.status_detail = status_detail

--- a/mimic/rest/rackconnect_v3_api.py
+++ b/mimic/rest/rackconnect_v3_api.py
@@ -275,3 +275,10 @@ class OneLoadBalancerPool(object):
         handler is invoked.
         """
         return json.dumps(self.pool.as_json())
+
+    @app.route("/nodes", methods=["GET"])
+    def get_node_collection_information(self, request):
+        """
+        List all the nodes for the load balancer pool
+        """
+        return json.dumps([node.short_json() for node in self.pool.nodes])

--- a/mimic/rest/rackconnect_v3_api.py
+++ b/mimic/rest/rackconnect_v3_api.py
@@ -85,7 +85,7 @@ lb_pool_attrs = [
               exclude_from_cmp=True)]
 
 
-@attributes(lb_pool_attrs)
+@attributes(lb_pool_attrs, apply_with_cmp=False)
 class LoadBalancerPool(object):
     """
     Represents a Load Balancer Pool, which cannot be created via the API.
@@ -140,7 +140,7 @@ lb_node_attrs = [
     Attribute("status_detail", default_value=None)]
 
 
-@attributes(lb_node_attrs, apply_with_cmp=False)
+@attributes(lb_node_attrs)
 class LoadBalancerPoolNode(object):
     """
     Represents a Load Balancer Pool Node.

--- a/mimic/rest/rackconnect_v3_api.py
+++ b/mimic/rest/rackconnect_v3_api.py
@@ -140,7 +140,7 @@ lb_node_attrs = [
     Attribute("status_detail", default_value=None)]
 
 
-@attributes(lb_node_attrs)
+@attributes(lb_node_attrs, apply_with_cmp=False)
 class LoadBalancerPoolNode(object):
     """
     Represents a Load Balancer Pool Node.

--- a/mimic/rest/rackconnect_v3_api.py
+++ b/mimic/rest/rackconnect_v3_api.py
@@ -20,8 +20,7 @@ from mimic.catalog import Entry
 from mimic.catalog import Endpoint
 from mimic.imimic import IAPIMock
 from mimic.rest.mimicapp import MimicApp
-from mimic.util.helper import (attribute_names, random_ipv4,
-                               seconds_to_timestamp)
+from mimic.util.helper import random_ipv4, seconds_to_timestamp
 
 
 Request.defaultContentType = 'application/json'
@@ -71,18 +70,16 @@ class RackConnectV3(object):
             default_lbs=self.default_lbs).app.resource()
 
 
-lb_pool_attrs = [
-    Attribute("id", default_factory=lambda: text_type(uuid4()),
-              instance_of=text_type),
-    Attribute("name", default_value=u"default", instance_of=text_type),
-    Attribute("port", default_value=80, instance_of=int),
-    Attribute("status", default_value=u"ACTIVE", instance_of=text_type),
-    Attribute("status_detail", default_value=None),
-    Attribute("virtual_ip", default_factory=random_ipv4),
-    Attribute('nodes', default_factory=list, instance_of=list)]
-
-
-@attributes(lb_pool_attrs, apply_with_cmp=False)
+@attributes(
+    [Attribute("id", default_factory=lambda: text_type(uuid4()),
+               instance_of=text_type),
+     Attribute("name", default_value=u"default", instance_of=text_type),
+     Attribute("port", default_value=80, instance_of=int),
+     Attribute("status", default_value=u"ACTIVE", instance_of=text_type),
+     Attribute("status_detail", default_value=None),
+     Attribute("virtual_ip", default_factory=random_ipv4),
+     Attribute('nodes', default_factory=list, instance_of=list)],
+    apply_with_cmp=False)
 class LoadBalancerPool(object):
     """
     Represents a RackConnecvt v3 Load Balancer Pool.
@@ -108,8 +105,10 @@ class LoadBalancerPool(object):
         details of this particular object
         """
         # no dictionary comprehensions in py2.6
-        response = dict([(attr, getattr(self, attr)) for attr in
-                         attribute_names(lb_pool_attrs) if attr != "nodes"])
+        response = dict([
+            (attr.name, getattr(self, attr.name))
+            for attr in LoadBalancerPool.characteristic_attributes
+            if attr.name != "nodes"])
         response['node_counts'] = {
             "cloud_servers": len(self.nodes),
             "external": 0,
@@ -139,17 +138,14 @@ class LoadBalancerPool(object):
 
 
 # XXX: External nodes are not currently supported in RackConnectV3
-lb_node_attrs = [
-    "created", "load_balancer_pool", "cloud_server",
-    Attribute("id", default_factory=lambda: text_type(uuid4()),
-              instance_of=text_type),
-    Attribute("updated", default_value=None),
-    Attribute("status", default_value=text_type("ACTIVE"),
-              instance_of=text_type),
-    Attribute("status_detail", default_value=None)]
 
-
-@attributes(lb_node_attrs)
+@attributes(["created", "load_balancer_pool", "cloud_server",
+             Attribute("id", default_factory=lambda: text_type(uuid4()),
+                       instance_of=text_type),
+             Attribute("updated", default_value=None),
+             Attribute("status", default_value=text_type("ACTIVE"),
+                       instance_of=text_type),
+             Attribute("status_detail", default_value=None)])
 class LoadBalancerPoolNode(object):
     """
     Represents a Load Balancer Pool Node.
@@ -184,10 +180,10 @@ class LoadBalancerPoolNode(object):
         (list load balancer pool nodes)
         """
         # no dictionary comprehensions in py2.6
-        response = dict([(attr, getattr(self, attr)) for attr in
-                         attribute_names(lb_node_attrs)
-                         if attr not in ('load_balancer_pool', 'cloud_server')
-                         ])
+        response = dict([
+            (attr.name, getattr(self, attr.name))
+            for attr in LoadBalancerPoolNode.characteristic_attributes
+            if attr.name not in ('load_balancer_pool', 'cloud_server')])
         response['load_balancer_pool'] = {'id': self.load_balancer_pool.id}
         response['cloud_server'] = {'id': self.cloud_server}
         return response

--- a/mimic/rest/rackconnect_v3_api.py
+++ b/mimic/rest/rackconnect_v3_api.py
@@ -12,7 +12,7 @@ from characteristic import attributes, Attribute
 from six import text_type
 
 from twisted.plugin import IPlugin
-from twisted.web.http import NOT_FOUND, NOT_IMPLEMENTED
+from twisted.web.http import NOT_FOUND, NOT_IMPLEMENTED, NO_CONTENT
 from twisted.web.server import Request
 from zope.interface import implementer
 
@@ -280,8 +280,36 @@ class LoadBalancerPoolsInRegion(object):
             pool.nodes.append(node)
             added_nodes.append(node)
 
-        return json.dumps([node.short_json() for node in added_nodes])
+        request.setResponseCode(201)
+        return json.dumps([n.short_json() for n in added_nodes])
 
+    @app.route("/nodes", methods=["DELETE"])
+    def bulk_delete_nodes_to_load_balancer_pools(self, request):
+        """
+        Delete multiple nodes from multiple load balancer pools.
+
+        http://docs.rcv3.apiary.io/#delete-%2Fv3%2F%7Btenant_id%7D%2Fload_balancer_pools%2Fnodes
+
+        TODO: handle errors!!!  It should return a 409 Conflict that is
+        documented, but the exact mechanism is not documented.  Do some get
+        deleted?  Do all that can get deleted get deleted?  Is it done by
+        order? Does the error message enumerate all the failed ones?)
+
+        For now, blow up with a 500.
+        """
+        body = json.loads(request.content.read())
+
+        for add in body:
+            pool_id = add['load_balancer_pool']['id']
+            pool = self._pool_by_id(pool_id)
+            if pool is None:
+                request.setResponseCode(500)
+                return "This does not handle errors yet."
+
+            node = pool.node_by_cloud_server(add['cloud_server']['id'])
+            pool.nodes.remove(node)
+
+        request.setResponseCode(NO_CONTENT)
 
     @app.route("/<string:id>", branch=True)
     def delegate_to_one_pool_handler(self, request, id):

--- a/mimic/rest/rackconnect_v3_api.py
+++ b/mimic/rest/rackconnect_v3_api.py
@@ -204,9 +204,6 @@ class RackConnectV3Region(object):
             self.iapi, lambda: defaultdict(list))
         per_tenant_per_region_lbs = per_tenant_lbs[self.region_name]
 
-        # TODO: right now, by default, all tenants have one load balancer
-        # pool set up.  This should be configurable via a control plane,
-        # since the tenant cannot add load balancer pools via the API
         if not per_tenant_per_region_lbs:
             per_tenant_per_region_lbs.extend([
                 LoadBalancerPool() for _ in range(self.default_lbs)])

--- a/mimic/rest/rackconnect_v3_api.py
+++ b/mimic/rest/rackconnect_v3_api.py
@@ -34,7 +34,7 @@ class RackConnectV3(object):
     API mock object for RackConnect V3.
 
     :ivar regions: The regions for which endpoints should be produced
-    :type regions: `iterable`
+    :type regions: ``iterable``
 
     :ivar int default_lbs: The number of default load balancers to be created
         per tenant per region
@@ -156,9 +156,10 @@ class LoadBalancerPoolNode(object):
     :param str status: The status of the load balancer - defaults to "ACTIVE"
     :param str status_detail: Any details about the status - defaults to None
     :param str cloud_server: The ID of the cloud server corresponding to
-        this node (not the same as the instance's ``id``).  Note - a node
-        in theory can also be some external resource (not a cloud server),
-        but that is not supported yet.
+        this node.  The cloud server's ID is not equivalent to the ``id``
+        attribute on :class:`LoadBalancerPoolNode`, because a node
+        in theory can also be some external (not a cloud server) resource,
+        but that is not supported yet on the API.
     """
     def short_json(self):
         """

--- a/mimic/rest/rackconnect_v3_api.py
+++ b/mimic/rest/rackconnect_v3_api.py
@@ -72,7 +72,8 @@ class RackConnectV3(object):
 
 
 lb_pool_attrs = [
-    Attribute("id", default_factory=lambda: text_type(uuid4())),
+    Attribute("id", default_factory=lambda: text_type(uuid4()),
+              instance_of=text_type),
     Attribute("name", default_value=u"default", instance_of=text_type),
     Attribute("port", default_value=80, instance_of=int),
     Attribute("status", default_value=u"ACTIVE", instance_of=text_type),
@@ -84,15 +85,20 @@ lb_pool_attrs = [
 @attributes(lb_pool_attrs, apply_with_cmp=False)
 class LoadBalancerPool(object):
     """
-    Represents a Load Balancer Pool, which cannot be created via the API.
+    Represents a RackConnecvt v3 Load Balancer Pool.
 
-    :param str id: The ID of the load balancer pool - is randomly generated
-        if not provided
-    :param str name: The name of the load balancer pool - defaults to
+    Load balancer pools cannot be created via the API, they have to just
+    already exist on the account.
+
+    :param text_type id: The ID of the load balancer pool - is randomly
+        generated if not provided
+    :param text_type name: The name of the load balancer pool - defaults to
         'default'
     :param int port: The incoming port of the load balancer - defaults to 80
-    :param str status: The status of the load balancer - defaults to "ACTIVE"
-    :param str status_detail: Any details about the status - defaults to None
+    :param text_Type status: The status of the load balancer - defaults to
+        "ACTIVE"
+    :param text_type status_detail: Any details about the status - defaults
+        to None
     :param list nodes: :class:`LoadBalancerPoolNode`s
     """
     def as_json(self):
@@ -113,7 +119,10 @@ class LoadBalancerPool(object):
 
     def node_by_cloud_server(self, cloud_server_id):
         """
-        Find a node by it's cloud server ID.
+        Find a node by its cloud server ID.
+
+        :return: a :class:`LoadBalancerPoolNode` with a server id matching
+            the given cloud server, or `None` if none are found
         """
         return next((node for node in self.nodes
                      if node.cloud_server == cloud_server_id),
@@ -122,6 +131,9 @@ class LoadBalancerPool(object):
     def node_by_id(self, node_id):
         """
         Find a node by it's node_id.
+
+        :return: a :class:`LoadBalancerPoolNode` with the given node id,
+            or `None` if none are found
         """
         return next((node for node in self.nodes if node.id == node_id), None)
 
@@ -130,9 +142,10 @@ class LoadBalancerPool(object):
 lb_node_attrs = [
     "created", "load_balancer_pool", "cloud_server",
     Attribute("id", default_factory=lambda: text_type(uuid4()),
-              instance_of=basestring),
+              instance_of=text_type),
     Attribute("updated", default_value=None),
-    Attribute("status", default_value="ACTIVE", instance_of=basestring),
+    Attribute("status", default_value=text_type("ACTIVE"),
+              instance_of=text_type),
     Attribute("status_detail", default_value=None)]
 
 
@@ -141,17 +154,19 @@ class LoadBalancerPoolNode(object):
     """
     Represents a Load Balancer Pool Node.
 
-    :param str id: The ID of the load balancer pool node - is randomly
+    :param text_type id: The ID of the load balancer pool node - is randomly
         generated if not provided
-    :param str created: The timestamp of when the load balancer node was
+    :param text_type created: The timestamp of when the load balancer node was
         created
-    :param str updated: The timestamp of when the load balancer node was
+    :param text_type updated: The timestamp of when the load balancer node was
         updated.  Can be None.
     :param load_balancer_pool: :class:`LoadBalancerPool` to which
         this node belongs
-    :param str status: The status of the load balancer - defaults to "ACTIVE"
-    :param str status_detail: Any details about the status - defaults to None
-    :param str cloud_server: The ID of the cloud server corresponding to
+    :param text_type status: The status of the load balancer - defaults to
+        "ACTIVE"
+    :param text_type status_detail: Any details about the status - defaults
+        to None
+    :param text_type cloud_server: The ID of the cloud server corresponding to
         this node.  The cloud server's ID is not equivalent to the ``id``
         attribute on :class:`LoadBalancerPoolNode`, because a node
         in theory can also be some external (not a cloud server) resource,
@@ -284,7 +299,7 @@ class LoadBalancerPoolsInRegion(object):
                                                  timestamp_format),
                     load_balancer_pool=pool,
                     cloud_server=add['cloud_server']['id'],
-                    status="ADDING")
+                    status=text_type("ADDING"))
 
                 pool.nodes.append(node)
                 added_nodes.append(node)

--- a/mimic/test/test_core.py
+++ b/mimic/test/test_core.py
@@ -5,7 +5,8 @@ from twisted.internet.task import Clock
 from twisted.trial.unittest import SynchronousTestCase
 
 from mimic.core import MimicCore
-from mimic.plugins import nova_plugin, loadbalancer_plugin, swift_plugin
+from mimic.plugins import (nova_plugin, loadbalancer_plugin, swift_plugin,
+                           rackconnect_v3_plugin)
 
 
 class CoreBuildingTests(SynchronousTestCase):
@@ -29,7 +30,8 @@ class CoreBuildingTests(SynchronousTestCase):
         """
         core = MimicCore.fromPlugins(Clock())
         plugin_apis = set((nova_plugin.nova, loadbalancer_plugin.loadbalancer,
-                           swift_plugin.swift))
+                           swift_plugin.swift,
+                           rackconnect_v3_plugin.rackconnect))
         self.assertEqual(
             plugin_apis,
             set(core._uuid_to_api.values()))

--- a/mimic/test/test_rackconnect_v3.py
+++ b/mimic/test/test_rackconnect_v3.py
@@ -168,8 +168,9 @@ class LoadbalancerPoolAPITests(SynchronousTestCase):
 
         TODO: test the response body if one is returned
         """
-        response, _ = self.successResultOf(
+        response, content = self.successResultOf(
             request_with_content(self, self.helper.root, "GET",
-                                 self.helper.uri + "/load_balancer_pools/x"))
+                                 self.helper.uri + "/load_balancer_pools/X"))
 
         self.assertEqual(404, response.code)
+        self.assertEqual("Load Balancer Pool X does not exist", content)

--- a/mimic/test/test_rackconnect_v3.py
+++ b/mimic/test/test_rackconnect_v3.py
@@ -67,6 +67,30 @@ class LoadBalancerObjectTests(SynchronousTestCase):
             },
             self.pool.nodes[0].short_json())
 
+    def test_LBPoolNode_update(self):
+        """
+        Updating the status changes the 'now', 'status', and 'status_detail'
+        attributes.
+        """
+        self.pool.nodes[0].update(now="2000-01-02T00:00:00Z",
+                                  status="DISABLED",
+                                  status_detail="Broken.")
+        self.assertEqual(
+            {
+                "id": "node_0",
+                "created": "2000-01-01T00:00:00Z",
+                "updated": "2000-01-02T00:00:00Z",
+                "load_balancer_pool": {
+                    "id": "pool_id"
+                },
+                "cloud_server": {
+                    "id": "server_0"
+                },
+                "status": "DISABLED",
+                "status_detail": "Broken."
+            },
+            self.pool.nodes[0].short_json())
+
     def test_LBPool_short_json(self):
         """
         Valid JSON response (as would be displayed when listing pools or

--- a/mimic/test/test_rackconnect_v3.py
+++ b/mimic/test/test_rackconnect_v3.py
@@ -165,8 +165,6 @@ class LoadbalancerPoolAPITests(SynchronousTestCase):
     def test_get_pool_404_invalid_pool(self):
         """
         Getting pool on a non-existant pool returns a 404.
-
-        TODO: test the response body if one is returned
         """
         response, content = self.successResultOf(
             request_with_content(self, self.helper.root, "GET",
@@ -174,3 +172,212 @@ class LoadbalancerPoolAPITests(SynchronousTestCase):
 
         self.assertEqual(404, response.code)
         self.assertEqual("Load Balancer Pool X does not exist", content)
+
+
+class LoadbalancerPoolNodesAPITests(SynchronousTestCase):
+    """
+    Tests for the LoadBalancerPool API for getting and updating nodes
+    """
+    def setUp(self):
+        """
+        Create a :obj:`MimicCore` with :obj:`RackConnectV3` as the only plugin
+        """
+        self.helper = APIMockHelper(self, [RackConnectV3()])
+        _, pool_list_json = self.successResultOf(
+            json_request(self, self.helper.root, "GET",
+                         self.helper.uri + "/load_balancer_pools"))
+        self.pool_id = pool_list_json[0]['id']
+
+    def request_with_content(self, method, relative_uri, **kwargs):
+        """
+        Helper function that makes a request and gets the non-json content.
+        """
+        return request_with_content(self, self.helper.root, method,
+                                    self.helper.uri + relative_uri, **kwargs)
+
+    def json_request(self, method, relative_uri, **kwargs):
+        """
+        Helper function that makes a request and gets the json content.
+        """
+        return json_request(self, self.helper.root, method,
+                            self.helper.uri + relative_uri, **kwargs)
+
+    def test_get_pool_404_invalid_pool_nodes(self):
+        """
+        Getting nodes on a non-existant pool returns a 404.
+        """
+        response, content = self.successResultOf(self.request_with_content(
+            "GET", "/load_balancer_pools/X/nodes".format(self.pool_id)))
+
+        self.assertEqual(404, response.code)
+        self.assertEqual("Load Balancer Pool X does not exist", content)
+
+    def test_get_pool_nodes_empty(self):
+        """
+        Getting nodes for an empty existing load balancer returns a 200 with
+        no nodes
+        """
+        response, json_content = self.successResultOf(self.json_request(
+            "GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
+        self.assertEqual(200, response.code)
+        self.assertEqual(json_content, [])
+
+    def _check_added_nodes_result(self, seconds, add_json, results_json):
+        """
+        Helper function to check that the results reflect the added nodes
+        """
+        self.assertEqual(len(add_json), len(results_json))
+
+        # Can't construct the whole thing, because the IDs are random, so
+        # compare some parts
+        for node_blob in results_json:
+            can_be_compared = node_blob.copy()
+
+            the_id = can_be_compared.pop('id')
+            self.assertTrue(isinstance(the_id, basestring))
+
+            can_be_compared.pop('cloud_server', None)
+            self.assertEqual({
+                "created": "1970-01-01T00:00:{0:02}Z".format(seconds),
+                "load_balancer_pool": {"id": self.pool_id},
+                "status": "ADDING",
+                "status_detail": None,
+                "updated": None
+            }, can_be_compared)
+
+        result_server_bits = sorted([blob['cloud_server']
+                                    for blob in results_json])
+        expected_server_bits = sorted([blob['cloud_server']
+                                       for blob in add_json])
+
+        self.assertEqual(expected_server_bits, result_server_bits)
+
+    def test_add_bulk_pool_nodes_success_response(self):
+        """
+        Adding multiple pool nodes successfully results in a 200 with the
+        correct node detail responses
+        """
+        self.helper.clock.advance(60)
+        add_data = [
+            {"cloud_server": {"id": "12345"},
+             "load_balancer_pool": self.pool_id},
+            {"cloud_server": {"id": "54321"},
+             "load_balancer_pool": self.pool_id}
+        ]
+        response, resp_json = self.successResultOf(self.json_request(
+            "POST", "/load_balancer_pools/{0}/nodes".format(self.pool_id),
+            body=add_data
+        ))
+        self.assertEqual(200, response.code)
+        self._check_added_nodes_result(60, add_data, resp_json)
+
+    def test_add_bulk_pool_nodes_then_list(self):
+        """
+        Adding multiple pool nodes successfully means that the next time nodes
+        are listed those nodes are listed.
+        """
+        self.helper.clock.advance(60)
+        add_data = [
+            {"cloud_server": {"id": "12345"},
+             "load_balancer_pool": self.pool_id},
+            {"cloud_server": {"id": "54321"},
+             "load_balancer_pool": self.pool_id}
+        ]
+        add_response, _ = self.successResultOf(self.json_request(
+            "POST", "/load_balancer_pools/{0}/nodes".format(self.pool_id),
+            body=add_data
+        ))
+        self.assertEqual(200, add_response.code)
+
+        _, list_json = self.successResultOf(self.json_request(
+            "GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
+        self._check_added_nodes_result(60, add_data, list_json)
+
+    def test_remove_bulk_pool_nodes_success(self):
+        """
+        Removing multiple pool nodes successfully results in a 204 with the
+        correct node detail responses
+        """
+        self.helper.clock.advance(60)
+        server_data = [
+            {"cloud_server": {"id": "12345"},
+             "load_balancer_pool": self.pool_id},
+            {"cloud_server": {"id": "54321"},
+             "load_balancer_pool": self.pool_id}
+        ]
+
+        # add first
+        self.successResultOf(self.json_request(
+            "POST", "/load_balancer_pools/{0}/nodes".format(self.pool_id),
+            body=server_data
+        ))
+
+        # ensure there are 2
+        _, list_json = self.successResultOf(self.json_request(
+            "GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
+        self.assertEqual(2, len(list_json))
+
+        # delete
+        response, _ = self.successResultOf(self.json_request(
+            "DELETE", "/load_balancer_pools/{0}/nodes".format(self.pool_id),
+            body=server_data))
+        self.assertEqual(204, response.code)
+
+        # ensure there are 0
+        _, list_json = self.successResultOf(self.json_request(
+            "GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
+        self.assertEqual(0, len(list_json))
+
+    def test_get_pool_nodes_details_unimplemented(self):
+        """
+        Getting pool nodes details is currently unimplemented
+        """
+        response, content = self.successResultOf(self.request_with_content(
+            "GET",
+            "/load_balancer_pools/{0}/nodes/details".format(self.pool_id)))
+        self.assertEqual(501, response.code)
+        self.assertEqual("Not implemented yet.", content)
+
+    def test_add_pool_node_unimplemented(self):
+        """
+        Adding a single pool node is currently unimplemented
+        """
+        response, content = self.successResultOf(self.request_with_content(
+            "POST", "/load_balancer_pools/{0}/nodes".format(self.pool_id),
+            body={
+                "cloud_server": {"id": "d95ae0c4-6ab8-4873-b82f-f8433840cff2"}
+            }))
+        self.assertEqual(501, response.code)
+        self.assertEqual("Not implemented yet.", content)
+
+    def test_get_pool_node_unimplemented(self):
+        """
+        Getting information a single pool node is currently unimplemented
+        """
+        response, content = self.successResultOf(self.request_with_content(
+            "GET", "/load_balancer_pools/{0}/nodes/1".format(self.pool_id)
+            ))
+        self.assertEqual(501, response.code)
+        self.assertEqual("Not implemented yet.", content)
+
+    def test_remove_pool_node_unimplemented(self):
+        """
+        Removing a single pool node is currently unimplemented
+        """
+        response, content = self.successResultOf(self.request_with_content(
+            "DELETE", "/load_balancer_pools/{0}/nodes/1".format(self.pool_id)
+            ))
+        self.assertEqual(501, response.code)
+        self.assertEqual("Not implemented yet.", content)
+
+    def test_get_pool_node_details_unimplemented(self):
+        """
+        Getting detailed information on a single pool node is currently
+        unimplemented
+        """
+        response, content = self.successResultOf(self.request_with_content(
+            "GET",
+            "/load_balancer_pools/{0}/nodes/1/details".format(self.pool_id)
+            ))
+        self.assertEqual(501, response.code)
+        self.assertEqual("Not implemented yet.", content)

--- a/mimic/test/test_rackconnect_v3.py
+++ b/mimic/test/test_rackconnect_v3.py
@@ -36,7 +36,7 @@ class LoadBalancerObjectTests(SynchronousTestCase):
 
     def setUp(self):
         self.pool = LoadBalancerPool(id=text_type("pool_id"),
-                                     virtual_ip="10.0.0.1")
+                                     virtual_ip=text_type("10.0.0.1"))
         for i in range(10):
             self.pool.nodes.append(
                 LoadBalancerPoolNode(id=text_type("node_{0}".format(i)),
@@ -222,10 +222,10 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
 
     def test_default_multiple_pools(self):
         """
-        If ``default_lbs`` is passed to :class:`RackConnectV3`, multiple load
-        balancers will be created per tenant per region
+        If ``default_pools`` is passed to :class:`RackConnectV3`, multiple
+        load balancer pools will be created per tenant per region
         """
-        self.rcv3 = RackConnectV3(regions=["ORD", "DFW"], default_lbs=2)
+        self.rcv3 = RackConnectV3(regions=["ORD", "DFW"], default_pools=2)
         self.helper = APIMockHelper(self, [self.rcv3])
         lb_ids = self.get_lb_ids()
         self.assertEqual(2, len(lb_ids[0]))

--- a/mimic/test/test_rackconnect_v3.py
+++ b/mimic/test/test_rackconnect_v3.py
@@ -140,3 +140,36 @@ class LoadbalancerPoolAPITests(SynchronousTestCase):
         nodes = [response[-1][0] for response in responses]
 
         self.assertNotEqual(nodes[0]['id'], nodes[1]['id'])
+
+    def test_get_pool_on_success(self):
+        """
+        Validate the JSON response of getting a single pool on an existing
+        pool.
+        """
+        _, pool_list_json = self.successResultOf(
+            json_request(self, self.helper.root, "GET",
+                         self.helper.uri + "/load_balancer_pools"))
+        pool = pool_list_json[0]
+
+        pool_details_response, pool_details_json = self.successResultOf(
+            json_request(self, self.helper.root, "GET",
+                         self.helper.uri + "/load_balancer_pools/" +
+                         pool['id']))
+
+        self.assertEqual(200, pool_details_response.code)
+        self.assertEqual(
+            ['application/json'],
+            pool_details_response.headers.getRawHeaders('content-type'))
+        self.assertEqual(pool, pool_details_json)
+
+    def test_get_pool_404_invalid_pool(self):
+        """
+        Getting pool on a non-existant pool returns a 404.
+
+        TODO: test the response body if one is returned
+        """
+        response, _ = self.successResultOf(
+            request_with_content(self, self.helper.root, "GET",
+                                 self.helper.uri + "/load_balancer_pools/x"))
+
+        self.assertEqual(404, response.code)

--- a/mimic/test/test_rackconnect_v3.py
+++ b/mimic/test/test_rackconnect_v3.py
@@ -2,14 +2,13 @@
 Unit tests for the Rackspace RackConnect V3 API.
 """
 
-import json
-import treq
-
 from twisted.trial.unittest import SynchronousTestCase
 from mimic.test.fixtures import APIMockHelper
 from mimic.rest.rackconnect_v3_api import (
-    LoadBalancerPool, LoadBalancerPoolNode)
-from mimic.test.helpers import request
+    LoadBalancerPool, LoadBalancerPoolNode, RackConnectV3,
+    lb_pool_attrs)
+from mimic.util.helper import attribute_names
+from mimic.test.helpers import json_request, request_with_content
 
 
 class LoadBalancerObjectTests(SynchronousTestCase):
@@ -81,3 +80,63 @@ class LoadBalancerObjectTests(SynchronousTestCase):
         self.assertIs(self.pool.nodes[3],
                       self.pool.node_by_cloud_server("server_3"))
 
+
+class LoadbalancerPoolAPITests(SynchronousTestCase):
+    """
+    Tests for the LoadBalancerPool API
+    """
+
+    def setUp(self):
+        """
+        Create a :obj:`MimicCore` with :obj:`RackConnectV3` as the only plugin
+        """
+        self.helper = APIMockHelper(self, [RackConnectV3()])
+
+    def test_list_pools_default_one(self):
+        """
+        Verify the JSON response from listing all load balancer pools.
+        By default, all tenants have one load balancer pool.
+        """
+        response, response_json = self.successResultOf(
+            json_request(self, self.helper.root, "GET",
+                         self.helper.uri + "/load_balancer_pools"))
+        self.assertEqual(200, response.code)
+        self.assertEqual(['application/json'],
+                         response.headers.getRawHeaders('content-type'))
+        self.assertEqual(1, len(response_json))
+
+        pool_json = response_json[0]
+        # has the right JSON
+        self.assertTrue(all(
+            attr in pool_json for attr in attribute_names(lb_pool_attrs)
+            if attr != "nodes"))
+        # Generated values
+        self.assertTrue(all(
+            pool_json.get(attr) for attr in attribute_names(lb_pool_attrs)
+            if attr not in ("nodes", "status_detail")))
+
+        self.assertEqual(
+            {
+                "cloud_servers": 0,
+                "external": 0,
+                "total": 0
+            },
+            pool_json['node_counts'],
+            "Pool should start off with no members.")
+
+    def test_different_regions_same_tenant_different_pools(self):
+        """
+        The same tenant has different pools in different regions.
+        """
+        self.helper = APIMockHelper(self,
+                                    [RackConnectV3(regions=["ORD", "DFW"])])
+
+        responses = [
+            self.successResultOf(json_request(
+                self, self.helper.root, "GET",
+                self.helper.nth_endpoint_public(i) + "/load_balancer_pools"))
+            for i in range(2)]
+
+        nodes = [response[-1][0] for response in responses]
+
+        self.assertNotEqual(nodes[0]['id'], nodes[1]['id'])

--- a/mimic/test/test_rackconnect_v3.py
+++ b/mimic/test/test_rackconnect_v3.py
@@ -10,9 +10,7 @@ from six import text_type
 from twisted.trial.unittest import SynchronousTestCase
 from mimic.test.fixtures import APIMockHelper
 from mimic.rest.rackconnect_v3_api import (
-    LoadBalancerPool, LoadBalancerPoolNode, RackConnectV3,
-    lb_pool_attrs)
-from mimic.util.helper import attribute_names
+    LoadBalancerPool, LoadBalancerPoolNode, RackConnectV3)
 from mimic.test.helpers import json_request, request_with_content
 
 
@@ -168,12 +166,14 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
         pool_json = response_json[0]
         # has the right JSON
         self.assertTrue(all(
-            attr in pool_json for attr in attribute_names(lb_pool_attrs)
-            if attr != "nodes"))
+            attr.name in pool_json
+            for attr in LoadBalancerPool.characteristic_attributes
+            if attr.name != "nodes"))
         # Generated values
         self.assertTrue(all(
-            pool_json.get(attr) for attr in attribute_names(lb_pool_attrs)
-            if attr not in ("nodes", "status_detail")))
+            pool_json.get(attr.name)
+            for attr in LoadBalancerPool.characteristic_attributes
+            if attr.name not in ("nodes", "status_detail")))
 
         self.assertEqual(
             {

--- a/mimic/test/test_rackconnect_v3.py
+++ b/mimic/test/test_rackconnect_v3.py
@@ -1,7 +1,6 @@
 """
 Unit tests for the Rackspace RackConnect V3 API.
 """
-
 from twisted.trial.unittest import SynchronousTestCase
 from mimic.test.fixtures import APIMockHelper
 from mimic.rest.rackconnect_v3_api import (
@@ -336,19 +335,17 @@ class LoadbalancerPoolNodesAPITests(SynchronousTestCase):
             "GET",
             "/load_balancer_pools/{0}/nodes/details".format(self.pool_id)))
         self.assertEqual(501, response.code)
-        self.assertEqual("Not implemented yet.", content)
 
     def test_add_pool_node_unimplemented(self):
         """
         Adding a single pool node is currently unimplemented
         """
-        response, content = self.successResultOf(self.request_with_content(
+        response, content = self.successResultOf(self.json_content(
             "POST", "/load_balancer_pools/{0}/nodes".format(self.pool_id),
             body={
                 "cloud_server": {"id": "d95ae0c4-6ab8-4873-b82f-f8433840cff2"}
             }))
         self.assertEqual(501, response.code)
-        self.assertEqual("Not implemented yet.", content)
 
     def test_get_pool_node_unimplemented(self):
         """
@@ -358,7 +355,6 @@ class LoadbalancerPoolNodesAPITests(SynchronousTestCase):
             "GET", "/load_balancer_pools/{0}/nodes/1".format(self.pool_id)
             ))
         self.assertEqual(501, response.code)
-        self.assertEqual("Not implemented yet.", content)
 
     def test_remove_pool_node_unimplemented(self):
         """
@@ -368,7 +364,6 @@ class LoadbalancerPoolNodesAPITests(SynchronousTestCase):
             "DELETE", "/load_balancer_pools/{0}/nodes/1".format(self.pool_id)
             ))
         self.assertEqual(501, response.code)
-        self.assertEqual("Not implemented yet.", content)
 
     def test_get_pool_node_details_unimplemented(self):
         """
@@ -380,4 +375,3 @@ class LoadbalancerPoolNodesAPITests(SynchronousTestCase):
             "/load_balancer_pools/{0}/nodes/1/details".format(self.pool_id)
             ))
         self.assertEqual(501, response.code)
-        self.assertEqual("Not implemented yet.", content)

--- a/mimic/test/test_rackconnect_v3.py
+++ b/mimic/test/test_rackconnect_v3.py
@@ -37,14 +37,16 @@ class LoadBalancerObjectTests(SynchronousTestCase):
     """
 
     def setUp(self):
-        self.pool = LoadBalancerPool(id="pool_id", virtual_ip="10.0.0.1")
+        self.pool = LoadBalancerPool(id=text_type("pool_id"),
+                                     virtual_ip="10.0.0.1")
         for i in range(10):
             self.pool.nodes.append(
-                LoadBalancerPoolNode(id="node_{0}".format(i),
+                LoadBalancerPoolNode(id=text_type("node_{0}".format(i)),
                                      created="2000-01-01T00:00:00Z",
                                      load_balancer_pool=self.pool,
                                      updated=None,
-                                     cloud_server="server_{0}".format(i)))
+                                     cloud_server=text_type(
+                                         "server_{0}".format(i))))
 
     def test_LBPoolNode_short_json(self):
         """

--- a/mimic/test/test_rackconnect_v3.py
+++ b/mimic/test/test_rackconnect_v3.py
@@ -231,7 +231,7 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
         """
         return [
             {"cloud_server": {"id": "{0}".format(randint(0, 9))},
-             "load_balancer_pool": pool_id}
+             "load_balancer_pool": {"id": pool_id}}
             for pool_id in self.get_lb_ids()[0]
         ]
 
@@ -269,19 +269,19 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
         Adding multiple pool nodes successfully results in a 200 with the
         correct node detail responses
         """
-        self.helper.clock.advance(60)
+        self.helper.clock.advance(50)
         add_data = self._get_add_nodes_json()
         response, resp_json = self.successResultOf(self.json_request(
             "POST", "/load_balancer_pools/nodes", body=add_data))
         self.assertEqual(200, response.code)
-        self._check_added_nodes_result(60, add_data, resp_json)
+        self._check_added_nodes_result(50, add_data, resp_json)
 
     def test_add_bulk_pool_nodes_then_list(self):
         """
         Adding multiple pool nodes successfully means that the next time nodes
         are listed those nodes are listed.
         """
-        self.helper.clock.advance(60)
+        self.helper.clock.advance(50)
         add_data = self._get_add_nodes_json()
         add_response, _ = self.successResultOf(self.json_request(
             "POST", "/load_balancer_pools/nodes", body=add_data))
@@ -289,14 +289,14 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
 
         _, list_json = self.successResultOf(self.json_request(
             "GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
-        self._check_added_nodes_result(60, add_data, list_json)
+        self._check_added_nodes_result(50, add_data, list_json)
 
     def test_remove_bulk_pool_nodes_success(self):
         """
         Removing multiple pool nodes successfully results in a 204 with the
         correct node detail responses
         """
-        self.helper.clock.advance(60)
+        self.helper.clock.advance(50)
         server_data = self._get_add_nodes_json()
 
         # add first

--- a/mimic/test/test_rackconnect_v3.py
+++ b/mimic/test/test_rackconnect_v3.py
@@ -1,0 +1,83 @@
+"""
+Unit tests for the Rackspace RackConnect V3 API.
+"""
+
+import json
+import treq
+
+from twisted.trial.unittest import SynchronousTestCase
+from mimic.test.fixtures import APIMockHelper
+from mimic.rest.rackconnect_v3_api import (
+    LoadBalancerPool, LoadBalancerPoolNode)
+from mimic.test.helpers import request
+
+
+class LoadBalancerObjectTests(SynchronousTestCase):
+    """
+    Tests for :class:`LoadBalancerPool` and :class:`LoadBalancerPoolNode`
+    """
+    def setUp(self):
+        self.pool = LoadBalancerPool(id="pool_id", virtual_ip="10.0.0.1")
+        for i in range(10):
+            self.pool.nodes.append(
+                LoadBalancerPoolNode(id="node_{0}".format(i),
+                                     created="2000-01-01T00:00:00Z",
+                                     load_balancer_pool=self.pool,
+                                     updated=None,
+                                     cloud_server="server_{0}".format(i)))
+
+    def test_LBPoolNode_short_json(self):
+        """
+        Valid JSON response (as would be displayed when listing nodes) is
+        produced by :func:`LoadBalancerPoolNode.short_json`
+        """
+        self.assertEqual(
+            {
+                "id": "node_0",
+                "created": "2000-01-01T00:00:00Z",
+                "updated": None,
+                "load_balancer_pool": {
+                    "id": "pool_id"
+                },
+                "cloud_server": {
+                    "id": "server_0"
+                },
+                "status": "ACTIVE",
+                "status_detail": None
+            },
+            self.pool.nodes[0].short_json())
+
+    def test_LBPool_short_json(self):
+        """
+        Valid JSON response (as would be displayed when listing pools or
+        getting pool details) is produced by :func:`LoadBalancerPool.as_json`.
+        """
+        self.assertEqual(
+            {
+                "id": "pool_id",
+                "name": "default",
+                "node_counts": {
+                    "cloud_servers": 10,
+                    "external": 0,
+                    "total": 10
+                },
+                "port": 80,
+                "virtual_ip": "10.0.0.1",
+                "status": "ACTIVE",
+                "status_detail": None
+            },
+            self.pool.as_json())
+
+    def test_LBPool_find_nodes_by_id(self):
+        """
+        A node can be retrieved by its ID.
+        """
+        self.assertIs(self.pool.nodes[5], self.pool.node_by_id("node_5"))
+
+    def test_LBPool_find_nodes_by_server_id(self):
+        """
+        A node can be retrieved by its cloud server ID.
+        """
+        self.assertIs(self.pool.nodes[3],
+                      self.pool.node_by_cloud_server("server_3"))
+

--- a/mimic/test/test_util.py
+++ b/mimic/test/test_util.py
@@ -14,7 +14,7 @@ class HelperTests(SynchronousTestCase):
     def _validate_ipv4_address(self, address, *prefixes):
         nums = [int(x) for x in address.split('.')]
         self.assertEqual(4, len(nums))
-        self.assertTrue(all(x > 0 and x < 255 for x in nums))
+        self.assertTrue(all(x >= 0 and x < 255 for x in nums))
         self.assertEqual(prefixes[:len(nums)], tuple(nums[:len(prefixes)]))
 
     def test_random_ipv4_completely_random(self):

--- a/mimic/test/test_util.py
+++ b/mimic/test/test_util.py
@@ -1,7 +1,6 @@
 """
 Unit tests for :mod:`mimic.util`
 """
-from characteristic import Attribute
 from twisted.trial.unittest import SynchronousTestCase
 
 from mimic.util import helper
@@ -41,16 +40,6 @@ class HelperTests(SynchronousTestCase):
         self.assertNotEqual(helper.random_hex_generator(3),
                             helper.random_hex_generator(3))
         self.assertEqual(len(helper.random_hex_generator(4)), 8)
-
-    def test_attribute_names(self):
-        """
-        :func:`helper.attribute_names` returns the string if an attribute is
-        a string, and the name if the attribute is a
-        :class:`characteristic.Attribute`
-        """
-        self.assertEqual(['ima_string', 'ima_name'],
-                         helper.attribute_names(['ima_string',
-                                                 Attribute('ima_name')]))
 
     def test_seconds_to_timestamp_default_timestamp(self):
         """

--- a/mimic/test/test_util.py
+++ b/mimic/test/test_util.py
@@ -1,0 +1,35 @@
+"""
+Unit tests for :mod:`mimic.util`
+"""
+
+from twisted.trial.unittest import SynchronousTestCase
+
+from mimic.util import helper
+
+
+class HelperTests(SynchronousTestCase):
+    """
+    Tests for :mod:`mimic.util.helper`
+    """
+    def _validate_ipv4_address(self, address, *prefixes):
+        nums = [int(x) for x in address.split('.')]
+        self.assertEqual(4, len(nums))
+        self.assertTrue(all(x > 0 and x < 255 for x in nums))
+        self.assertEqual(prefixes[:len(nums)], tuple(nums[:len(prefixes)]))
+
+    def test_random_ipv4_completely_random(self):
+        """
+        A completely random IP address is generated if prefixes are not
+        provided.
+        """
+        self._validate_ipv4_address(helper.random_ipv4())
+
+    def test_random_ipv4_with_prefixes(self):
+        """
+        Random IP addresses can be generated with pre-determined prefixes.
+        """
+        prefixes = []
+        for i in range(1, 5):
+            prefixes.append(i)
+            self._validate_ipv4_address(helper.random_ipv4(*prefixes),
+                                        *prefixes)

--- a/mimic/test/test_util.py
+++ b/mimic/test/test_util.py
@@ -1,7 +1,7 @@
 """
 Unit tests for :mod:`mimic.util`
 """
-
+from characteristic import Attribute
 from twisted.trial.unittest import SynchronousTestCase
 
 from mimic.util import helper
@@ -33,3 +33,13 @@ class HelperTests(SynchronousTestCase):
             prefixes.append(i)
             self._validate_ipv4_address(helper.random_ipv4(*prefixes),
                                         *prefixes)
+
+    def test_attribute_names(self):
+        """
+        :func:`helper.attribute_names` returns the string if an attribute is
+        a string, and the name if the attribute is a
+        :class:`characteristic.Attribute`
+        """
+        self.assertEqual(['ima_string', 'ima_name'],
+                         helper.attribute_names(['ima_string',
+                                                 Attribute('ima_name')]))

--- a/mimic/util/helper.py
+++ b/mimic/util/helper.py
@@ -22,7 +22,7 @@ def random_ipv4(*numbers):
     address.
     """
     all_numbers = [text_type(num) for num in
-                   list(numbers) + [randint(1, 255) for _ in range(4)]]
+                   list(numbers) + [randint(0, 255) for _ in range(4)]]
     return ".".join(all_numbers[:4])
 
 

--- a/mimic/util/helper.py
+++ b/mimic/util/helper.py
@@ -8,6 +8,7 @@ Helper methods
 from datetime import datetime, timedelta
 from random import randint
 
+from characteristic import Attribute
 from six import text_type
 
 
@@ -23,6 +24,15 @@ def random_ipv4(*numbers):
     all_numbers = [text_type(num) for num in
                    list(numbers) + [randint(1, 255) for _ in range(4)]]
     return ".".join(all_numbers[:4])
+
+
+def attribute_names(attribute_list):
+    """
+    Get a list of attribute names given an attribute list of either `str` or
+    :class:`characteristic.Attribute`
+    """
+    return [attr.name if isinstance(attr, Attribute) else attr
+            for attr in attribute_list]
 
 
 def not_found_response(resource='servers'):

--- a/mimic/util/helper.py
+++ b/mimic/util/helper.py
@@ -35,6 +35,13 @@ def attribute_names(attribute_list):
             for attr in attribute_list]
 
 
+def seconds_to_timestamp(seconds, format=fmt):
+    """
+    Return an ISO8601 Zulu timestamp given seconds since the epoch.
+    """
+    return datetime.utcfromtimestamp(seconds).strftime(format)
+
+
 def not_found_response(resource='servers'):
     """
     Return a 404 response body for Nova, depending on the resource.  Expects

--- a/mimic/util/helper.py
+++ b/mimic/util/helper.py
@@ -1,13 +1,28 @@
-
+# -*- test-case-name: mimic.test.test_util -*-
+#
 """
 Helper methods
 
 :var fmt: strftime format for datetimes used in JSON.
 """
 from datetime import datetime, timedelta
+from random import randint
+
+from six import text_type
 
 
 fmt = '%Y-%m-%dT%H:%M:%S.%fZ'
+
+
+def random_ipv4(*numbers):
+    """
+    Return a random IPv4 address - parts of the IP address can be provided.
+    For example, ``random_ipv4(192, 168)`` will return a random 192.168.x.x
+    address.
+    """
+    all_numbers = [text_type(num) for num in
+                   list(numbers) + [randint(1, 255) for _ in range(4)]]
+    return ".".join(all_numbers[:4])
 
 
 def not_found_response(resource='servers'):

--- a/mimic/util/helper.py
+++ b/mimic/util/helper.py
@@ -9,7 +9,6 @@ import os
 from datetime import datetime, timedelta
 from random import randint
 
-from characteristic import Attribute
 from six import text_type
 
 
@@ -32,15 +31,6 @@ def random_hex_generator(num):
     Returns randomly generated n bytes of encoded hex data for the given `num`
     """
     return os.urandom(num).encode("hex")
-
-
-def attribute_names(attribute_list):
-    """
-    Get a list of attribute names given an attribute list of either `str` or
-    :class:`characteristic.Attribute`
-    """
-    return [attr.name if isinstance(attr, Attribute) else attr
-            for attr in attribute_list]
 
 
 def seconds_to_timestamp(seconds, format=fmt):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ klein==0.2.1
 twisted==14.0.0
 jsonschema==2.0
 treq==0.2.0
-characteristic==14.1.0
+characteristic==14.2.0
 six==1.6.1

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     packages=find_packages(exclude=[]) + ["twisted.plugins"],
     package_dir={'mimic': 'mimic'},
     install_requires=[
-        "characteristic==14.1.0",
+        "characteristic==14.2.0",
         "klein==0.2.1",
         "twisted>=13.2.0",
         "jsonschema==2.0",


### PR DESCRIPTION
This provides API support for RackConnect V3 load balancers.  First task of #104 

To Do:
- [x] Add tests to bring back coverage to 100%

We could add the negative cases such as validating that the server being added to the load balancer pool actually exists in the Nova plugin in a different PR.