### PR TITLE
RFR: add .coverage and _trial_temp to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
 *.project
 *.pydev*
+.coverage
 .DS_Store
 *.pyc
 dropin.cache
 twistd.pid
 docs/_build
 _tmp
+_trial_temp
 .tox
 *.egg-info


### PR DESCRIPTION
These files are automatically generated by the build and cause the git
state to appear dirty. We should explicitly ignore them.