### PR TITLE
fail when request can't be generated

### DIFF
--- a/mimic/test/helpers.py
+++ b/mimic/test/helpers.py
@@ -38,7 +38,6 @@ class AbortableStringTransport(StringTransport):
         self.loseConnection()
 
 
-
 class RequestTraversalAgent(object):
     """
     :obj:`IAgent` implementation that issues an in-memory request rather than

--- a/mimic/test/helpers.py
+++ b/mimic/test/helpers.py
@@ -25,6 +25,20 @@ from twisted.python.failure import Failure
 import treq
 
 
+class AbortableStringTransport(StringTransport):
+    """
+    A :obj:`StringTransport` that supports ``abortConnection``.
+    """
+
+    def abortConnection(self):
+        """
+        Since all connection cessation is immediate in this in-memory
+        transport, just call ``loseConnection``.
+        """
+        self.loseConnection()
+
+
+
 class RequestTraversalAgent(object):
     """
     :obj:`IAgent` implementation that issues an in-memory request rather than
@@ -63,7 +77,7 @@ class RequestTraversalAgent(object):
 
         # We want to capture the output of that connection so we'll make an
         # in-memory transport.
-        clientTransport = StringTransport()
+        clientTransport = AbortableStringTransport()
 
         # When the protocol is connected to a transport, it ought to send the
         # whole request because callers of this should not use an asynchronous

--- a/mimic/test/test_util.py
+++ b/mimic/test/test_util.py
@@ -2,8 +2,10 @@
 Unit tests for :mod:`mimic.util`
 """
 from twisted.trial.unittest import SynchronousTestCase
+from twisted.web.resource import Resource
 
 from mimic.util import helper
+from mimic.test.helpers import request
 
 
 class HelperTests(SynchronousTestCase):
@@ -65,3 +67,19 @@ class HelperTests(SynchronousTestCase):
         for match in matches:
             self.assertEqual(match[1],
                              helper.seconds_to_timestamp(0, match[0]))
+
+
+class TestHelperTests(SynchronousTestCase):
+    """
+    Tests for :obj:`mimic.test.helpers`.
+    """
+
+    def test_unicode_body(self):
+        """
+        If :obj:`request` is given a unicode request body, the deferred
+        synchronously fails so that the caller can immediately tell something
+        is wrong.
+        """
+        self.failureResultOf(
+            request(self, Resource(), b"POST", b"", u"not bytes")
+        )


### PR DESCRIPTION
Add a test for our test helper to make sure that it is implemented in such a way that you can see when you give request the wrong arguments.