### PR TITLE
Fix osx pypy on travis

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -29,8 +29,9 @@ if [[ "$DARWIN" = true ]]; then
             pyenv global 2.7.8
             ;;
         pypy)
-	    # travis/tox are not finding pypy when installed using pyenv.
-            brew install pypy
+            brew upgrade pyenv
+            pyenv install pypy-2.5.0
+            pyenv global pypy-2.5.0
             ;;
         docs)
             curl -O https://bootstrap.pypa.io/get-pip.py

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -3,5 +3,9 @@
 set -e
 set -x
 
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    eval "$(pyenv init -)"
+fi
+
 source ~/.venv/bin/activate
 tox -e $TOX_ENV -- $TOX_FLAGS


### PR DESCRIPTION
Use pyenv instead of brew to install pypy. The reason pyenv's pypy was not working is that pyenv wasn't being reinitialized in the run.sh.