### PR TITLE
Pin development dependencies

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,20 @@
+cffi==0.8.6
+coverage==3.7.1
+cryptography==0.7.2
 doc8==0.3.4
+docutils==0.12
+enum34==1.0.4
 flake8==2.1.0
+Jinja2==2.7.3
+MarkupSafe==0.23
+pbr==0.10.7
+mccabe==0.3
 pep257==0.3.2
+pep8==1.6.2
 coverage==3.7.1
 unittest2==0.5.1
 Sphinx==1.2.2
+stevedore==1.2.0
+treq==15.0.0
+unittest2==0.5.1
 -e .

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py26, py27, pypy, docs, lint
 
 [testenv]
 deps =
-    coverage
+    coverage==3.7.1
 commands =
     coverage erase
     coverage run {envbindir}/trial --rterrors {posargs:mimic}
@@ -17,9 +17,18 @@ commands =
 
 [testenv:docs]
 deps =
-    doc8
-    sphinx
-    sphinx_rtd_theme
+     chardet==2.3.0
+     doc8==0.5.0
+     docutils==0.12
+     Jinja2==2.7.3
+     MarkupSafe==0.23
+     pbr==0.10.7
+     Pygments==2.0.2
+     restructuredtext-lint==0.10.0
+     six==1.9.0
+     Sphinx==1.2.3
+     sphinx-rtd-theme==0.1.6
+     stevedore==1.2.0
 basepython = python2.7
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
@@ -30,8 +39,8 @@ commands =
 [testenv:docs-spellcheck]
 deps =
     {[testenv:docs]deps}
-    pyenchant
-    sphinxcontrib-spelling
+    pyenchant==1.6.6
+    sphinxcontrib-spelling==2.1.1
 basepython = python2.7
 commands =
     sphinx-build -W -b spelling docs docs/_build/html
@@ -45,9 +54,11 @@ commands =
 
 [testenv:lint]
 deps =
-    flake8
-    #flake8-import-order
-    pep257
+    flake8==2.3.0
+    mccabe==0.3
+    pep257==0.4.1
+    pep8==1.6.2
+    pyflakes==0.8.1
 commands =
     flake8 ./twisted ./mimic
     pep257 --ignore=D400,D401,D200,D203,D204,D205 ./mimic ./twisted

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,7 @@ deps =
     pep8==1.6.2
     pyflakes==0.8.1
 commands =
-    flake8 ./twisted ./mimic
+    flake8 --ignore=W503 ./twisted ./mimic
     pep257 --ignore=D400,D401,D200,D203,D204,D205 ./mimic ./twisted
 
 [flake8]


### PR DESCRIPTION
We just started failing builds due to a new release of pep8. Deal with that release and ignore the warning it introduced, and lock all transitive dependencies in tox and dev-requirements.txt to avoid this kind of surprise failure in the future.