### PR TITLE
initial error injection for nova

### DIFF
--- a/mimic/model/nova_behaviors.py
+++ b/mimic/model/nova_behaviors.py
@@ -97,14 +97,6 @@ def regexp_predicate(value):
     return re.compile(value).match
 
 
-def tenant_id_criterion(value):
-    """
-    Return a Criterion which matches the given regular expression string
-    against the ``"tenant_id"`` attribute.
-    """
-    return Criterion(name='tenant_id', predicate=regexp_predicate(value))
-
-
 def server_name_criterion(value):
     """
     Return a Criterion which matches the given regular expression string

--- a/mimic/model/nova_behaviors.py
+++ b/mimic/model/nova_behaviors.py
@@ -35,7 +35,7 @@ class BehaviorLookup(object):
 
 server_creation = BehaviorLookup()
 
-@server_creation.behavior("fail")
+@server_creation.behavior_creator("fail")
 def create_fail_behavior(parameters):
     """
     Create a failing behavior for server creation.

--- a/mimic/model/nova_behaviors.py
+++ b/mimic/model/nova_behaviors.py
@@ -55,25 +55,6 @@ def create_fail_behavior(parameters):
     return fail_without_creating
 
 
-"""
-POST /mimicking/...nova-behavior.../...your-tenant.../behaviors/creation/
-
-{
-    "criteria": [
-        {"tenant_id": "maybe_fail_.*"},
-        {"server_name": "failing_server_.*"},
-        {"metadata": {"key_we_should_have": "fail",
-                      "key_we_should_not_have": null}}
-    ],
-    "name": "fail",
-    "parameters": {
-        "code": 404,
-        "message": "Stuff is broken, what"
-    }
-}
-"""
-
-
 @attributes(['name', 'predicate'])
 class Criterion(object):
     """

--- a/mimic/model/nova_behaviors.py
+++ b/mimic/model/nova_behaviors.py
@@ -22,15 +22,15 @@ class BehaviorLookup(object):
             return thunk
         return decorator
 
-    def create_behavior(self, name, params):
+    def create_behavior(self, name, parameters):
         """
         Create behavior identified by the given name, with the given
         parameters.  This is used during the process of registering a behavior.
 
-        :param params: An object (deserialized from JSON) which serves as
+        :param parameters: An object (deserialized from JSON) which serves as
             parameters to the named behavior creator.
         """
-        return self.behaviors[name](params)
+        return self.behaviors[name](parameters)
 
 
 server_creation = BehaviorLookup()

--- a/mimic/model/nova_behaviors.py
+++ b/mimic/model/nova_behaviors.py
@@ -76,23 +76,26 @@ POST /mimicking/...nova-behavior.../...your-tenant.../behaviors/creation/
 
 @attributes(['name', 'predicate'])
 class Criterion(object):
-
     """
-
+    A criterion evaluates a predicate (callable object returning boolean)
+    against an attribute with the given name.
     """
 
     def evaluate(self, attributes):
         """
-
+        Extract the attribute with this Criterion's name from ``attributes``
+        and evaluate it against this Criterion's predicate, returning True if
+        it matches and False otherwise.
         """
         return self.predicate(attributes[self.name])
 
 
 @attributes(['criteria'])
 class CriteriaCollection(object):
-
     """
-
+    A CriteriaCollection is a collection of Criterion which implements the same
+    interface (``evaluate(attributes)``) by evaluating each of the Criterion
+    objects it comprises and returning True if they all match.
     """
 
     def evaluate(self, attributes):
@@ -107,28 +110,33 @@ class CriteriaCollection(object):
 
 def regexp_predicate(value):
     """
-
+    Return a predicate for use with a Criterion which matches a given regular
+    expression.
     """
     return re.compile(value).match
 
 
 def tenant_id_criterion(value):
     """
-
+    Return a Criterion which matches the given regular expression string
+    against the ``"tenant_id"`` attribute.
     """
     return Criterion(name='tenant_id', predicate=regexp_predicate(value))
 
 
 def server_name_criterion(value):
     """
-
+    Return a Criterion which matches the given regular expression string
+    against the ``"server_name"`` attribute.
     """
     return Criterion(name='server_name', predicate=regexp_predicate(value))
 
 
 def metadata_criterion(value):
     """
+    Return a Criterion which matches against metadata.
 
+    :param value: ??? (FIXME this is the wrong shape)
     """
     name = value['name']
     value_predicate = regexp_predicate(value['value'])

--- a/mimic/model/nova_behaviors.py
+++ b/mimic/model/nova_behaviors.py
@@ -47,3 +47,23 @@ def create_fail_behavior(parameters):
         http.setResponseCode(status_code)
         return dumps(invalid_resource(failure_message, status_code))
     return fail_without_creating
+
+
+
+"""
+POST /mimicking/...nova-behavior.../...your-tenant.../behaviors/creation/
+
+{
+    "criteria": [
+        {"tenant_id": "maybe_fail_.*"},
+        {"server_name": "failing_server_.*"},
+        {"metadata_field": {"name": "should", "value": "fail"}},
+        {"metadata_field": {"name": "yes", "value": "definitely"}},
+    ],
+    "name": "fail",
+    "parameters": {
+        "code": 404,
+        "message": "Stuff is broken, what"
+    }
+}
+"""

--- a/mimic/model/nova_behaviors.py
+++ b/mimic/model/nova_behaviors.py
@@ -1,0 +1,49 @@
+"""
+Custom behaviors for the nova mimic.
+"""
+from json import dumps
+from characteristic import attributes, Attribute
+from mimic.util.helper import invalid_resource
+
+@attributes([Attribute("behaviors", default_factory=dict)])
+class BehaviorLookup(object):
+    """
+    A collection of behaviors with a related schema.
+    """
+
+    def behavior_creator(self, name):
+        """
+        Decorator which declares the decorated function is a behavior for this
+        table.
+        """
+        def decorator(thunk):
+            thunk.behavior_name = name
+            self.behaviors[name] = thunk
+            return thunk
+        return decorator
+
+    def create_behavior(self, name, params):
+        """
+        Create behavior identified by the given name, with the given
+        parameters.  This is used during the process of registering a behavior.
+
+        :param params: An object (deserialized from JSON) which serves as
+            parameters to the named behavior creator.
+        """
+        return self.behaviors[name](params)
+
+
+server_creation = BehaviorLookup()
+
+@server_creation.behavior("fail")
+def create_fail_behavior(parameters):
+    """
+    Create a failing behavior for server creation.
+    """
+    status_code = parameters.get("code", 500)
+    failure_message = parameters.get("message", "Server creation failed.")
+    def fail_without_creating(collection, http, json, absolutize_url):
+        # behavior for failing to even start to build
+        http.setResponseCode(status_code)
+        return dumps(invalid_resource(failure_message, status_code))
+    return fail_without_creating

--- a/mimic/model/nova_behaviors.py
+++ b/mimic/model/nova_behaviors.py
@@ -111,15 +111,14 @@ def metadata_criterion(value):
 
     :param value: ??? (FIXME this is the wrong shape)
     """
-    name = value['name']
-    value_predicate = regexp_predicate(value['value'])
-
-    def predicate(metadata):
-        return value_predicate(metadata.get(name))
+    def predicate(attribute):
+        for k, v in value.items():
+            if not re.compile(v).match(attribute.get(k, "")):
+                return False
+        return True
     return Criterion(name='metadata', predicate=predicate)
 
 nova_criterion_factories = {
-    "tenant_id": tenant_id_criterion,
     "server_name": server_name_criterion,
     "metadata": metadata_criterion
 }

--- a/mimic/model/nova_objects.py
+++ b/mimic/model/nova_objects.py
@@ -287,7 +287,9 @@ def metadata_to_creation_behavior(metadata):
 
 
 @attributes(["tenant_id", "region_name", "clock",
-             Attribute("servers", default_factory=list)])
+             Attribute("servers", default_factory=list),
+             Attribute("creation_behaviors_and_criteria",
+                       default_factory=list)])
 class RegionalServerCollection(object):
     """
     A collection of servers, in a given region, for a given tenant.

--- a/mimic/model/nova_objects.py
+++ b/mimic/model/nova_objects.py
@@ -317,6 +317,14 @@ class RegionalServerCollection(object):
         request to inject an error in advance, based on whether it matches the
         parameters in the given creation JSON and HTTP request properties.
         """
+        creation_attributes = {
+            "tenant_id": self.tenant_id,
+            "server_name": creation_json["server"]["name"],
+            "metadata": creation_json["server"].get("metadata")
+        }
+        for behavior, criteria in self.creation_behaviors_and_criteria:
+            if criteria.evaluate(creation_attributes):
+                return behavior
         return None
 
     def request_creation(self, creation_http_request, creation_json,

--- a/mimic/model/nova_objects.py
+++ b/mimic/model/nova_objects.py
@@ -303,6 +303,13 @@ class RegionalServerCollection(object):
             if server.server_id == server_id:
                 return server
 
+    def register_creation_behavior_for_criteria(self, behavior, criteria):
+        """
+        Register the given behavior for server creation based on the given
+        criteria.
+        """
+        self.creation_behaviors_and_criteria.append((behavior, criteria))
+
     def registered_creation_behavior(self, creation_http_request,
                                      creation_json):
         """

--- a/mimic/rest/nova_api.py
+++ b/mimic/rest/nova_api.py
@@ -65,6 +65,24 @@ class NovaApi(object):
         return (NovaRegion(self, uri_prefix, session_store, region)
                 .app.resource())
 
+    def _get_session(self, session_store, tenant_id):
+        """
+        Retrieve or create a new Nova session from a given tenant identifier
+        and :obj:`SessionStore`.
+
+        For use with ``data_for_api``.
+
+        Temporary hack; see this issue
+        https://github.com/rackerlabs/mimic/issues/158
+        """
+        return (
+            session_store.session_for_tenant_id(tenant_id)
+            .data_for_api(self, lambda: GlobalServerCollections(
+                tenant_id=tenant_id,
+                clock=session_store.clock
+            ))
+        )
+
 
 @implementer(IAPIMock, IPlugin)
 @attributes(["nova_api"])

--- a/mimic/rest/nova_api.py
+++ b/mimic/rest/nova_api.py
@@ -163,17 +163,8 @@ class NovaRegion(object):
         Get the given server-cache object for the given tenant, creating one if
         there isn't one.
         """
-        return (
-            self._session_store.session_for_tenant_id(tenant_id)
-            .data_for_api(
-                self._api_mock,
-                lambda: GlobalServerCollections(
-                    tenant_id=tenant_id,
-                    clock=self._session_store.clock
-                )
-            )
-            .collection_for_region(self._name)
-        )
+        return (self._api_mock._get_session(self._session_store, tenant_id)
+                .collection_for_region(self._name))
 
     app = MimicApp()
 

--- a/mimic/test/fixtures.py
+++ b/mimic/test/fixtures.py
@@ -83,4 +83,6 @@ class APIMockHelper(object):
         self.nth_endpoint_public = self.auth.nth_endpoint_public
         self.get_service_endpoint = self.auth.get_service_endpoint
 
-        self.uri = self.nth_endpoint_public(0)
+        tenant_id = self.auth.service_catalog_json["access"]["token"]["tenant"]["id"]
+        service_name = apis[0].catalog_entries(tenant_id)[0].name
+        self.uri = self.get_service_endpoint(service_name)

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -331,8 +331,9 @@ class NovaAPINegativeTests(SynchronousTestCase):
         Create a :obj:`MimicCore` with :obj:`NovaApi` as the only plugin,
         and create a server
         """
-        helper = APIMockHelper(self, [NovaApi(["ORD", "MIMIC"]),
-            NovaControlApi(NovaApi)])
+        nova_api = NovaApi(["ORD", "MIMIC"])
+        nova_control_api = NovaControlApi(nova_api=nova_api)
+        helper = APIMockHelper(self, [nova_api, nova_control_api])
         self.nova_control_endpoint = helper.auth.get_service_endpoint(
             "cloudServersBehavior",
             "ORD")
@@ -553,8 +554,7 @@ class NovaAPINegativeTests(SynchronousTestCase):
                      "criteria": [{"server_name": "failing_server_name"}]}
         set_criteria = request(self, self.root, "POST", self.nova_control_endpoint,
             json.dumps(criterion))
-        set_criteria_response = self.successResultOf(
-            treq.json_content(set_criteria))
+        set_criteria_response = self.successResultOf(set_criteria)
         self.assertEqual(set_criteria_response.code, 201)
         create_server_response = self.create_server(name="failing_server_name")
         self.assertEquals(create_server_response.code, 500)

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -549,11 +549,13 @@ class NovaAPINegativeTests(SynchronousTestCase):
         and response code when the criteria is registered.
         """
         serverfail = {"message": "Create server failure", "code": 500}
-        criterion = {"name": "create_server_failure",
+        criterion = {"name": "fail",
                      "parameters": serverfail,
                      "criteria": [{"server_name": "failing_server_name"}]}
-        set_criteria = request(self, self.root, "POST", self.nova_control_endpoint,
-            json.dumps(criterion))
+        set_criteria = request(self, self.root, "POST",
+                               self.nova_control_endpoint +
+                               "/behaviors/creation/",
+                               json.dumps(criterion))
         set_criteria_response = self.successResultOf(set_criteria)
         self.assertEqual(set_criteria_response.code, 201)
         create_server_response = self.create_server(name="failing_server_name")

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -5,11 +5,12 @@ import treq
 from twisted.trial.unittest import SynchronousTestCase
 
 from mimic.test.helpers import json_request, request, validate_link_json
-from mimic.rest.nova_api import NovaApi
+from mimic.rest.nova_api import NovaApi, NovaControlApi
 from mimic.test.fixtures import APIMockHelper, TenantAuthentication
 
 
 class NovaAPITests(SynchronousTestCase):
+
     """
     Tests for the Nova Api plugin.
     """
@@ -92,7 +93,8 @@ class NovaAPITests(SynchronousTestCase):
         Test to verify :func:`list_servers` on ``GET /v2.0/<tenant_id>/servers?name<name>``,
         when a server with that name exists
         """
-        list_servers = request(self, self.root, "GET", self.uri + '/servers?name=' + self.server_name)
+        list_servers = request(
+            self, self.root, "GET", self.uri + '/servers?name=' + self.server_name)
         list_servers_response = self.successResultOf(list_servers)
         list_servers_response_body = self.successResultOf(
             treq.json_content(list_servers_response))
@@ -106,7 +108,8 @@ class NovaAPITests(SynchronousTestCase):
         Test to verify :func:`list_servers` on ``GET /v2.0/<tenant_id>/servers?name<name>``
         when a server with that name does not exist
         """
-        list_servers = request(self, self.root, "GET", self.uri + '/servers?name=no_server')
+        list_servers = request(
+            self, self.root, "GET", self.uri + '/servers?name=no_server')
         list_servers_response = self.successResultOf(list_servers)
         list_servers_response_body = self.successResultOf(
             treq.json_content(list_servers_response))
@@ -118,7 +121,8 @@ class NovaAPITests(SynchronousTestCase):
         Test to verify :func:`get_server` on ``GET /v2.0/<tenant_id>/servers/<server_id>``,
         when the server_id exists
         """
-        get_server = request(self, self.root, "GET", self.uri + '/servers/' + self.server_id)
+        get_server = request(
+            self, self.root, "GET", self.uri + '/servers/' + self.server_id)
         get_server_response = self.successResultOf(get_server)
         get_server_response_body = self.successResultOf(
             treq.json_content(get_server_response))
@@ -134,7 +138,8 @@ class NovaAPITests(SynchronousTestCase):
         Test to verify :func:`get_server` on ``GET /v2.0/<tenant_id>/servers/<server_id>``,
         when the server_id does not exist
         """
-        get_server = request(self, self.root, "GET", self.uri + '/servers/test-server-id')
+        get_server = request(
+            self, self.root, "GET", self.uri + '/servers/test-server-id')
         get_server_response = self.successResultOf(get_server)
         self.assertEqual(get_server_response.code, 404)
 
@@ -142,15 +147,18 @@ class NovaAPITests(SynchronousTestCase):
         """
         Test to verify :func:`list_servers_with_details` on ``GET /v2.0/<tenant_id>/servers/detail``
         """
-        list_servers_detail = request(self, self.root, "GET", self.uri + '/servers/detail')
-        list_servers_detail_response = self.successResultOf(list_servers_detail)
+        list_servers_detail = request(
+            self, self.root, "GET", self.uri + '/servers/detail')
+        list_servers_detail_response = self.successResultOf(
+            list_servers_detail)
         list_servers_detail_response_body = self.successResultOf(
             treq.json_content(list_servers_detail_response))
         self.assertEqual(list_servers_detail_response.code, 200)
         self.assertEqual(list_servers_detail_response_body['servers'][0]['id'],
                          self.server_id)
         self.assertEqual(len(list_servers_detail_response_body['servers']), 1)
-        self.assertEqual(list_servers_detail_response_body['servers'][0]['status'], 'ACTIVE')
+        self.assertEqual(
+            list_servers_detail_response_body['servers'][0]['status'], 'ACTIVE')
 
         self.validate_server_detail_json(
             list_servers_detail_response_body['servers'][0])
@@ -198,7 +206,8 @@ class NovaAPITests(SynchronousTestCase):
         """
         Test to verify :func:`delete_server` on ``DELETE /v2.0/<tenant_id>/servers/<server_id>``
         """
-        delete_server = request(self, self.root, "DELETE", self.uri + '/servers/' + self.server_id)
+        delete_server = request(
+            self, self.root, "DELETE", self.uri + '/servers/' + self.server_id)
         delete_server_response = self.successResultOf(delete_server)
         self.assertEqual(delete_server_response.code, 204)
         self.assertEqual(self.successResultOf(treq.content(delete_server_response)),
@@ -209,7 +218,8 @@ class NovaAPITests(SynchronousTestCase):
         Test to verify :func:`delete_server` on ``DELETE /v2.0/<tenant_id>/servers/<server_id>``,
         when the server_id does not exist
         """
-        delete_server = request(self, self.root, "DELETE", self.uri + '/servers/test-server-id')
+        delete_server = request(
+            self, self.root, "DELETE", self.uri + '/servers/test-server-id')
         delete_server_response = self.successResultOf(delete_server)
         self.assertEqual(delete_server_response.code, 404)
 
@@ -217,33 +227,40 @@ class NovaAPITests(SynchronousTestCase):
         """
         Test to verify :func:`get_image` on ``GET /v2.0/<tenant_id>/images/<image_id>``
         """
-        get_server_image = request(self, self.root, "GET", self.uri + '/images/test-image-id')
+        get_server_image = request(
+            self, self.root, "GET", self.uri + '/images/test-image-id')
         get_server_image_response = self.successResultOf(get_server_image)
         get_server_image_response_body = self.successResultOf(
             treq.json_content(get_server_image_response))
         self.assertEqual(get_server_image_response.code, 200)
-        self.assertEqual(get_server_image_response_body['image']['id'], 'test-image-id')
-        self.assertEqual(get_server_image_response_body['image']['status'], 'ACTIVE')
+        self.assertEqual(
+            get_server_image_response_body['image']['id'], 'test-image-id')
+        self.assertEqual(
+            get_server_image_response_body['image']['status'], 'ACTIVE')
 
     def test_get_server_flavor(self):
         """
         Test to verify :func:`get_image` on ``GET /v2.0/<tenant_id>/flavors/<flavor_id>``
         """
-        get_server_flavor = request(self, self.root, "GET", self.uri + '/flavors/test-flavor-id')
+        get_server_flavor = request(
+            self, self.root, "GET", self.uri + '/flavors/test-flavor-id')
         get_server_flavor_response = self.successResultOf(get_server_flavor)
         get_server_flavor_response_body = self.successResultOf(
             treq.json_content(get_server_flavor_response))
         self.assertEqual(get_server_flavor_response.code, 200)
-        self.assertEqual(get_server_flavor_response_body['flavor']['id'], 'test-flavor-id')
+        self.assertEqual(
+            get_server_flavor_response_body['flavor']['id'], 'test-flavor-id')
 
     def test_get_server_limits(self):
         """
         Test to verify :func:`get_limit` on ``GET /v2.0/<tenant_id>/limits``
         """
-        get_server_limits = request(self, self.root, "GET", self.uri + '/limits')
+        get_server_limits = request(
+            self, self.root, "GET", self.uri + '/limits')
         get_server_limits_response = self.successResultOf(get_server_limits)
         self.assertEqual(get_server_limits_response.code, 200)
-        self.assertTrue(self.successResultOf(treq.json_content(get_server_limits_response)))
+        self.assertTrue(
+            self.successResultOf(treq.json_content(get_server_limits_response)))
 
     def test_get_server_ips(self):
         """
@@ -255,8 +272,10 @@ class NovaAPITests(SynchronousTestCase):
         get_server_ips_response_body = self.successResultOf(
             treq.json_content(get_server_ips_response))
         self.assertEqual(get_server_ips_response.code, 200)
-        list_servers_detail = request(self, self.root, "GET", self.uri + '/servers/detail')
-        list_servers_detail_response = self.successResultOf(list_servers_detail)
+        list_servers_detail = request(
+            self, self.root, "GET", self.uri + '/servers/detail')
+        list_servers_detail_response = self.successResultOf(
+            list_servers_detail)
         list_servers_detail_response_body = self.successResultOf(
             treq.json_content(list_servers_detail_response))
         self.assertEqual(get_server_ips_response_body['addresses'],
@@ -312,7 +331,11 @@ class NovaAPINegativeTests(SynchronousTestCase):
         Create a :obj:`MimicCore` with :obj:`NovaApi` as the only plugin,
         and create a server
         """
-        helper = APIMockHelper(self, [NovaApi(["ORD", "MIMIC"])])
+        helper = APIMockHelper(self, [NovaApi(["ORD", "MIMIC"]),
+            NovaControlApi(NovaApi)])
+        self.nova_control_endpoint = helper.auth.get_service_endpoint(
+            "cloudServersBehavior",
+            "ORD")
         self.root = helper.root
         self.uri = helper.uri
         self.helper = helper
@@ -420,9 +443,11 @@ class NovaAPINegativeTests(SynchronousTestCase):
         get_server_response = self.successResultOf(get_server)
         get_server_response_body = self.successResultOf(
             treq.json_content(get_server_response))
-        self.assertEquals(get_server_response_body['server']['status'], "BUILD")
+        self.assertEquals(
+            get_server_response_body['server']['status'], "BUILD")
         # List servers with details and verify the server is in BUILD status
-        list_servers = request(self, self.root, "GET", self.uri + '/servers/detail')
+        list_servers = request(
+            self, self.root, "GET", self.uri + '/servers/detail')
         list_servers_response = self.successResultOf(list_servers)
         self.assertEquals(list_servers_response.code, 200)
         list_servers_response_body = self.successResultOf(
@@ -438,7 +463,8 @@ class NovaAPINegativeTests(SynchronousTestCase):
         get_server_response = self.successResultOf(get_server)
         get_server_response_body = self.successResultOf(
             treq.json_content(get_server_response))
-        self.assertEquals(get_server_response_body['server']['status'], "ACTIVE")
+        self.assertEquals(
+            get_server_response_body['server']['status'], "ACTIVE")
 
     def test_server_in_error_state(self):
         """
@@ -457,7 +483,8 @@ class NovaAPINegativeTests(SynchronousTestCase):
         get_server_response = self.successResultOf(get_server)
         get_server_response_body = self.successResultOf(
             treq.json_content(get_server_response))
-        self.assertEquals(get_server_response_body['server']['status'], "ERROR")
+        self.assertEquals(
+            get_server_response_body['server']['status'], "ERROR")
 
     def test_delete_server_fails_specified_number_of_times(self):
         """
@@ -514,3 +541,25 @@ class NovaAPINegativeTests(SynchronousTestCase):
                                     '/flavors/1')
         get_server_flavor_response = self.successResultOf(get_server_flavor)
         self.assertEqual(get_server_flavor_response.code, 404)
+
+    def test_create_server_failure_using_behaviors(self):
+        """
+        Test to verify :func:`create_server` fails with given error message
+        and response code when the criteria is registered.
+        """
+        serverfail = {"message": "Create server failure", "code": 500}
+        criterion = {"name": "create_server_failure",
+                     "parameters": serverfail,
+                     "criteria": [{"server_name": "failing_server_name"}]}
+        set_criteria = request(self, self.root, "POST", self.nova_control_endpoint,
+            json.dumps(criterion))
+        set_criteria_response = self.successResultOf(
+            treq.json_content(set_criteria))
+        self.assertEqual(set_criteria_response.code, 201)
+        create_server_response = self.create_server(name="failing_server_name")
+        self.assertEquals(create_server_response.code, 500)
+        create_server_response_body = self.successResultOf(
+            treq.json_content(create_server_response))
+        self.assertEquals(create_server_response_body['message'],
+                          "Create server failure")
+        self.assertEquals(create_server_response_body['code'], 500)

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -545,8 +545,8 @@ class NovaAPINegativeTests(SynchronousTestCase):
 
     def test_create_server_failure_using_behaviors(self):
         """
-        Test to verify :func:`create_server` fails with given error message
-        and response code when the criteria is registered.
+        :func:`create_server` fails with given error message and response code
+        when a behavior is registered that matches its hostname.
         """
         serverfail = {"message": "Create server failure", "code": 500}
         criterion = {"name": "fail",


### PR DESCRIPTION
This establishes a general-purpose URI hierarchy for manipulating behaviors, and a single implementation of one behavior - "fail to create server" - which can be registered ahead of time instead of using metadata.

We will need follow-on work to refactor this to be more general, but this should be good enough to get started with.