### PR TITLE
RFR: fix(maas): webhook, not webhock

### DIFF
--- a/mimic/rest/maas_api.py
+++ b/mimic/rest/maas_api.py
@@ -87,7 +87,7 @@ class M_Cache(dict):
                                         'label': 'Technical Contacts - Email',
                                         'critical_state': [], 'warning_state': [],
                                         'ok_state': [], 'metadata': None}]
-        self.notificationtypes_list = [{'id': 'webhock', 'fields': [{'name': 'url',
+        self.notificationtypes_list = [{'id': 'webhook', 'fields': [{'name': 'url',
                                                                      'optional': False,
                                                                      'description': 'An HTTP or \
                                                                       HTTPS URL to POST to'}]},


### PR DESCRIPTION
This was breaking Cloud Intelligence in a hilarious way.

![screen shot 2014-12-16 at 11 38 53 am](https://cloud.githubusercontent.com/assets/1271410/5460559/b8f746ee-8518-11e4-8acb-775efdd76db6.png)
