### PR TITLE
bulk-delete nodes from CLB

### DIFF
--- a/mimic/canned_responses/loadbalancer.py
+++ b/mimic/canned_responses/loadbalancer.py
@@ -244,6 +244,7 @@ def delete_node(store, lb_id, node_id, current_timestamp):
         _verify_and_update_lb_state(store, lb_id, False, current_timestamp)
 
         if store.lbs[lb_id]["status"] != "ACTIVE":
+            # Error message verified as of 2015-04-22
             resource = invalid_resource(
                 "Load Balancer '{0}' has a status of '{1}' and is considered "
                 "immutable.".format(lb_id, store.lbs[lb_id]["status"]), 422)
@@ -276,6 +277,7 @@ def delete_nodes(store, lb_id, node_ids, current_timestamp):
     _verify_and_update_lb_state(store, lb_id, False, current_timestamp)
 
     if store.lbs[lb_id]["status"] != "ACTIVE":
+        # Error message verified as of 2015-04-22
         resp = {"message": "LoadBalancer is not ACTIVE",
                 "code": 422}
         return resp, 422

--- a/mimic/rest/loadbalancer_api.py
+++ b/mimic/rest/loadbalancer_api.py
@@ -12,7 +12,8 @@ from twisted.plugin import IPlugin
 from mimic.canned_responses.loadbalancer import (
     Region_Tenant_CLBs,
     add_load_balancer, del_load_balancer, list_load_balancers,
-    add_node, delete_node, list_nodes, get_load_balancers, get_nodes)
+    add_node, delete_node, delete_nodes, list_nodes, get_load_balancers,
+    get_nodes)
 from mimic.rest.mimicapp import MimicApp
 from mimic.imimic import IAPIMock
 from mimic.catalog import Entry
@@ -187,6 +188,19 @@ class LoadBalancerRegion(object):
         )
         request.setResponseCode(response_data[1])
         return json.dumps(response_data[0])
+
+    @app.route('/v2/<string:tenant_id>/loadbalancers/<int:lb_id>/nodes',
+               methods=['DELETE'])
+    def delete_nodes_from_load_balancer(self, request, tenant_id, lb_id):
+        """
+        Deletes multiple nodes from a LB.
+        """
+        node_ids = map(int, request.args.get('id', []))
+        response_data = delete_nodes(
+            self.session(tenant_id), lb_id, node_ids,
+            self._session_store.clock.seconds())
+        request.setResponseCode(response_data[1])
+        return json_dump(response_data[0])
 
     @app.route('/v2/<string:tenant_id>/loadbalancers/<int:lb_id>/nodes',
                methods=['GET'])

--- a/mimic/test/test_loadbalancer.py
+++ b/mimic/test/test_loadbalancer.py
@@ -523,6 +523,27 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
         delete_node_response = self.successResultOf(delete_nodes)
         self.assertEqual(delete_node_response.code, 202)
 
+    def test_delete_node_on_non_existant_loadbalancer(self):
+        """
+        Test to verify :func: `delete_node` does delete a nodes on a
+        non existant loadbalancer.
+        """
+        delete_nodes = request(
+            self, self.root, "DELETE", self.uri + '/loadbalancers/123' +
+            '/nodes/' + str(self.node[0]["id"]))
+        delete_node_response = self.successResultOf(delete_nodes)
+        self.assertEqual(delete_node_response.code, 404)
+
+    def test_delete_non_existant_node_on_loadbalancer(self):
+        """
+        Test to verify :func: `delete_node` does not delete a non existant node.
+        """
+        delete_nodes = request(
+            self, self.root, "DELETE", self.uri + '/loadbalancers/' +
+            str(self.lb_id) + '/nodes/123')
+        delete_node_response = self.successResultOf(delete_nodes)
+        self.assertEqual(delete_node_response.code, 404)
+
     def test_delete_multiple_nodes_on_loadbalancer(self):
         """
         Test to verify :func: `delete_nodes` deletes the nodes on the loadbalancer.
@@ -604,27 +625,6 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
         # and the one valid node that we tried to delete is still there
         remaining = [node['id'] for node in self._get_nodes(self.lb_id)]
         self.assertEquals(remaining, [self.node[0]['id']])
-
-    def test_delete_node_on_non_existant_loadbalancer(self):
-        """
-        Test to verify :func: `delete_node` does delete a nodes on a
-        non existant loadbalancer.
-        """
-        delete_nodes = request(
-            self, self.root, "DELETE", self.uri + '/loadbalancers/123' +
-            '/nodes/' + str(self.node[0]["id"]))
-        delete_node_response = self.successResultOf(delete_nodes)
-        self.assertEqual(delete_node_response.code, 404)
-
-    def test_delete_non_existant_node_on_loadbalancer(self):
-        """
-        Test to verify :func: `delete_node` does not delete a non existant node.
-        """
-        delete_nodes = request(
-            self, self.root, "DELETE", self.uri + '/loadbalancers/' +
-            str(self.lb_id) + '/nodes/123')
-        delete_node_response = self.successResultOf(delete_nodes)
-        self.assertEqual(delete_node_response.code, 404)
 
 
 class LoadbalancerAPINegativeTests(SynchronousTestCase):

--- a/mimic/test/test_loadbalancer.py
+++ b/mimic/test/test_loadbalancer.py
@@ -606,11 +606,24 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
             {'code': 400,
              'message': "Must supply one or more id's to process this request."})
 
+    def test_bulk_delete_invalid_lb(self):
+        """
+        Bulk-deleting nodes from a non-existent LB returns a 404 and an appropriate
+        message.
+        """
+        lb_id = self.lb_id + 1
+        node_ids_to_delete = [self.node[0]['id']]
+        response, body = _bulk_delete(self, self.root, self.uri, lb_id, node_ids_to_delete)
+        self.assertEqual(response.code, 404)
+        self.assertEqual(
+            body,
+            {'code': 404,
+             'message': "Load balancer not found"})
+
     def test_bulk_delete_nonexistent_nodes(self):
         """
-        When trying to delete multiple nodes from a non-existent LB, if any of
-        the nodes don't exist, no nodes are deleted and a special error result
-        is returned.
+        When trying to delete multiple nodes, if any of the nodes don't exist, no
+        nodes are deleted and a special error result is returned.
         """
         node_ids_to_delete = [self.node[0]['id'], 1000000, 1000001]
         response, body = _bulk_delete(


### PR DESCRIPTION
Fixes #213.

This introduces support for the `DELETE .../loadbalancers/{lb_id}/nodes?id=1&id=2` endpoint for deleting multiple nodes at a time.
