### PR TITLE
RFR - Return 401 if authing with the wrong tenant ID

### DIFF
--- a/mimic/rest/auth_api.py
+++ b/mimic/rest/auth_api.py
@@ -46,58 +46,78 @@ class AuthApi(object):
         tenant_id = (content['auth'].get('tenantName', None) or
                      content['auth'].get('tenantId', None))
 
-        try:
-            if content['auth'].get('passwordCredentials'):
-                username = content['auth']['passwordCredentials']['username']
-                password = content['auth']['passwordCredentials']['password']
-                session = self.core.sessions.session_for_username_password(
-                    username, password, tenant_id)
-            elif content['auth'].get('RAX-KSKEY:apiKeyCredentials'):
-                username = content['auth']['RAX-KSKEY:apiKeyCredentials'][
-                    'username']
-                api_key = content['auth']['RAX-KSKEY:apiKeyCredentials'][
-                    'apiKey']
-                session = self.core.sessions.session_for_api_key(
-                    username, api_key, tenant_id)
-            elif content['auth'].get('token') and tenant_id:
-                session = self.core.sessions.session_for_tenant_id(tenant_id)
+        def format_response(callable_returning_session,
+                            nonmatching_tenant_message_generator):
+            try:
+                session = callable_returning_session()
+            except NonMatchingTenantError as e:
+                request.setResponseCode(401)
+                return json.dumps({
+                    "unauthorized": {
+                        "code": 401,
+                        "message": nonmatching_tenant_message_generator(e)
+                    }
+                })
             else:
-                request.setResponseCode(400)
-                return json.dumps(
-                    invalid_resource("Invalid JSON request body"))
-        except NonMatchingTenantError as e:
-            request.setResponseCode(401)
-            message = ("Tenant with Name/Id: '{0}' is not valid for "
-                       "User '{1}' (id: '{2}')".format(e.desired_tenant,
-                                                       e.session.username,
-                                                       e.session.user_id))
-            return json.dumps({
-                "unauthorized": {
-                    "code": 401,
-                    "message": message
+                request.setResponseCode(200)
+                prefix_map = {
+                    # map of entry to URI prefix for that entry
                 }
-            })
 
-        request.setResponseCode(200)
-        prefix_map = {
-            # map of entry to URI prefix for that entry
-        }
+                def lookup(entry):
+                    return prefix_map[entry]
+                result = get_token(
+                    session.tenant_id,
+                    entry_generator=lambda tenant_id:
+                    list(self.core.entries_for_tenant(
+                         tenant_id, prefix_map, base_uri_from_request(request))),
+                    prefix_for_endpoint=lookup,
+                    response_token=session.token,
+                    response_user_id=session.user_id,
+                    response_user_name=session.username,
+                )
+                result['access']['user']['roles'].append({
+                    'description': 'User Admin Role.',
+                    'id': '3',
+                    'name': 'identity:user-admin'})
+                return json.dumps(result)
 
-        def lookup(entry):
-            return prefix_map[entry]
-        result = get_token(
-            session.tenant_id,
-            entry_generator=lambda tenant_id:
-            list(self.core.entries_for_tenant(
-                 tenant_id, prefix_map, base_uri_from_request(request))),
-            prefix_for_endpoint=lookup,
-            response_token=session.token,
-            response_user_id=session.user_id,
-            response_user_name=session.username,
-        )
-        result['access']['user']['roles'].append(
-            {'description': 'User Admin Role.', 'id': '3', 'name': 'identity:user-admin'})
-        return json.dumps(result)
+        username_generator = (
+            lambda exception: "Tenant with Name/Id: '{0}' is not valid for "
+                              "User '{1}' (id: '{2}')".format(
+                                  exception.desired_tenant,
+                                  exception.session.username,
+                                  exception.session.user_id))
+
+        if content['auth'].get('passwordCredentials'):
+            username = content['auth']['passwordCredentials']['username']
+            password = content['auth']['passwordCredentials']['password']
+            return format_response(
+                lambda: self.core.sessions.session_for_username_password(
+                    username, password, tenant_id),
+                username_generator)
+
+        elif content['auth'].get('RAX-KSKEY:apiKeyCredentials'):
+            username = content['auth']['RAX-KSKEY:apiKeyCredentials'][
+                'username']
+            api_key = content['auth']['RAX-KSKEY:apiKeyCredentials'][
+                'apiKey']
+            return format_response(
+                lambda: self.core.sessions.session_for_api_key(
+                    username, api_key, tenant_id),
+                username_generator)
+
+        elif content['auth'].get('token') and tenant_id:
+            token = content['auth']['token']['id']
+            return format_response(
+                lambda: self.core.sessions.session_for_token(token,
+                                                             tenant_id),
+                lambda e: "Token doesn't belong to Tenant with Id/Name: "
+                          "'{0}'".format(e.desired_tenant))
+        else:
+            request.setResponseCode(400)
+            return json.dumps(
+                invalid_resource("Invalid JSON request body"))
 
     @app.route('/v1.1/mosso/<string:tenant_id>', methods=['GET'])
     def get_username(self, request, tenant_id):

--- a/mimic/test/test_auth.py
+++ b/mimic/test/test_auth.py
@@ -657,7 +657,6 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         (response, json_body) = self.successResultOf(json_request(
             self, root, "POST", "/identity/v2.0/tokens", creds))
         self.assertEqual(response.code, 200)
-        username = json_body["access"]["user"]["id"]
 
         creds['auth']['tenantId'] = "23456"
 
@@ -667,8 +666,8 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         self.assertEqual(fail_body, {
             "unauthorized": {
                 "code": 401,
-                "message": ("Tenant with Name/Id: '23456' is not valid for "
-                            "User 'demoauthor' (id: '{0}')".format(username))
+                "message": ("Token doesn't belong to Tenant with Id/Name: "
+                            "'23456'")
             }
         })
 

--- a/mimic/test/test_auth.py
+++ b/mimic/test/test_auth.py
@@ -559,6 +559,119 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         user_name = json_body["access"]["user"]["name"]
         self.assertTrue(user_name)
 
+    def test_token_and_catalog_for_password_credentials_wrong_tenant(self):
+        """
+        Tenant ID is validated when provided in username/password auth.
+
+        If authed once as one tenant ID, and a second time with a different
+        tenant ID, then the second auth will return with a 401 Unauthorized.
+        """
+        core = MimicCore(Clock(), [ExampleAPI()])
+        root = MimicRoot(core).app.resource()
+
+        creds = {
+            "auth": {
+                "passwordCredentials": {
+                    "username": "demoauthor",
+                    "password": "theUsersPassword"
+                },
+                "tenantId": "12345"
+            }
+        }
+
+        (response, json_body) = self.successResultOf(json_request(
+            self, root, "POST", "/identity/v2.0/tokens", creds))
+        self.assertEqual(response.code, 200)
+        username = json_body["access"]["user"]["id"]
+
+        creds['auth']['tenantId'] = "23456"
+
+        (response, fail_body) = self.successResultOf(json_request(
+            self, root, "POST", "/identity/v2.0/tokens", creds))
+        self.assertEqual(response.code, 401)
+        self.assertEqual(fail_body, {
+            "unauthorized": {
+                "code": 401,
+                "message": ("Tenant with Name/Id: '23456' is not valid for "
+                            "User 'demoauthor' (id: '{0}')".format(username))
+            }
+        })
+
+    def test_token_and_catalog_for_api_credentials_wrong_tenant(self):
+        """
+        Tenant ID is validated when provided in api-key auth.
+
+        If authed once as one tenant ID, and a second time with a different
+        tenant ID, then the second auth will return with a 401 Unauthorized.
+        """
+        core = MimicCore(Clock(), [ExampleAPI()])
+        root = MimicRoot(core).app.resource()
+
+        creds = {
+            "auth": {
+                "RAX-KSKEY:apiKeyCredentials": {
+                    "username": "demoauthor",
+                    "apiKey": "jhgjhghg-nhghghgh-12222"
+                },
+                "tenantName": "12345"
+            }
+        }
+
+        (response, json_body) = self.successResultOf(json_request(
+            self, root, "POST", "/identity/v2.0/tokens", creds))
+        self.assertEqual(response.code, 200)
+        username = json_body["access"]["user"]["id"]
+
+        creds['auth']['tenantName'] = "23456"
+
+        (response, fail_body) = self.successResultOf(json_request(
+            self, root, "POST", "/identity/v2.0/tokens", creds))
+        self.assertEqual(response.code, 401)
+        self.assertEqual(fail_body, {
+            "unauthorized": {
+                "code": 401,
+                "message": ("Tenant with Name/Id: '23456' is not valid for "
+                            "User 'demoauthor' (id: '{0}')".format(username))
+            }
+        })
+
+    def test_token_and_catalog_for_token_credentials_wrong_tenant(self):
+        """
+        Tenant ID is validated when provided in token auth.
+
+        If authed once as one tenant ID, and a second time with a different
+        tenant ID, then the second auth will return with a 401 Unauthorized.
+        """
+        core = MimicCore(Clock(), [ExampleAPI()])
+        root = MimicRoot(core).app.resource()
+
+        creds = {
+            "auth": {
+                "tenantId": "12345",
+                "token": {
+                    "id": "iuyiuyiuy-uyiuyiuy-1987878"
+                }
+            }
+        }
+
+        (response, json_body) = self.successResultOf(json_request(
+            self, root, "POST", "/identity/v2.0/tokens", creds))
+        self.assertEqual(response.code, 200)
+        username = json_body["access"]["user"]["id"]
+
+        creds['auth']['tenantId'] = "23456"
+
+        (response, fail_body) = self.successResultOf(json_request(
+            self, root, "POST", "/identity/v2.0/tokens", creds))
+        self.assertEqual(response.code, 401)
+        self.assertEqual(fail_body, {
+            "unauthorized": {
+                "code": 401,
+                "message": ("Tenant with Name/Id: '23456' is not valid for "
+                            "User 'demoauthor' (id: '{0}')".format(username))
+            }
+        })
+
     def test_get_token_and_catalog_for_invalid_json_request_body(self):
         """
         :func: `get_token_and_service_catalog` returns response code 400, when


### PR DESCRIPTION
This should fix issue #146.

Basically if you auth once, and auth again but specify a different tenant ID, identity should return 401.
I unfortunately also had to sneak a change to actually validate the token, because I couldn't trigger the failure otherwise.  Luckily this doesn't break any tests.

Not super happy about the `get_token_and_service_catalog` refactor, but the error message for username/password and username/api-key differs very slightly from the token/tenant_id auth.  Suggestions welcome.