### PR TITLE
Nodes should by default be added as ACTIVE, like servers in Nova.

### DIFF
--- a/mimic/rest/rackconnect_v3_api.py
+++ b/mimic/rest/rackconnect_v3_api.py
@@ -297,8 +297,7 @@ class LoadBalancerPoolsInRegion(object):
                     created=seconds_to_timestamp(self.clock.seconds(),
                                                  timestamp_format),
                     load_balancer_pool=pool,
-                    cloud_server=add['cloud_server']['id'],
-                    status=text_type("ADDING"))
+                    cloud_server=add['cloud_server']['id'])
 
                 pool.nodes.append(node)
                 added_nodes.append(node)

--- a/mimic/test/test_rackconnect_v3.py
+++ b/mimic/test/test_rackconnect_v3.py
@@ -320,7 +320,7 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
                 "cloud_server": add_blob['cloud_server'],
                 "load_balancer_pool": add_blob['load_balancer_pool'],
                 "created": "1970-01-01T00:00:{0:02}Z".format(seconds),
-                "status": "ADDING",
+                "status": "ACTIVE",
                 "status_detail": None,
                 "updated": None
             }


### PR DESCRIPTION
Intermediary states should probably be introduced via a control plane.