### PR TITLE
Remove duplicate dependencies from dev-requirements.txt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,7 +11,6 @@ pbr==0.10.7
 mccabe==0.3
 pep257==0.3.2
 pep8==1.6.2
-coverage==3.7.1
 unittest2==0.5.1
 Sphinx==1.2.2
 stevedore==1.2.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,5 +15,4 @@ unittest2==0.5.1
 Sphinx==1.2.2
 stevedore==1.2.0
 treq==15.0.0
-unittest2==0.5.1
 -e .


### PR DESCRIPTION
Clean virtualenv:

```
~/P/r/mimic: pip install -r dev-requirements.txt                                                                                                                                                    14:08:42
Double requirement given: coverage==3.7.1 (from -r dev-requirements.txt (line 14)) (already in coverage==3.7.1 (from -r dev-requirements.txt (line 2)), name='coverage')
```

So I fixed that, and then I got:

```
~/P/r/mimic: pip install -r dev-requirements.txt                                                                                                                                                    14:09:38
Double requirement given: unittest2==0.5.1 (from -r dev-requirements.txt (line 18)) (already in unittest2==0.5.1 (from -r dev-requirements.txt (line 14)), name='unittest2')
```

So I fixed that, and then `pip install -r dev-requirements.txt` worked.

`pip install -r requirements.txt` just works, although I noticed it uses ancient versions of treq and Twisted.

Maybe in the future it would be good to do pip install as part of CI?