### PR TITLE
RFR: style(maas): s/get_ecan_objectIds/get_ecan_object_ids

### DIFF
--- a/mimic/test/test_maas.py
+++ b/mimic/test/test_maas.py
@@ -103,7 +103,7 @@ class MaasAPITests(SynchronousTestCase):
                 break
         return xobjectid
 
-    def get_ecan_objectIds(self):
+    def get_ecan_object_ids(self):
         """
         Get the Entity, check, alarm an notification(plan) objects created by setUp()
         """
@@ -184,7 +184,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         test get entity
         """
-        ecan = self.get_ecan_objectIds()
+        ecan = self.get_ecan_object_ids()
         req = request(self, self.root, "GET", self.uri+'/entities/'+ecan['entity_id'], '')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
@@ -205,7 +205,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         test get check
         """
-        ecan = self.get_ecan_objectIds()
+        ecan = self.get_ecan_object_ids()
         req = request(self, self.root, "GET",
                       self.uri+'/entities/'+ecan['entity_id']+'/checks/'+ecan['check_id'], '')
         resp = self.successResultOf(req)
@@ -217,7 +217,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         test get check
         """
-        ecan = self.get_ecan_objectIds()
+        ecan = self.get_ecan_object_ids()
         req = request(self, self.root, "GET",
                       self.uri+'/entities/'+ecan['entity_id']+'/checks', '')
         resp = self.successResultOf(req)
@@ -230,7 +230,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         update entity
         """
-        ecan = self.get_ecan_objectIds()
+        ecan = self.get_ecan_object_ids()
         req = request(self, self.root, "GET", self.uri+'/entities/'+ecan['entity_id'], '')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
@@ -249,7 +249,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         update check
         """
-        ecan = self.get_ecan_objectIds()
+        ecan = self.get_ecan_object_ids()
         req = request(self, self.root, "GET",
                       self.uri+'/entities/'+ecan['entity_id']+'/checks/'+ecan['check_id'], '')
         resp = self.successResultOf(req)
@@ -272,7 +272,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         update alarm
         """
-        ecan = self.get_ecan_objectIds()
+        ecan = self.get_ecan_object_ids()
         req = request(self, self.root, "GET", self.uri+'/views/overview', '')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
@@ -293,7 +293,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         delete alarm
         """
-        ecan = self.get_ecan_objectIds()
+        ecan = self.get_ecan_object_ids()
         req = request(self, self.root, "DELETE",
                       self.uri+'/entities/'+ecan['entity_id']+'/alarms/'+ecan['alarm_id'], '')
         resp = self.successResultOf(req)
@@ -307,7 +307,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         delete check
         """
-        ecan = self.get_ecan_objectIds()
+        ecan = self.get_ecan_object_ids()
         req = request(self, self.root, "DELETE",
                       self.uri+'/entities/'+ecan['entity_id']+'/checks/'+ecan['check_id'], '')
         resp = self.successResultOf(req)
@@ -323,7 +323,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         delete entity
         """
-        ecan = self.get_ecan_objectIds()
+        ecan = self.get_ecan_object_ids()
         req = request(self, self.root, "DELETE",
                       self.uri+'/entities/'+ecan['entity_id'], '')
         resp = self.successResultOf(req)
@@ -366,7 +366,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         get available metrics
         """
-        ecan = self.get_ecan_objectIds()
+        ecan = self.get_ecan_object_ids()
         req = request(self, self.root, "GET", self.uri+'/views/metric_list', '')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
@@ -378,7 +378,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         get datapoints for graph
         """
-        ecan = self.get_ecan_objectIds()
+        ecan = self.get_ecan_object_ids()
         metrics = []
         req = request(self, self.root, "GET", self.uri+'/views/metric_list', '')
         resp = self.successResultOf(req)
@@ -409,7 +409,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         Get a specific notification plan
         """
-        ecan = self.get_ecan_objectIds()
+        ecan = self.get_ecan_object_ids()
         req = request(self, self.root, "GET", self.uri+'/notification_plans/'+ecan['np_id'], '')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
@@ -436,7 +436,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         Update a notification target
         """
-        ecan = self.get_ecan_objectIds()
+        ecan = self.get_ecan_object_ids()
         postdata = {'id': ecan['nt_id'], 'label': 'changed'}
         req = request(self, self.root, "PUT", self.uri+'/notifications/'+ecan['nt_id'],
                       json.dumps(postdata))
@@ -458,7 +458,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         Delete a notification target
         """
-        ecan = self.get_ecan_objectIds()
+        ecan = self.get_ecan_object_ids()
         req = request(self, self.root, "DELETE", self.uri+'/notifications/'+ecan['nt_id'], '')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 204)
@@ -477,7 +477,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         Update a notification plan
         """
-        ecan = self.get_ecan_objectIds()
+        ecan = self.get_ecan_object_ids()
         postdata = {'id': ecan['np_id'], 'label': 'changed'}
         req = request(self, self.root, "PUT", self.uri+'/notification_plans/'+ecan['np_id'],
                       json.dumps(postdata))
@@ -493,7 +493,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         Delete a notification plan
         """
-        ecan = self.get_ecan_objectIds()
+        ecan = self.get_ecan_object_ids()
         req = request(self, self.root, "DELETE", self.uri+'/notification_plans/'+ecan['np_id'], '')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 204)
@@ -522,7 +522,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         Get a specific suppression
         """
-        ecan = self.get_ecan_objectIds()
+        ecan = self.get_ecan_object_ids()
         req = request(self, self.root, "GET", self.uri+'/suppressions/'+ecan['sp_id'], '')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
@@ -533,7 +533,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         Get all the suppressions
         """
-        ecan = self.get_ecan_objectIds()
+        ecan = self.get_ecan_object_ids()
         req = request(self, self.root, "GET", self.uri+'/suppressions', '')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
@@ -545,7 +545,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         Update an suppression
         """
-        ecan = self.get_ecan_objectIds()
+        ecan = self.get_ecan_object_ids()
         postdata = {'id': ecan['sp_id'], 'label': 'changed'}
         req = request(self, self.root, "PUT", self.uri+'/suppressions/'+ecan['sp_id'],
                       json.dumps(postdata))
@@ -561,7 +561,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         Delete an suppression
         """
-        ecan = self.get_ecan_objectIds()
+        ecan = self.get_ecan_object_ids()
         req = request(self, self.root, "DELETE", self.uri+'/suppressions/'+ecan['sp_id'], '')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 204)
@@ -591,7 +591,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         test_alarms_by_np
         """
-        ecan = self.get_ecan_objectIds()
+        ecan = self.get_ecan_object_ids()
         req = request(self, self.root, "GET", self.uri+'/views/overview', '')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
@@ -612,7 +612,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         Cant delete a notificationPlan that's being pointed to by alarms
         """
-        ecan = self.get_ecan_objectIds()
+        ecan = self.get_ecan_object_ids()
         req = request(self, self.root, "GET", self.uri+'/views/overview', '')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)


### PR DESCRIPTION
We should be consistent about using underscores and no CamelCase when
defining function names, since Python is strictly a
`words_with_underscores` language when it comes to defining functions
(PEP 8).
