### PR TITLE
feat(maas): add /monitoring_zones endpoint

### DIFF
--- a/mimic/canned_responses/maas_monitoring_zones.py
+++ b/mimic/canned_responses/maas_monitoring_zones.py
@@ -1,0 +1,58 @@
+"""
+Canned responses for MAAS monitoring zones.
+"""
+
+
+def monitoring_zones():
+    """
+    Canned response for the /monitoring_zones call.
+    """
+    return [{
+        "id": "mzdfw",
+        "label": "Dallas Fort Worth (DFW)",
+        "country_code": "US",
+        "source_ips": [
+            "dead:beef:cafe:face::/64",
+            "1.2.3.128/26"
+        ]
+    }, {
+        "id": "mzhkg",
+        "label": "Hong Kong (HKG)",
+        "country_code": "HK",
+        "source_ips": [
+            "4.5.6.64/26",
+            "1337:f005:ba11:d00d:0:0:0:0/64"
+        ]
+    }, {
+        "id": "mziad",
+        "label": "Northern Virginia (IAD)",
+        "country_code": "US",
+        "source_ips": [
+            "5ca1:ab1e:7e1e:ca57::/64",
+            "7.8.9.192/26"
+        ]
+    }, {
+        "id": "mzlon",
+        "label": "London (LON)",
+        "country_code": "GB",
+        "source_ips": [
+            "1ceb:00da:8bad:food::/64",
+            "11.12.13.0/26"
+        ]
+    }, {
+        "id": "mzord",
+        "label": "Chicago (ORD)",
+        "country_code": "US",
+        "source_ips": [
+            "ba5e:ba11:1111:2222::/64",
+            "14.15.16.0/26"
+        ]
+    }, {
+        "id": "mzsyd",
+        "label": "Sydney (SYD)",
+        "country_code": "AU",
+        "source_ips": [
+            "17.18.19.0/26",
+            "1111:2222:3333:4444::/64"
+        ]
+    }]

--- a/mimic/rest/maas_api.py
+++ b/mimic/rest/maas_api.py
@@ -21,6 +21,7 @@ from mimic.catalog import Endpoint
 from mimic.rest.mimicapp import MimicApp
 from mimic.imimic import IAPIMock
 from mimic.canned_responses.maas_json_home import json_home
+from mimic.canned_responses.maas_monitoring_zones import monitoring_zones
 from mimic.util.helper import random_hex_generator
 
 
@@ -829,7 +830,23 @@ class MaasMock(object):
                 break
         request.setResponseCode(204)
         request.setHeader('content-type', 'text/plain')
-        pass
+        return ''
+
+    @app.route('/v1.0/<string:tenant_id>/monitoring_zones', methods=['GET'])
+    def list_monitoring_zones(self, request, tenant_id):
+        """
+        Lists the monitoring zones
+        """
+        mzs = monitoring_zones()
+        metadata = {
+            'count': len(mzs),
+            'limit': 100,
+            'marker': None,
+            'next_marker': None,
+            'next_href': None
+            }
+        request.setResponseCode(200)
+        return json.dumps({'values': mzs, 'metadata': metadata})
 
     @app.route('/v1.0/<string:tenant_id>/views/alarmCountsPerNp', methods=['GET'])
     def alarm_counts_per_np(self, request, tenant_id):

--- a/mimic/test/test_maas.py
+++ b/mimic/test/test_maas.py
@@ -576,6 +576,17 @@ class MaasAPITests(SynchronousTestCase):
                 break
         self.assertEquals(None, mysp)
 
+    def test_list_monitoring_zones(self):
+        """
+        List the monitoring zones
+        """
+        req = request(self, self.root, "GET", self.uri+'/monitoring_zones', '')
+        resp = self.successResultOf(req)
+        self.assertEquals(resp.code, 200)
+        data = self.get_responsebody(resp)
+        mz = data['values'][0]
+        self.assertEquals('mzdfw', mz['id'])
+
     def test_alarm_count_per_np(self):
         """
         test_alarm_count_per_np


### PR DESCRIPTION
See the Cloud Monitoring docs section [5.6.1](http://goo.gl/Gl21sb).

This is used in Cloud Intelligence for building UI around creating and editing details of remote checks. I want these features to work when I'm running against Mimic.
