### PR TITLE
feat(alarms): add /entities/{entityId}/alarms endpoint

### DIFF
--- a/mimic/rest/maas_api.py
+++ b/mimic/rest/maas_api.py
@@ -546,6 +546,26 @@ class MaasMock(object):
         request.setHeader('content-type', 'text/plain')
         return ''
 
+    @app.route('/v1.0/<string:tenant_id>/entities/<string:entity_id>/alarms', methods=['GET'])
+    def get_alarms_for_entity(self, request, tenant_id, entity_id):
+        """
+        Get all alarms for the specified entity.
+        """
+        alarms = [
+            dict(alarm) for alarm in self._entity_cache_for_tenant(tenant_id).alarms_list
+            if alarm['entity_id'] == entity_id
+            ]
+        for alarm in alarms:
+            del alarm['entity_id']
+        metadata = {}
+        metadata['count'] = len(alarms)
+        metadata['limit'] = 1000
+        metadata['marker'] = None
+        metadata['next_marker'] = None
+        metadata['next_href'] = None
+        request.setResponseCode(200)
+        return json.dumps({'metadata': metadata, 'values': alarms})
+
     @app.route('/v1.0/<string:tenant_id>/views/overview', methods=['GET'])
     def overview(self, request, tenant_id):
         """

--- a/mimic/test/test_maas.py
+++ b/mimic/test/test_maas.py
@@ -303,6 +303,19 @@ class MaasAPITests(SynchronousTestCase):
         self.assertEquals(resp.code, 200)
         self.assertEquals(0, len(self.get_responsebody(resp)['values'][0]['alarms']))
 
+    def test_get_alarms_for_entity(self):
+        """
+        get all alarms for the entity
+        """
+        ecan = self.get_ecan_objectIds()
+        req = request(self, self.root, "GET",
+                      self.uri + '/entities/' + ecan['entity_id'] + '/alarms', '')
+        resp = self.successResultOf(req)
+        self.assertEquals(resp.code, 200)
+        data = self.get_responsebody(resp)
+        self.assertEquals(1, data['metadata']['count'])
+        self.assertEquals(ecan['alarm_id'], data['values'][0]['id'])
+
     def test_delete_check(self):
         """
         delete check


### PR DESCRIPTION
See the Cloud Monitoring docs, section [5.12.3](http://goo.gl/9TUYBP).

I want this for a new feature Cloud Intelligence is developing that needs to be able to get all the alarms for a given Entity.
