### PR TITLE
Normalize links in nova

### DIFF
--- a/mimic/model/nova_objects.py
+++ b/mimic/model/nova_objects.py
@@ -94,16 +94,17 @@ class Server(object):
             "updated": seconds_to_timestamp(self.update_time),
             "flavor": {
                 "id": self.flavor_ref,
-                "links": [{"href": absolutize_url(
-                    "{0}/flavors/{1}".format(tenant_id,
-                                             self.flavor_ref))}],
-                "rel": "bookmark"
+                "links": [{
+                    "href": absolutize_url(
+                        "{0}/flavors/{1}".format(tenant_id, self.flavor_ref)),
+                    "rel": "bookmark"}],
             },
             "image": {
                 "id": self.image_ref,
                 "links": [{
                     "href": absolutize_url("{0}/images/{1}".format(
-                        tenant_id, self.flavor_ref))
+                        tenant_id, self.flavor_ref)),
+                    "rel": "bookmark"
                 }]
             }
             if self.image_ref is not None else '',

--- a/mimic/test/helpers.py
+++ b/mimic/test/helpers.py
@@ -195,3 +195,35 @@ def json_request(testCase, rootResource, method, uri, body=b"",
         return body_d
 
     return d.addCallback(get_body)
+
+
+def validate_link_json(testCase, json_containing_links):
+    """
+    Ensure that a JSON blob has the keys "id" and "links", and that the value
+    for links is a list of dicts containing 'href' and 'rel'
+
+    :param TestCase testCase: a test case to call assertions on
+    :param dict json_content: A dictionary to validate that it has a correct
+        'links' attribute.
+    """
+    testCase.assertIsInstance(json_containing_links, dict,
+                              "{0} is not a dictionary"
+                              .format(json_containing_links))
+    testCase.assertIn('id', json_containing_links,
+                      'There is no "id" attribute in {0}'
+                      .format(json_containing_links))
+    testCase.assertIn('links', json_containing_links,
+                      'There is no "links" attribute in {0}'
+                      .format(json_containing_links))
+    testCase.assertIsInstance(json_containing_links['links'], list,
+                              "Links is not a list in {0}"
+                              .format(json_containing_links))
+    for link in json_containing_links['links']:
+        testCase.assertIn('href', link,
+                          'Link does not contain "href": {0}'.format(link))
+        testCase.assertIn('rel', link,
+                          'Link does not contain "rel": {0}'.format(link))
+        testCase.assertIsInstance(link['href'], basestring,
+                                  '"href" is not a string: {0}'.format(link))
+        testCase.assertIsInstance(link['rel'], basestring,
+                                  '"rel" is not a string: {0}'.format(link))

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -33,9 +33,9 @@ class NovaAPITests(SynchronousTestCase):
                 }
             }))
         self.create_server_response = self.successResultOf(create_server)
-        create_server_response_body = self.successResultOf(
+        self.create_server_response_body = self.successResultOf(
             treq.json_content(self.create_server_response))
-        self.server_id = create_server_response_body['server']['id']
+        self.server_id = self.create_server_response_body['server']['id']
         self.nth_endpoint_public = helper.nth_endpoint_public
 
     def validate_server_detail_json(self, server_json):
@@ -71,6 +71,7 @@ class NovaAPITests(SynchronousTestCase):
         """
         self.assertEqual(self.create_server_response.code, 202)
         self.assertTrue(type(self.server_id), unicode)
+        validate_link_json(self, self.create_server_response_body['server'])
 
     def test_list_servers(self):
         """
@@ -84,6 +85,7 @@ class NovaAPITests(SynchronousTestCase):
         self.assertEqual(list_servers_response_body['servers'][0]['id'],
                          self.server_id)
         self.assertEqual(len(list_servers_response_body['servers']), 1)
+        validate_link_json(self, list_servers_response_body['servers'][0])
 
     def test_list_servers_with_args(self):
         """

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -4,7 +4,7 @@ import treq
 
 from twisted.trial.unittest import SynchronousTestCase
 
-from mimic.test.helpers import json_request, request
+from mimic.test.helpers import json_request, request, validate_link_json
 from mimic.rest.nova_api import NovaApi
 from mimic.test.fixtures import APIMockHelper, TenantAuthentication
 
@@ -37,6 +37,33 @@ class NovaAPITests(SynchronousTestCase):
             treq.json_content(self.create_server_response))
         self.server_id = create_server_response_body['server']['id']
         self.nth_endpoint_public = helper.nth_endpoint_public
+
+    def validate_server_detail_json(self, server_json):
+        """
+        Tests to validate the server JSON.
+        """
+        validate_link_json(self, server_json)
+        # id and links has already been checked, there are others that are not
+        # yet implemented in mimic/optional
+        response_keys = ("accessIPv4", "accessIPv6", "addresses", "created",
+                         "flavor", "image", "metadata", "name", "status",
+                         "tenant_id", "updated", "OS-EXT-STS:task_state",
+                         "OS-DCF:diskConfig")
+        for key in response_keys:
+            self.assertIn(key, server_json)
+
+        validate_link_json(self, server_json['image'])
+        validate_link_json(self, server_json['flavor'])
+
+        self.assertIsInstance(server_json['addresses'], dict)
+        for addresses in server_json['addresses'].values():
+            self.assertIsInstance(addresses, list)
+            for address in addresses:
+                self.assertIn('addr', address)
+                self.assertIn('version', address)
+                self.assertIn(address['version'], (4, 6),
+                              "Address version must be 4 or 6: {0}"
+                              .format(address))
 
     def test_create_server(self):
         """
@@ -96,7 +123,9 @@ class NovaAPITests(SynchronousTestCase):
         self.assertEqual(get_server_response.code, 200)
         self.assertEqual(get_server_response_body['server']['id'],
                          self.server_id)
-        self.assertEqual(get_server_response_body['server']['status'], 'ACTIVE')
+        self.assertEqual(
+            get_server_response_body['server']['status'], 'ACTIVE')
+        self.validate_server_detail_json(get_server_response_body['server'])
 
     def test_get_server_negative(self):
         """
@@ -120,6 +149,9 @@ class NovaAPITests(SynchronousTestCase):
                          self.server_id)
         self.assertEqual(len(list_servers_detail_response_body['servers']), 1)
         self.assertEqual(list_servers_detail_response_body['servers'][0]['status'], 'ACTIVE')
+
+        self.validate_server_detail_json(
+            list_servers_detail_response_body['servers'][0])
 
     def test_list_servers_with_details_with_args(self):
         """
@@ -146,6 +178,7 @@ class NovaAPITests(SynchronousTestCase):
         self.assertEqual(body['servers'][0]['id'], self.server_id)
         self.assertEqual(len(body['servers']), 1)
         self.assertEqual(body['servers'][0]['status'], 'ACTIVE')
+        self.validate_server_detail_json(body['servers'][0])
 
     def test_list_servers_with_details_with_args_negative(self):
         """


### PR DESCRIPTION
The flavor links blob and image links blob were missing the "rel" attribute, or it was in the wrong place.

Actually add a test to attempt to validate the json responses returned by nova APIs.