### PR TITLE
retry builds on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - travis_retry ./.travis/install.sh
 
 script:
-  - ./.travis/run.sh
+  - travis_retry ./.travis/run.sh
 
 after_success:
   - source ~/.venv/bin/activate && coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
       compiler: clang
 
 install:
-  - ./.travis/install.sh
+  - travis_retry ./.travis/install.sh
 
 script:
   - ./.travis/run.sh


### PR DESCRIPTION
use travis's ```retry_build``` command. It is meant to try to rerun a step a maximum of three times if any error condition in the step is met.

The functionality is detailed here: http://docs.travis-ci.com/user/build-timeouts/