### PR TITLE
Do not re-append identity:admin role to user roles

### DIFF
--- a/mimic/rest/auth_api.py
+++ b/mimic/rest/auth_api.py
@@ -76,10 +76,6 @@ class AuthApi(object):
                     response_user_id=session.user_id,
                     response_user_name=session.username,
                 )
-                result['access']['user']['roles'].append({
-                    'description': 'User Admin Role.',
-                    'id': '3',
-                    'name': 'identity:user-admin'})
                 return json.dumps(result)
 
         username_generator = (

--- a/mimic/test/test_auth.py
+++ b/mimic/test/test_auth.py
@@ -291,6 +291,34 @@ class GetAuthTokenAPITests(SynchronousTestCase):
         self.assertEqual(200, response.code)
         self.assertEqual(json_body['access']['user']['roles'], HARD_CODED_ROLES)
 
+    def test_response_has_same_roles_despite_number_of_auths(self):
+        """
+        The JSON response for authenticate has only one `identity:user-admin`
+        role, no matter how many times the user authenticates.
+        """
+        core = MimicCore(Clock(), [])
+        root = MimicRoot(core).app.resource()
+
+        creds = {
+            "auth": {
+                "passwordCredentials": {
+                    "username": "demoauthor",
+                    "password": "theUsersPassword"
+                }
+
+            }
+        }
+
+        self.successResultOf(json_request(
+            self, root, "POST", "/identity/v2.0/tokens", creds))
+        self.successResultOf(json_request(
+            self, root, "POST", "/identity/v2.0/tokens", creds))
+        (response, json_body) = self.successResultOf(json_request(
+            self, root, "POST", "/identity/v2.0/tokens", creds))
+
+        self.assertEqual(200, response.code)
+        self.assertEqual(json_body['access']['user']['roles'], HARD_CODED_ROLES)
+
     def test_authentication_request_with_no_body_causes_http_bad_request(self):
         """
         The response for empty body request is bad_request.


### PR DESCRIPTION
It is already in the hard-coded roles for the user, which should be sufficient prior to RBAC implementation.

Fixes #153