### PR TITLE
exlude clang on linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ matrix:
   exclude:
     - os: osx
       compiler: gcc
+    - os: linux
+      compiler: clang
 
 install:
   - ./.travis/install.sh


### PR DESCRIPTION
Exclude osx/gcc and linux/clang.