### PR TITLE
RFR: Include validate token api call

### DIFF
--- a/mimic/canned_responses/auth.py
+++ b/mimic/canned_responses/auth.py
@@ -113,7 +113,7 @@ def get_token(tenant_id,
         }
     }
 
-    if (entry_generator and prefix_for_endpoint):
+    if entry_generator is not None and prefix_for_endpoint is not None:
         response["access"]["serviceCatalog"] = list(entry_json())
     return response
 

--- a/mimic/canned_responses/auth.py
+++ b/mimic/canned_responses/auth.py
@@ -11,7 +11,8 @@ GLOBAL_MUTABLE_TOKEN_STORE = {}
 HARD_CODED_TOKEN = "fff73937db5047b8b12fc9691ea5b9e8"
 HARD_CODED_USER_ID = "10002"
 HARD_CODED_USER_NAME = "mimictestuser"
-HARD_CODED_ROLES = [{"id": "3", "description": "User Admin Role.",
+HARD_CODED_ROLES = [{"id": "3",
+                     "description": "User Admin Role.",
                      "name": "identity:user-admin"}]
 
 
@@ -22,6 +23,38 @@ def format_timestamp(dt):
     :param datetime.datetime dt: A datetime.datetime object to be formatted.
     """
     return dt.strftime('%Y-%m-%dT%H:%M:%S.999-05:00')
+
+
+def impersonator_user_role(id, name):
+    """
+    Canned response for validate token if the token being validated
+    is an impersonated token.
+    """
+    return {
+        "id": id,
+        "roles": [
+            {"id": "10000001",
+             "serviceId": "test-eabb70a0e702a4626977c331d5c4",
+             "description": "Service admin role for cloud feeds access. Assign only to service users",
+             "name": "cloudfeeds:service-admin"},
+            {"id": "10000002",
+             "serviceId": "test-eabb70a0e702a4626977c331d5c4",
+             "description": "Checkmate Access role",
+             "name": "checkmate"},
+            {"id": "100000003",
+             "serviceId": "test-eabb70a0e702a4626977c331d5c4",
+             "description": "Service admin role for Monitoring access. Assign only to service users",
+             "name": "monitoring:service-admin"},
+            {"id": "100000004",
+             "serviceId": "test-eabb70a0e702a4626977c331d5c4",
+             "description": "Admin Role.",
+             "name": "identity:admin"},
+            {"id": "10000005",
+             "serviceId": "test-d4614b87411e141fe8109099bc4f",
+             "description": "Role to access Customer service as an Admin",
+             "name": "customer:admin"}],
+        "name": name
+    }
 
 
 def get_token(tenant_id,

--- a/mimic/canned_responses/auth.py
+++ b/mimic/canned_responses/auth.py
@@ -25,8 +25,8 @@ def format_timestamp(dt):
 
 
 def get_token(tenant_id,
-              entry_generator,
-              prefix_for_endpoint,
+              entry_generator=None,
+              prefix_for_endpoint=None,
               timestamp=format_timestamp,
               response_token=HARD_CODED_TOKEN,
               response_user_id=HARD_CODED_USER_ID,
@@ -61,7 +61,7 @@ def get_token(tenant_id,
                 "endpoints": list(endpoint_json())
             }
 
-    return {
+    response = {
         "access": {
             "token": {
                 # TODO: This token should be synthesized and stored in an
@@ -72,7 +72,6 @@ def get_token(tenant_id,
                     "id": tenant_id,
                     "name": tenant_id},
                 "RAX-AUTH:authenticatedBy": ["PASSWORD"]},
-            "serviceCatalog": list(entry_json()),
             "user": {
                 "id": response_user_id,
                 "name": response_user_name,
@@ -80,6 +79,10 @@ def get_token(tenant_id,
             }
         }
     }
+
+    if (entry_generator and prefix_for_endpoint):
+        response["access"]["serviceCatalog"] = list(entry_json())
+    return response
 
 
 def get_endpoints(tenant_id, entry_generator, prefix_for_endpoint):

--- a/mimic/rest/auth_api.py
+++ b/mimic/rest/auth_api.py
@@ -7,7 +7,7 @@ import json
 
 from twisted.web.server import Request
 from twisted.python.urlpath import URLPath
-from mimic.canned_responses.auth import get_token, get_endpoints
+from mimic.canned_responses.auth import get_token, get_endpoints, impersonator_user_role
 from mimic.rest.mimicapp import MimicApp
 from mimic.canned_responses.auth import format_timestamp
 from mimic.util.helper import invalid_resource
@@ -106,8 +106,8 @@ class AuthApi(object):
         elif content['auth'].get('token') and tenant_id:
             token = content['auth']['token']['id']
             return format_response(
-                lambda: self.core.sessions.session_for_token(token,
-                                                             tenant_id),
+                lambda: self.core.sessions.session_for_token(
+                    token, tenant_id)[0],
                 lambda e: "Token doesn't belong to Tenant with Id/Name: "
                           "'{0}'".format(e.desired_tenant))
         else:
@@ -135,14 +135,15 @@ class AuthApi(object):
         except ValueError:
             request.setResponseCode(400)
             return json.dumps(invalid_resource("Invalid JSON request body"))
-
+        impersonator_token = request.getHeader("X-Auth-Token")
         expires_in = content['RAX-AUTH:impersonation']['expire-in-seconds']
         username = content['RAX-AUTH:impersonation']['user']['username']
 
         session = self.core.sessions.session_for_impersonation(username,
-                                                               expires_in)
+                                                               expires_in,
+                                                               impersonator_token)
         return json.dumps({"access": {
-            "token": {"id": session.token,
+            "token": {"id": session.impersonated_token,
                       "expires": format_timestamp(session.expires)}
         }})
 
@@ -156,13 +157,18 @@ class AuthApi(object):
         tenant_id = request.args.get('belongsTo')
         if tenant_id:
             tenant_id = tenant_id[0]
-        session = self.core.sessions.session_for_token(token_id, tenant_id)
+        (session, impersonator_session) = self.core.sessions.session_for_token(
+            token_id, tenant_id)
         response = get_token(
             session.tenant_id,
             response_token=session.token,
             response_user_id=session.user_id,
             response_user_name=session.username,
         )
+        if impersonator_session:
+            response["access"]["RAX-AUTH:impersonator"] = impersonator_user_role(
+                impersonator_session.user_id,
+                impersonator_session.username)
         return json.dumps(response)
 
     @app.route('/v2.0/tokens/<string:token_id>/endpoints', methods=['GET'])
@@ -174,7 +180,8 @@ class AuthApi(object):
         # FIXME: TEST
         request.setResponseCode(200)
         prefix_map = {}
-        session = self.core.sessions.session_for_token(token_id)
+        (session, impersonator_session) = self.core.sessions.session_for_token(
+            token_id)
         return json.dumps(get_endpoints(
             session.tenant_id,
             entry_generator=lambda tenant_id: list(

--- a/mimic/rest/auth_api.py
+++ b/mimic/rest/auth_api.py
@@ -4,6 +4,7 @@ Defines get token, impersonation
 """
 
 import json
+import time
 
 from twisted.web.server import Request
 from twisted.python.urlpath import URLPath
@@ -12,6 +13,7 @@ from mimic.rest.mimicapp import MimicApp
 from mimic.canned_responses.auth import format_timestamp
 from mimic.util.helper import invalid_resource
 from mimic.session import NonMatchingTenantError
+from mimic.util.helper import seconds_to_timestamp
 
 Request.defaultContentType = 'application/json'
 
@@ -157,7 +159,7 @@ class AuthApi(object):
             "access": {
                 "token": {
                     "id": token_id,
-                    "expires": "2010-11-01T03:32:15-05:00",
+                    "expires": seconds_to_timestamp(int(time.time() + 36000)),
                     "tenant": {
                         "id": tenant_id,
                         "name": "My Project"

--- a/mimic/rest/auth_api.py
+++ b/mimic/rest/auth_api.py
@@ -169,14 +169,15 @@ class AuthApi(object):
                     "RAX-AUTH:defaultRegion": "DFW",
                     "id": "123",
                     "name": "testuser",
-                    "roles": [{
-                        "id": "123",
-                        "name": "monitoring:service-admin"
-                    },
+                    "roles": [
                         {
-                        "id": "234",
-                        "name": "object-store:admin",
-                    }
+                            "id": "234",
+                            "name": "identity:service-admin",
+                        },
+                        {
+                            "id": "456",
+                            "name": "identity:default"
+                        }
                     ]
                 }
             }

--- a/mimic/rest/auth_api.py
+++ b/mimic/rest/auth_api.py
@@ -171,7 +171,7 @@ class AuthApi(object):
                     "name": "testuser",
                     "roles": [{
                         "id": "123",
-                        "name": "compute:admin"
+                        "name": "monitoring:service-admin"
                     },
                         {
                         "id": "234",

--- a/mimic/rest/auth_api.py
+++ b/mimic/rest/auth_api.py
@@ -152,22 +152,7 @@ class AuthApi(object):
         Validate a token id and return its roles.
         """
         request.setResponseCode(200)
-        # try:
-        #     content = json.loads(request.content.read())
-        # except ValueError:
-        #     request.setResponseCode(400)
-        #     return json.dumps(invalid_resource("Invalid JSON request body"))
-
-        # expires_in = content['RAX-AUTH:impersonation']['expire-in-seconds']
-        # username = content['RAX-AUTH:impersonation']['user']['username']
-
-        # session = self.core.sessions.session_for_impersonation(username,
-        #                                                        expires_in)
-        # return json.dumps({"access": {
-        #     "token": {"id": session.token,
-        # #               "expires": format_timestamp(session.expires)}
-        # }})
-        return b''
+        return json.dumps({})
 
     @app.route('/v2.0/tokens/<string:token_id>/endpoints', methods=['GET'])
     def get_endpoints_for_token(self, request, token_id):

--- a/mimic/rest/auth_api.py
+++ b/mimic/rest/auth_api.py
@@ -135,7 +135,7 @@ class AuthApi(object):
         except ValueError:
             request.setResponseCode(400)
             return json.dumps(invalid_resource("Invalid JSON request body"))
-        impersonator_token = request.getHeader("X-Auth-Token")
+        impersonator_token = request.getHeader("x-auth-token")
         expires_in = content['RAX-AUTH:impersonation']['expire-in-seconds']
         username = content['RAX-AUTH:impersonation']['user']['username']
 

--- a/mimic/rest/auth_api.py
+++ b/mimic/rest/auth_api.py
@@ -154,7 +154,9 @@ class AuthApi(object):
         """
         request.setResponseCode(200)
         tenant_id = request.args.get('belongsTo')
-        session = self.core.sessions.session_for_token(token_id, tenant_id[0])
+        if tenant_id:
+            tenant_id = tenant_id[0]
+        session = self.core.sessions.session_for_token(token_id, tenant_id)
         response = get_token(
             session.tenant_id,
             response_token=session.token,

--- a/mimic/rest/auth_api.py
+++ b/mimic/rest/auth_api.py
@@ -172,7 +172,7 @@ class AuthApi(object):
                     "roles": [
                         {
                             "id": "234",
-                            "name": "identity:service-admin",
+                            "name": "identity:user-admin",
                         },
                         {
                             "id": "456",

--- a/mimic/rest/auth_api.py
+++ b/mimic/rest/auth_api.py
@@ -146,6 +146,29 @@ class AuthApi(object):
                       "expires": format_timestamp(session.expires)}
         }})
 
+    @app.route('/v2.0/tokens/<string:token_id>', methods=['GET'])
+    def validate_token(self, request, token_id):
+        """
+        Validate a token id and return its roles.
+        """
+        request.setResponseCode(200)
+        # try:
+        #     content = json.loads(request.content.read())
+        # except ValueError:
+        #     request.setResponseCode(400)
+        #     return json.dumps(invalid_resource("Invalid JSON request body"))
+
+        # expires_in = content['RAX-AUTH:impersonation']['expire-in-seconds']
+        # username = content['RAX-AUTH:impersonation']['user']['username']
+
+        # session = self.core.sessions.session_for_impersonation(username,
+        #                                                        expires_in)
+        # return json.dumps({"access": {
+        #     "token": {"id": session.token,
+        # #               "expires": format_timestamp(session.expires)}
+        # }})
+        return b''
+
     @app.route('/v2.0/tokens/<string:token_id>/endpoints', methods=['GET'])
     def get_endpoints_for_token(self, request, token_id):
         """

--- a/mimic/rest/auth_api.py
+++ b/mimic/rest/auth_api.py
@@ -152,7 +152,34 @@ class AuthApi(object):
         Validate a token id and return its roles.
         """
         request.setResponseCode(200)
-        return json.dumps({})
+        tenant_id = request.args.get('belongsTo', None)
+        response = {
+            "access": {
+                "token": {
+                    "id": token_id,
+                    "expires": "2010-11-01T03:32:15-05:00",
+                    "tenant": {
+                        "id": tenant_id,
+                        "name": "My Project"
+                    }
+                },
+                "user": {
+                    "RAX-AUTH:defaultRegion": "DFW",
+                    "id": "123",
+                    "name": "testuser",
+                    "roles": [{
+                        "id": "123",
+                        "name": "compute:admin"
+                    },
+                        {
+                        "id": "234",
+                        "name": "object-store:admin",
+                    }
+                    ]
+                }
+            }
+        }
+        return json.dumps(response)
 
     @app.route('/v2.0/tokens/<string:token_id>/endpoints', methods=['GET'])
     def get_endpoints_for_token(self, request, token_id):

--- a/mimic/session.py
+++ b/mimic/session.py
@@ -159,13 +159,13 @@ class SessionStore(object):
     def session_for_impersonation(self, username, expires_in, impersonator_token=None):
         """
         Create or return a :obj:`Session` impersonating a given user; this
-        session is distinct from the user's normal login session in that it
-        will have an independent token.
+        session updates the expiration to be that indicated.
         """
         impersonator_session = self._token_to_session.get(impersonator_token)
         session = self.session_for_username_password(
             username, "lucky we don't check passwords, isn't it",
         )
+        session.expires = datetime.utcfromtimestamp(self.clock.seconds() + expires_in)
         self._impersonated_token_to_impersonator_session[
             session.impersonated_token] = impersonator_session
         return session

--- a/mimic/session.py
+++ b/mimic/session.py
@@ -177,4 +177,4 @@ class SessionStore(object):
         """
         if tenant_id not in self._tenant_to_token:
             return self._new_session(tenant_id=tenant_id)
-        return self.session_for_token(self._tenant_to_token[tenant_id])
+        return self.session_for_token(self._tenant_to_token[tenant_id])[0]

--- a/mimic/test/helpers.py
+++ b/mimic/test/helpers.py
@@ -179,7 +179,7 @@ def request_with_content(testCase, rootResource, method, uri, body=b"",
 
 
 def json_request(testCase, rootResource, method, uri, body=b"",
-                 baseURI='http://localhost:8900/'):
+                 baseURI='http://localhost:8900/', headers=None):
     """
     Issue a request with a JSON body (if there's a body at all) and return
     synchronously with a tuple of ``(response, JSON response body)``
@@ -187,7 +187,7 @@ def json_request(testCase, rootResource, method, uri, body=b"",
     if body != "":
         body = json.dumps(body)
 
-    d = request(testCase, rootResource, method, uri, body, baseURI)
+    d = request(testCase, rootResource, method, uri, body, baseURI, headers)
 
     def get_body(response):
         body_d = treq.json_content(response)

--- a/mimic/test/test_auth.py
+++ b/mimic/test/test_auth.py
@@ -774,3 +774,20 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
                                 "{ bad request: }"))
 
         self.assertEqual(400, response.code)
+
+    def test_response_for_validate_token(self):
+        """
+        Test to verify :func: `validate_token`.
+        """
+        core = MimicCore(Clock(), [ExampleAPI()])
+        root = MimicRoot(core).app.resource()
+
+        (response, json_body) = self.successResultOf(json_request(
+            self, root, "GET",
+            "http://mybase/identity/v2.0/tokens/123456a?belongsTo='111111'"
+        ))
+        self.assertEqual(200, response.code)
+        self.assertTrue(json_body['access']['token']['id'])
+        self.assertTrue(json_body['access']['user']['id'])
+        self.assertTrue(len(json_body['access']['user']['roles']) > 0)
+        self.assertTrue(json_body['access'].get('serviceCatalog') is None)

--- a/mimic/test/test_auth.py
+++ b/mimic/test/test_auth.py
@@ -794,13 +794,29 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
 
         (response, json_body) = self.successResultOf(json_request(
             self, root, "GET",
-            "http://mybase/identity/v2.0/tokens/123456a?belongsTo='111111'"
+            "http://mybase/identity/v2.0/tokens/123456a?belongsTo=111111"
         ))
         self.assertEqual(200, response.code)
-        self.assertTrue(json_body['access']['token']['id'])
+        self.assertEqual(json_body['access']['token']['id'], '123456a')
         self.assertTrue(json_body['access']['user']['id'])
         self.assertTrue(len(json_body['access']['user']['roles']) > 0)
         self.assertTrue(json_body['access'].get('serviceCatalog') is None)
+
+    def test_response_for_validate_token_when_tenant_not_provided(self):
+        """
+        Test to verify :func: `validate_token` when tenant_id is not
+        provided using the argument `belongsTo`
+        """
+        core = MimicCore(Clock(), [ExampleAPI()])
+        root = MimicRoot(core).app.resource()
+
+        (response, json_body) = self.successResultOf(json_request(
+            self, root, "GET",
+            "http://mybase/identity/v2.0/tokens/123456a"
+        ))
+        self.assertEqual(200, response.code)
+        self.assertEqual(json_body['access']['token']['id'], '123456a')
+        self.assertTrue(json_body['access']['token']['tenant']['id'])
 
     def test_response_for_validate_token_then_authenticate(self):
         """

--- a/mimic/test/test_session.py
+++ b/mimic/test/test_session.py
@@ -73,7 +73,7 @@ class SessionCreationTests(SynchronousTestCase):
         for the API key.
         """
         sessions = SessionStore(Clock())
-        a = sessions.session_for_token("testtoken")
+        (a, z) = sessions.session_for_token("testtoken")
         b = sessions.session_for_username_password(a.username, "testpswd")
         c = sessions.session_for_api_key(a.username, "testapikey")
         self.assertIdentical(a, b)
@@ -104,10 +104,10 @@ class SessionCreationTests(SynchronousTestCase):
         sessions = SessionStore(Clock())
         a = sessions.session_for_username_password("username",
                                                    "testpswd")
-        b = sessions.session_for_token(a.token)
+        (b, z) = sessions.session_for_token(a.token)
         self.assertIdentical(a, b)
         c = sessions.session_for_api_key("apiuser", "testkey")
-        d = sessions.session_for_token(c.token)
+        (d, y) = sessions.session_for_token(c.token)
         self.assertIdentical(c, d)
 
     def test_by_token_after_username_wrong_tenant(self):
@@ -122,7 +122,7 @@ class SessionCreationTests(SynchronousTestCase):
                                                    "testpswd")
         self.assertRaises(
             NonMatchingTenantError,
-            sessions.session_for_token,
+            sessions.session_for_token[0],
             a.token, a.tenant_id + 'wrong')
 
     def test_impersonation(self):
@@ -138,7 +138,7 @@ class SessionCreationTests(SynchronousTestCase):
         a = sessions.session_for_impersonation("pretender", A_LOT)
         a_prime = sessions.session_for_impersonation("pretender", A_LOT)
         self.assertIdentical(a, a_prime)
-        b = sessions.session_for_token(a.token)
+        (b, z) = sessions.session_for_token(a.token)
         self.assertEqual(
             a.expires, datetime.utcfromtimestamp(A_LITTLE + A_LOT))
         self.assertIdentical(a, b)
@@ -212,7 +212,7 @@ class SessionCreationTests(SynchronousTestCase):
             sessions.session_for_username_password("someuser1", "testpass"),
             sessions.session_for_impersonation("someuser2", 12),
             sessions.session_for_api_key("someuser3", "someapikey"),
-            sessions.session_for_token("sometoken"),
+            sessions.session_for_token("sometoken")[0],
         ]
         integer = re.compile('^\d+$')
         for session in sessions:
@@ -237,7 +237,7 @@ class SessionCreationTests(SynchronousTestCase):
                                                    "tenant1"),
             sessions.session_for_api_key("user2", "apikey",
                                          tenant_id="tenant2"),
-            sessions.session_for_token("token", tenant_id="tenant3"),
+            sessions.session_for_token("token", tenant_id="tenant3")[0],
             sessions.session_for_tenant_id("tenant4")
         ]
         for i, session in enumerate(sessions):

--- a/mimic/test/test_session.py
+++ b/mimic/test/test_session.py
@@ -122,7 +122,7 @@ class SessionCreationTests(SynchronousTestCase):
                                                    "testpswd")
         self.assertRaises(
             NonMatchingTenantError,
-            sessions.session_for_token[0],
+            sessions.session_for_token,
             a.token, a.tenant_id + 'wrong')
 
     def test_impersonation(self):

--- a/mimic/test/test_session.py
+++ b/mimic/test/test_session.py
@@ -128,7 +128,7 @@ class SessionCreationTests(SynchronousTestCase):
     def test_impersonation(self):
         """
         SessionStore.session_for_impersonation will return a session that can
-        be retrieved by token_id but not username.
+        be retrieved by impersonated token_id or username.
         """
         clock = Clock()
         sessions = SessionStore(clock)
@@ -144,7 +144,7 @@ class SessionCreationTests(SynchronousTestCase):
         self.assertIdentical(a, b)
         c = sessions.session_for_username_password("pretender",
                                                    "not a password")
-        self.assertNotIdentical(a, c)
+        self.assertIdentical(a, c)
         self.assertEqual(a.username, c.username)
         self.assertEqual(a.tenant_id, c.tenant_id)
 

--- a/mimic/test/test_session.py
+++ b/mimic/test/test_session.py
@@ -73,7 +73,7 @@ class SessionCreationTests(SynchronousTestCase):
         for the API key.
         """
         sessions = SessionStore(Clock())
-        (a, z) = sessions.session_for_token("testtoken")
+        a = sessions.session_for_token("testtoken")
         b = sessions.session_for_username_password(a.username, "testpswd")
         c = sessions.session_for_api_key(a.username, "testapikey")
         self.assertIdentical(a, b)
@@ -104,10 +104,10 @@ class SessionCreationTests(SynchronousTestCase):
         sessions = SessionStore(Clock())
         a = sessions.session_for_username_password("username",
                                                    "testpswd")
-        (b, z) = sessions.session_for_token(a.token)
+        b = sessions.session_for_token(a.token)
         self.assertIdentical(a, b)
         c = sessions.session_for_api_key("apiuser", "testkey")
-        (d, y) = sessions.session_for_token(c.token)
+        d = sessions.session_for_token(c.token)
         self.assertIdentical(c, d)
 
     def test_by_token_after_username_wrong_tenant(self):
@@ -138,7 +138,7 @@ class SessionCreationTests(SynchronousTestCase):
         a = sessions.session_for_impersonation("pretender", A_LOT)
         a_prime = sessions.session_for_impersonation("pretender", A_LOT)
         self.assertIdentical(a, a_prime)
-        (b, z) = sessions.session_for_token(a.token)
+        b = sessions.session_for_token(a.token)
         self.assertEqual(
             a.expires, datetime.utcfromtimestamp(A_LITTLE + A_LOT))
         self.assertIdentical(a, b)
@@ -212,7 +212,7 @@ class SessionCreationTests(SynchronousTestCase):
             sessions.session_for_username_password("someuser1", "testpass"),
             sessions.session_for_impersonation("someuser2", 12),
             sessions.session_for_api_key("someuser3", "someapikey"),
-            sessions.session_for_token("sometoken")[0],
+            sessions.session_for_token("sometoken"),
         ]
         integer = re.compile('^\d+$')
         for session in sessions:
@@ -237,7 +237,7 @@ class SessionCreationTests(SynchronousTestCase):
                                                    "tenant1"),
             sessions.session_for_api_key("user2", "apikey",
                                          tenant_id="tenant2"),
-            sessions.session_for_token("token", tenant_id="tenant3")[0],
+            sessions.session_for_token("token", tenant_id="tenant3"),
             sessions.session_for_tenant_id("tenant4")
         ]
         for i, session in enumerate(sessions):


### PR DESCRIPTION
Includes the Identity admin api call that validates the token. For the purposes of the ele testing, such a validation always passes and also creates a new session for the given tenant_id and token_id. 