### PR TITLE
Make delete LB return actually empty responses, not `""`

### DIFF
--- a/mimic/canned_responses/loadbalancer.py
+++ b/mimic/canned_responses/loadbalancer.py
@@ -5,7 +5,8 @@ add/get/delete/list nodes
 """
 from random import randrange
 from copy import deepcopy
-from mimic.util.helper import (not_found_response, invalid_resource,
+from mimic.util.helper import (EMPTY_RESPONSE,
+                               not_found_response, invalid_resource,
                                set_resource_status, seconds_to_timestamp)
 from twisted.python import log
 
@@ -126,10 +127,10 @@ def del_load_balancer(store, lb_id, current_timestamp):
                 store.lbs[lb_id]["status"] == "ERROR",
                 store.lbs[lb_id]["status"] == "PENDING-UPDATE"]):
             del store.lbs[lb_id]
-            return b'', 202
+            return EMPTY_RESPONSE, 202
 
         if store.lbs[lb_id]["status"] == "PENDING-DELETE":
-            return b'', 202
+            return EMPTY_RESPONSE, 202
 
         if store.lbs[lb_id]["status"] == "DELETED":
             _verify_and_update_lb_state(store, lb_id,

--- a/mimic/rest/loadbalancer_api.py
+++ b/mimic/rest/loadbalancer_api.py
@@ -18,7 +18,7 @@ from mimic.imimic import IAPIMock
 from mimic.catalog import Entry
 from mimic.catalog import Endpoint
 from random import randrange
-from mimic.util.helper import invalid_resource
+from mimic.util.helper import invalid_resource, json_dump
 
 
 Request.defaultContentType = 'application/json'
@@ -141,7 +141,7 @@ class LoadBalancerRegion(object):
             lb_id, self._session_store.clock.seconds()
         )
         request.setResponseCode(response_data[1])
-        return json.dumps(response_data[0])
+        return json_dump(response_data[0])
 
     @app.route('/v2/<string:tenant_id>/loadbalancers/<int:lb_id>/nodes', methods=['POST'])
     def add_node_to_load_balancer(self, request, tenant_id, lb_id):

--- a/mimic/util/helper.py
+++ b/mimic/util/helper.py
@@ -8,12 +8,27 @@ Helper methods
 import os
 import string
 from datetime import datetime, timedelta
+import json
 from random import choice, randint
 
 from six import text_type
 
 
 fmt = '%Y-%m-%dT%H:%M:%S.%fZ'
+
+
+EMPTY_RESPONSE = object()
+
+
+def json_dump(o):
+    """
+    Serialize an object to JSON, unless it is :obj:`EMPTY_RESPONSE`, in which
+    case the empty string will be returned.
+    """
+    if o is EMPTY_RESPONSE:
+        return b''
+    else:
+        return json.dumps(o)
 
 
 def random_string(length, selectable=None):


### PR DESCRIPTION
This enables API + backend code to represent truly empty responses with an `EMPTY_RESPONSE` constant and a new utility function `json_dump`, which honors `EMPTY_RESPONSE` to return an empty string instead of a json-serialized empty string.

It also makes the delete-LB call use this new facility. There are lots of other cases where it can be used, but this is just a first pass.