### PR TITLE
Multi-os support setup files for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,44 @@
-language: python
+language: c
+
+os:
+  - osx
+  - linux
+
+compiler:
+    - clang
+    - gcc
 
 env:
-  - TOX_ENV=lint
-  - TOX_ENV=py26
-  - TOX_ENV=py27
-  - TOX_ENV=pypy
-  - TOX_ENV=docs
-  - TOX_ENV=docs-spellcheck
-  - TOX_ENV=docs-linkcheck
+  matrix:
+     - TOX_ENV=lint
+     - TOX_ENV=py26
+     - TOX_ENV=py27
+     - TOX_ENV=pypy
+     - TOX_ENV=docs
+     - TOX_ENV=docs-spellcheck
+     - TOX_ENV=docs-linkcheck
 
 matrix:
   allow_failures:
-    - env: "TOX_ENV=docs-linkcheck"
+    - env: TOX_ENV=docs-linkcheck
+  exclude:
+    - os: osx
+      compiler: gcc
+    - os: linux
+      compiler: clang
 
 install:
   - ./.travis/install.sh
 
-script: tox -e $TOX_ENV
+script:
+  - ./.travis/run.sh
 
 after_success:
-    - if [[ "${TOX_ENV:0:2}" == 'py' ]]; then coveralls; fi
+  - source ~/.venv/bin/activate && coveralls
 
 notifications:
   irc:
-    channels: "chat.freenode.net##mimic"
-    template:
-      - "%{repository}@%{branch} - %{author}: %{message} (%{build_url})"
-    use_notice: true
+     channels: "chat.freenode.net##mimic"
+     template:
+       - "%{repository}@%{branch} - %{author}: %{message} (%{build_url})"
+     use_notice: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ matrix:
   exclude:
     - os: osx
       compiler: gcc
-    - os: linux
-      compiler: clang
 
 install:
   - ./.travis/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ os:
   - linux
 
 compiler:
-    - clang
-    - gcc
+  - clang
+  - gcc
 
 env:
   matrix:
@@ -36,9 +36,9 @@ script:
 after_success:
   - source ~/.venv/bin/activate && coveralls
 
-# notifications:
-#   irc:
-#      channels: "chat.freenode.net##mimic"
-#      template:
-#        - "%{repository}@%{branch} - %{author}: %{message} (%{build_url})"
-#      use_notice: true
+notifications:
+  irc:
+     channels: "chat.freenode.net##mimic"
+     template:
+       - "%{repository}@%{branch} - %{author}: %{message} (%{build_url})"
+     use_notice: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,9 @@ script:
 after_success:
   - source ~/.venv/bin/activate && coveralls
 
-notifications:
-  irc:
-     channels: "chat.freenode.net##mimic"
-     template:
-       - "%{repository}@%{branch} - %{author}: %{message} (%{build_url})"
-     use_notice: true
+# notifications:
+#   irc:
+#      channels: "chat.freenode.net##mimic"
+#      template:
+#        - "%{repository}@%{branch} - %{author}: %{message} (%{build_url})"
+#      use_notice: true

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -29,9 +29,8 @@ if [[ "$DARWIN" = true ]]; then
             pyenv global 2.7.8
             ;;
         pypy)
-            brew upgrade pyenv
-            pyenv install pypy-2.4.0
-            pyenv global pypy-2.4.0
+	    # travis/tox are not findind pypy when installed.
+            brew install pypy
             ;;
         docs)
             curl -O https://bootstrap.pypa.io/get-pip.py

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -29,7 +29,7 @@ if [[ "$DARWIN" = true ]]; then
             pyenv global 2.7.8
             ;;
         pypy)
-	    # travis/tox are not findind pypy when installed.
+	    # travis/tox are not finding pypy when installed using pyenv.
             brew install pypy
             ;;
         docs)

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -30,9 +30,7 @@ if [[ "$DARWIN" = true ]]; then
             ;;
         pypy)
             # do not like this idea
-            brew upgrade pyenv
-            pyenv install pypy-2.4.0
-            pyenv global pypy-2.4.0
+	    brew install pypy
             ;;
         docs)
             curl -O https://bootstrap.pypa.io/get-pip.py

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,29 +1,74 @@
 #!/bin/bash
 
-# Getting around a buggy PyPy in Travis
-# Script from pyca/cryptography
-
 set -e
 set -x
 
-if [[ "${TOX_ENV}" == "pypy"* ]]; then
-    sudo add-apt-repository -y ppa:pypy/ppa
-    sudo apt-get -y update
-    sudo apt-get install -y pypy pypy-dev
-
-    # This is required because we need to get rid of the Travis installed PyPy
-    # or it'll take precedence over the PPA installed one.
-    sudo rm -rf /usr/local/pypy/bin
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    DARWIN=true
+else
+    DARWIN=false
 fi
 
-if [[ "${TOX_ENV}" == "docs-spellcheck" ]]; then
-    if [[ "$DARWIN" = true ]]; then
-        brew update
-        brew install enchant
-    else
-        sudo apt-get -y update
-        sudo apt-get install libenchant-dev
+if [[ "$DARWIN" = true ]]; then
+
+    brew update
+
+    if which pyenv > /dev/null; then
+        eval "$(pyenv init -)"
     fi
+
+    case "${TOX_ENV}" in
+        py26)
+            brew upgrade pyenv
+            pyenv install 2.6.9
+            pyenv global 2.6.9
+            ;;
+        py27)
+            brew upgrade pyenv
+            pyenv install 2.7.8
+            pyenv global 2.7.8
+            ;;
+        pypy)
+            # do not like this idea
+            brew install pypy
+            ;;
+        docs)
+            curl -O https://bootstrap.pypa.io/get-pip.py
+            sudo python get-pip.py
+            ;;
+    esac
+    pyenv rehash
+
+else
+
+    sudo add-apt-repository -y ppa:fkrull/deadsnakes
+
+    if [[ "${TOX_ENV}" == "pypy" ]]; then
+        sudo add-apt-repository -y ppa:pypy/ppa
+    fi
+
+    sudo apt-get -y update
+
+    case "${TOX_ENV}" in
+        py26)
+            sudo apt-get install python2.6 python2.6-dev
+            ;;
+        py27)
+            sudo apt-get install python2.7 python2.7-dev
+            ;;
+        pypy)
+            sudo apt-get install --force-yes pypy pypy-dev
+            ;;
+        docs)
+            sudo apt-get install libenchant-dev
+            ;;
+        docs-spellcheck)
+            sudo apt-get install libenchant-dev
+            ;;
+    esac
 fi
 
+sudo pip install virtualenv
+virtualenv ~/.venv
+source ~/.venv/bin/activate
 pip install tox coveralls

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -29,8 +29,9 @@ if [[ "$DARWIN" = true ]]; then
             pyenv global 2.7.8
             ;;
         pypy)
-            # do not like this idea
-	    brew install pypy
+            brew upgrade pyenv
+            pyenv install pypy-2.4.0
+            pyenv global pypy-2.4.0
             ;;
         docs)
             curl -O https://bootstrap.pypa.io/get-pip.py

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -30,7 +30,9 @@ if [[ "$DARWIN" = true ]]; then
             ;;
         pypy)
             # do not like this idea
-            brew install pypy
+            brew upgrade pyenv
+            pyenv install pypy-2.4.0
+            pyenv global pypy-2.4.0
             ;;
         docs)
             curl -O https://bootstrap.pypa.io/get-pip.py

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+set -x
+
+source ~/.venv/bin/activate
+tox -e $TOX_ENV -- $TOX_FLAGS

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -4,5 +4,4 @@ set -e
 set -x
 
 source ~/.venv/bin/activate
-which python
 tox -e $TOX_ENV -- $TOX_FLAGS

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -4,4 +4,5 @@ set -e
 set -x
 
 source ~/.venv/bin/activate
+which python
 tox -e $TOX_ENV -- $TOX_FLAGS

--- a/tox.ini
+++ b/tox.ini
@@ -15,13 +15,6 @@ commands =
     coverage run {envbindir}/trial --rterrors {posargs:mimic}
     coverage report -m
 
-[testenv:pypy]
-basepython = pypy
-# disable coverage, issues with tracing/slow
-commands =
-	 {envbindir}/trial -rterrors {posargs:mimic}
-
-
 [testenv:docs]
 deps =
     doc8

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ commands =
     coverage run {envbindir}/trial --rterrors {posargs:mimic}
     coverage report -m
 
-[testenv:py26]
+[testenv:pypy]
 basepython = pypy
 # disable coverage, issues with tracing/slow
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,13 @@ commands =
     coverage run {envbindir}/trial --rterrors {posargs:mimic}
     coverage report -m
 
+[testenv:py26]
+basepython = pypy
+# disable coverage, issues with tracing/slow
+commands =
+	 {envbindir}/trial -rterrors {posargs:mimic}
+
+
 [testenv:docs]
 deps =
     doc8


### PR DESCRIPTION
This patch enables multi-os support for testing using Travis. It basically just makes it so each of the tox environments can be tested on both OSX and Linux.

My thought is that this patch be merged prior to the mac-app bundle PR #103.

Thanks!