### PR TITLE
RFR: changing token, tenant authentication to fetch session by tenant

### DIFF
--- a/mimic/rest/auth_api.py
+++ b/mimic/rest/auth_api.py
@@ -54,8 +54,7 @@ class AuthApi(object):
             session = self.core.sessions.session_for_api_key(
                 username, api_key, tenant_id)
         elif content['auth'].get('token') and tenant_id:
-            session = self.core.sessions.session_for_token(
-                content['auth']['token']['id'], tenant_id)
+            session = self.core.sessions.session_for_tenant_id(tenant_id)
         else:
             request.setResponseCode(400)
             return json.dumps(invalid_resource("Invalid JSON request body"))


### PR DESCRIPTION
Currently we are storing the session for the tenant , token id authentication using the token id; changing this to be storing the session using tenant id instead.
