### PR TITLE
add nodes returns 202, not 200

### DIFF
--- a/mimic/canned_responses/loadbalancer.py
+++ b/mimic/canned_responses/loadbalancer.py
@@ -192,7 +192,7 @@ def add_node(store, node_list, lb_id, current_timestamp):
             store.lbs[lb_id]["nodeCount"] = len(store.lbs[lb_id]["nodes"])
             _verify_and_update_lb_state(store, lb_id,
                                         current_timestamp=current_timestamp)
-        return {"nodes": nodes}, 200
+        return {"nodes": nodes}, 202
 
     return not_found_response("loadbalancer"), 404
 

--- a/mimic/test/test_loadbalancer.py
+++ b/mimic/test/test_loadbalancer.py
@@ -342,7 +342,7 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
         """
         Test to verify :func: `add_node` create a node successfully.
         """
-        self.assertEqual(self.create_node_response.code, 200)
+        self.assertEqual(self.create_node_response.code, 202)
         self.assertEqual(len(self.create_node_response_body["nodes"]), 1)
         # verify that the node has all the attributes
         node1 = self.create_node_response_body["nodes"][0]
@@ -373,7 +373,7 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
         create_node_response = self.successResultOf(create_multiple_nodes)
         create_node_response_body = self.successResultOf(treq.json_content(
                                                          create_node_response))
-        self.assertEqual(create_node_response.code, 200)
+        self.assertEqual(create_node_response.code, 202)
         self.assertEqual(len(create_node_response_body["nodes"]), 2)
 
     def test_add_duplicate_node(self):
@@ -613,7 +613,7 @@ class LoadbalancerAPINegativeTests(SynchronousTestCase):
         lb = create_lb_response_body["loadBalancer"]
         self.assertEqual(lb["status"], "ACTIVE")
         create_node_response = self._add_node_to_lb(lb["id"])
-        self.assertEqual(create_node_response.code, 200)
+        self.assertEqual(create_node_response.code, 202)
         # get loadbalncer after adding node and verify its in error state
         errored_lb = self._get_loadbalancer(lb["id"])
         self.assertEqual(errored_lb["loadBalancer"]["status"], "ERROR")
@@ -641,7 +641,7 @@ class LoadbalancerAPINegativeTests(SynchronousTestCase):
         lb = create_lb_response_body["loadBalancer"]
         self.assertEqual(lb["status"], "ACTIVE")
         create_node_response = self._add_node_to_lb(lb["id"])
-        self.assertEqual(create_node_response.code, 200)
+        self.assertEqual(create_node_response.code, 202)
         # get loadbalncer after adding node and verify its in PENDING-UPDATE state
         errored_lb = self._get_loadbalancer(lb["id"])
         self.assertEqual(errored_lb["loadBalancer"]["status"], "PENDING-UPDATE")
@@ -670,7 +670,7 @@ class LoadbalancerAPINegativeTests(SynchronousTestCase):
         lb = create_lb_response_body["loadBalancer"]
         self.assertEqual(lb["status"], "ACTIVE")
         create_node_response = self._add_node_to_lb(lb["id"])
-        self.assertEqual(create_node_response.code, 200)
+        self.assertEqual(create_node_response.code, 202)
         # get loadbalncer after adding node and verify its in PENDING-UPDATE state
         errored_lb = self._get_loadbalancer(lb["id"])
         self.assertEqual(errored_lb["loadBalancer"]["status"], "PENDING-UPDATE")


### PR DESCRIPTION
In production I've only seen CLB returning 202 from the add nodes call, not 200. It seems that at some point in time the documentation was erroneously describing a response of 200, but it was corrected to 202. 

http://docs.rackspace.com/loadbalancers/api/v1.0/clb-devguide/content/POST_createLoadBalancer_v1.0__account__loadbalancers_load-balancers.html#comment-1677370185