### PR TITLE
Handle nova metadata

### DIFF
--- a/mimic/model/nova_objects.py
+++ b/mimic/model/nova_objects.py
@@ -183,10 +183,6 @@ class Server(object):
         All the response messages have been verified as of 2015-04-23 against
         Rackspace Nova.
         """
-        # When setting metadata, None is special for some reason
-        if metadata is None:
-            raise BadRequestError(nova_message=(
-                "Malformed request body. metadata must be object"))
         if not isinstance(metadata, dict):
             raise BadRequestError(nova_message="Malformed request body")
         if len(metadata) > max_metadata_items:

--- a/mimic/model/nova_objects.py
+++ b/mimic/model/nova_objects.py
@@ -40,7 +40,8 @@ class BadRequestError(Exception):
              "creation_time", "update_time", "public_ips", "private_ips",
              "status", "flavor_ref", "image_ref", "disk_config",
              "admin_password", "creation_request_json",
-             Attribute('max_metadata', instance_of=int, default_value=40)])
+             Attribute('max_metadata_items', instance_of=int,
+                       default_value=40)])
 class Server(object):
     """
     A :obj:`Server` is a representation of all the state associated with a nova
@@ -163,9 +164,10 @@ class Server(object):
         Rackspace Nova.
         """
         if key not in self.metadata:
-            if len(self.metadata) == self.max_metadata:
+            if len(self.metadata) == self.max_metadata_items:
                 raise LimitError(nova_message=(
-                    "Maximum number of metadata items exceeds 40"))
+                    "Maximum number of metadata items exceeds {0}"
+                    .format(self.max_metadata_items)))
 
         if not isinstance(value, string_types):
             raise BadRequestError(nova_message=(
@@ -189,7 +191,8 @@ class Server(object):
             raise BadRequestError(nova_message="Malformed request body")
         if len(metadata) > max_metadata_items:
             raise LimitError(nova_message=(
-                "Maximum number of metadata items exceeds 40"))
+                "Maximum number of metadata items exceeds {0}"
+                .format(max_metadata_items)))
         if not all(isinstance(v, string_types) for v in metadata.values()):
             raise BadRequestError(nova_message=(
                 "Invalid metadata: The input is not a string or unicode"))
@@ -234,6 +237,7 @@ class Server(object):
             disk_config=disk_config,
             status="ACTIVE",
             admin_password=random_string(12),
+            max_metadata_items=max_metadata_items
         )
         collection.servers.append(self)
         return self

--- a/mimic/rest/nova_api.py
+++ b/mimic/rest/nova_api.py
@@ -391,6 +391,12 @@ class ServerMetadata(object):
             request.setResponseCode(400)
             return json.dumps(bad_request("Malformed request body"))
 
+        # When setting metadata, None is special for some reason
+        if content['metadata'] is None:
+            request.setResponseCode(400)
+            return json.dumps(bad_request(
+                "Malformed request body. metadata must be object"))
+
         try:
             Server.validate_metadata(content['metadata'])
         except BadRequestError as e:

--- a/mimic/rest/nova_api.py
+++ b/mimic/rest/nova_api.py
@@ -24,7 +24,7 @@ from mimic.catalog import Entry
 from mimic.catalog import Endpoint
 from mimic.imimic import IAPIMock
 from mimic.model.nova_objects import (
-    GlobalServerCollections, LimitError, Server)
+    BadRequestError, GlobalServerCollections, LimitError, Server)
 from mimic.util.helper import bad_request
 
 Request.defaultContentType = 'application/json'
@@ -216,14 +216,14 @@ class NovaRegion(object):
         try:
             creation = (self._region_collection_for_tenant(tenant_id)
                         .request_creation(request, content, self.url))
-        except ValueError as e:
+        except BadRequestError as e:
             request.setResponseCode(400)
-            return json.dumps(bad_request(e.message))
+            return json.dumps(bad_request(e.nova_message))
         except LimitError as e:
             request.setResponseCode(403)
             return json.dumps({
                 "forbidden": {
-                    "message": e.message,
+                    "message": e.nova_message,
                     "code": 403
                 }
             })
@@ -394,14 +394,14 @@ class ServerMetadata(object):
 
         try:
             Server.validate_metadata(content['metadata'])
-        except ValueError as e:
+        except BadRequestError as e:
             request.setResponseCode(400)
-            return json.dumps(bad_request(e.message))
+            return json.dumps(bad_request(e.nova_message))
         except LimitError as e:
             request.setResponseCode(403)
             return json.dumps({
                 "forbidden": {
-                    "message": e.message,
+                    "message": e.nova_message,
                     "code": 403
                 }
             })
@@ -447,14 +447,14 @@ class ServerMetadata(object):
 
         try:
             self._server.set_metadata_item(key, content['meta'][key])
-        except ValueError as e:
+        except BadRequestError as e:
             request.setResponseCode(400)
-            return json.dumps(bad_request(e.message))
+            return json.dumps(bad_request(e.nova_message))
         except LimitError as e:
             request.setResponseCode(403)
             return json.dumps({
                 "forbidden": {
-                    "message": e.message,
+                    "message": e.nova_message,
                     "code": 403
                 }
             })

--- a/mimic/rest/nova_api.py
+++ b/mimic/rest/nova_api.py
@@ -359,7 +359,6 @@ class ServerMetadata(object):
         """
         return json.dumps({'metadata': self._server.metadata})
 
-
     @app.route('/', methods=['PUT'])
     def set_metadata(self, request):
         """

--- a/mimic/rest/nova_api.py
+++ b/mimic/rest/nova_api.py
@@ -357,7 +357,7 @@ class ServerMetadata(object):
         """
         List all metadata associated with a server.
         """
-        return json.dumps({'metadata': self.server.metadata})
+        return json.dumps({'metadata': self._server.metadata})
 
 
     @app.route('/', methods=['PUT'])

--- a/mimic/rest/nova_api.py
+++ b/mimic/rest/nova_api.py
@@ -432,7 +432,7 @@ class ServerMetadata(object):
             return json.dumps(bad_request("Malformed request body"))
 
         # more than one key is ok, non-"meta" keys are just ignored
-        if 'meta' not in content:
+        if 'meta' not in content or not isinstance(content['meta'], dict):
             request.setResponseCode(400)
             return json.dumps(bad_request("Malformed request body"))
 

--- a/mimic/test/helpers.py
+++ b/mimic/test/helpers.py
@@ -6,6 +6,8 @@ from __future__ import print_function
 
 import json
 
+from six import string_types
+
 from zope.interface import implementer
 
 from twisted.test.proto_helpers import StringTransport, MemoryReactor
@@ -184,7 +186,7 @@ def json_request(testCase, rootResource, method, uri, body=b"",
     Issue a request with a JSON body (if there's a body at all) and return
     synchronously with a tuple of ``(response, JSON response body)``
     """
-    if body != "":
+    if not isinstance(body, string_types):
         body = json.dumps(body)
 
     d = request(testCase, rootResource, method, uri, body, baseURI, headers)

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -856,6 +856,21 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         response, body = self.create_server(None)
         self.assertEqual(response.code, 202)
 
+    def test_get_metadata(self):
+        """
+        Getting metadata gets whatever metadata the server has.
+        """
+        metadata = {'key': 'value', 'key2': 'anothervalue'}
+        response, body = self.successResultOf(json_request(
+            self, self.root, "GET",
+            self.get_server_url(metadata) + '/metadata'))
+        self.assertEqual(response.code, 200)
+        self.assertEqual(body, {'metadata': metadata})
+
+        # double check against server details
+        self.assertEqual(
+            body, {'metadata': self.get_created_server_metadata()})
+
     def test_set_metadata_with_only_metadata_body_succeeds(self):
         """
         When setting metadata with a body that looks like

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -828,8 +828,8 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         should return an HTTP status code of 403 and an error message saying
         there are too many items.
         """
-        metadata = {"key{0}".format(i): "value{0}".format(i)
-                    for i in xrange(100)}
+        metadata = dict(("key{0}".format(i), "value{0}".format(i))
+                        for i in xrange(100))
         self.assert_maximum_metadata(*self.create_server(metadata))
 
     def test_create_server_with_invalid_metadata_values(self):
@@ -845,7 +845,7 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         When ``create_server`` is passed metadata with too many items and
         invalid metadata values, the too many items error takes precedence.
         """
-        metadata = {"key{0}".format(i): [] for i in xrange(100)}
+        metadata = dict(("key{0}".format(i), []) for i in xrange(100))
         self.assert_maximum_metadata(*self.create_server(metadata))
 
     def test_create_server_null_metadata_succeeds(self):
@@ -906,8 +906,8 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         should return an HTTP status code of 403 and an error message saying
         there are too many items.
         """
-        metadata = {"key{0}".format(i): "value{0}".format(i)
-                    for i in xrange(100)}
+        metadata = dict(("key{0}".format(i), "value{0}".format(i))
+                        for i in xrange(100))
         self.assert_maximum_metadata(
             *self.set_metadata({"metadata": metadata}))
 
@@ -925,7 +925,7 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         When ``set_metadata`` is passed metadata with too many items and
         invalid metadata values, the too many items error takes precedence.
         """
-        metadata = {"key{0}".format(i): [] for i in xrange(100)}
+        metadata = dict(("key{0}".format(i), []) for i in xrange(100))
         self.assert_maximum_metadata(
             *self.set_metadata({"metadata": metadata}))
 
@@ -976,8 +976,8 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         it should return an HTTP status code of 403 and an error message
         saying there are too many items.
         """
-        metadata = {"key{0}".format(i): "value{0}".format(i)
-                    for i in xrange(40)}
+        metadata = dict(("key{0}".format(i), "value{0}".format(i))
+                        for i in xrange(40))
         self.assert_maximum_metadata(
             *self.set_metadata_item(metadata, 'newkey',
                                     {"meta": {"newkey": "newval"}}))
@@ -989,15 +989,15 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         key, it should succeed (because it replaces the original metadata
         item).
         """
-        metadata = {"key{0}".format(i): "value{0}".format(i)
-                    for i in xrange(40)}
+        metadata = dict(("key{0}".format(i), "value{0}".format(i))
+                        for i in xrange(40))
         response, body = self.set_metadata_item(
             metadata, 'key0', {"meta": {"key0": "newval"}})
         self.assertEqual(response.code, 200)
         self.assertEqual(body, {"meta": {"key0": "newval"}})
 
-        expected = {"key{0}".format(i): "value{0}".format(i)
-                    for i in xrange(1, 40)}
+        expected = dict(("key{0}".format(i), "value{0}".format(i))
+                        for i in xrange(1, 40))
         expected['key0'] = 'newval'
         self.assertEqual(self.get_created_server_metadata(), expected)
 
@@ -1015,7 +1015,7 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         When ``set_metadata_item`` is passed metadata with too many items and
         invalid metadata values, the too many items error takes precedence.
         """
-        metadata = {"key{0}".format(i): "value{0}".format(i)
-                    for i in xrange(40)}
+        metadata = dict(("key{0}".format(i), "value{0}".format(i))
+                        for i in xrange(40))
         self.assert_maximum_metadata(
             *self.set_metadata_item(metadata, 'key', {"meta": {"key": []}}))

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -1,4 +1,3 @@
-
 import json
 import treq
 
@@ -89,6 +88,82 @@ class NovaAPITests(SynchronousTestCase):
             }))
         create_server_response = self.successResultOf(create_server)
         self.assertEqual(create_server_response.code, 400)
+
+    def test_create_server_with_too_many_metadata_items(self):
+        """
+        When ``create_server`` is passed metadata with too many items, it
+        should return an HTTP status code of 403 and an error message saying
+        there are too many items.
+        """
+        response, body = self.successResultOf(json_request(
+            self, self.root, "POST", self.uri + '/servers',
+            {
+                "server": {
+                    "name": self.server_name + "A",
+                    "imageRef": "test-image",
+                    "flavorRef": "test-flavor",
+                    "OS-DCF:diskConfig": "MANUAL",
+                    "metadata": {
+                        "key{0}".format(i): "value{0}".format(i)
+                        for i in xrange(100)
+                    }
+                }
+            }))
+        self.assertEqual(response.code, 403)
+        self.assertEqual(body, {"forbidden": {
+            "message": "Maximum number of metadata items exceeds 40",
+            "code": 403
+        }})
+
+    def test_create_server_with_invalid_metadata_values(self):
+        """
+        When ``create_server`` is passed metadata with non-string-type values,
+        it should return an HTTP status code of 400 and an error message
+        saying that values must be strings or unicode.
+        """
+        response, body = self.successResultOf(json_request(
+            self, self.root, "POST", self.uri + '/servers',
+            {
+                "server": {
+                    "name": self.server_name + "A",
+                    "imageRef": "test-image",
+                    "flavorRef": "test-flavor",
+                    "OS-DCF:diskConfig": "MANUAL",
+                    "metadata": {"key": []}
+                }
+            }))
+
+        self.assertEqual(response.code, 400)
+        self.assertEqual(body, {"badRequest": {
+            "message": (
+                "Invalid metadata: The input is not a string or unicode"),
+            "code": 400
+        }})
+
+    def test_create_server_too_many_metadata_items_takes_precedence(self):
+        """
+        When ``create_server`` is passed metadata with too many items and
+        invalid metadata values, the too many items error takes precedence.
+        """
+        response, body = self.successResultOf(json_request(
+            self, self.root, "POST", self.uri + '/servers',
+            {
+                "server": {
+                    "name": self.server_name + "A",
+                    "imageRef": "test-image",
+                    "flavorRef": "test-flavor",
+                    "OS-DCF:diskConfig": "MANUAL",
+                    "metadata": {
+                        "key{0}".format(i): i
+                        for i in xrange(100)
+                    }
+                }
+            }))
+        self.assertEqual(response.code, 403)
+        self.assertEqual(body, {"forbidden": {
+            "message": "Maximum number of metadata items exceeds 40",
+            "code": 403
+        }})
 
     def validate_server_detail_json(self, server_json):
         """

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -941,7 +941,7 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         When setting metadata with an invalid request body (not a dict), it
         should return an HTTP status code of 400:malformed request body
         """
-        self.assert_malformed_body(*self.set_metadata("meh"))
+        self.assert_malformed_body(*self.set_metadata('meh'))
 
     def test_set_metadata_with_invalid_metadata_object(self):
         """
@@ -1048,6 +1048,21 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         self.assert_malformed_body(
             *self.set_metadata_item({}, "meh",
                                     {"metadata": {"meh": "value"}}))
+
+    def test_set_metadata_item_with_mismatching_key_and_body(self):
+        """
+        When setting metadata item, the key in the 'meta' dictionary needs to
+        match the key in the URL, or a special 400 response is returned.
+        """
+        response, body = self.set_metadata_item(
+            {}, "key", {"meta": {"notkey": "value"}})
+        self.assertEqual(response.code, 400)
+        self.assertEqual(body, {
+            "badRequest": {
+                "message": "Request body and URI mismatch",
+                "code": 400
+            }
+        })
 
     def test_set_metadata_item_with_wrong_meta_type_fails(self):
         """

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -828,9 +828,8 @@ class NovaAPIMetadataTests(SynchronousTestCase):
 
     def test_create_server_with_invalid_metadata_object(self):
         """
-        When ``create_server`` is passed metadata with too many items, it
-        should return an HTTP status code of 403 and an error message saying
-        there are too many items.
+        When ``create_server`` with an invalid metadata object (a string), it
+        should return an HTTP status code of 400:malformed body.
         """
         self.assert_malformed_body(*self.create_server("not metadata"))
 
@@ -862,8 +861,8 @@ class NovaAPIMetadataTests(SynchronousTestCase):
 
     def test_create_server_null_metadata_succeeds(self):
         """
-        When ``create_server`` is passed metadata with too many items and
-        invalid metadata values, the too many items error takes precedence.
+        When ``create_server`` is passed null metadata, it successfully
+        creates a server.
         """
         response, body = self.create_server(None)
         self.assertEqual(response.code, 202)
@@ -905,7 +904,7 @@ class NovaAPIMetadataTests(SynchronousTestCase):
     def test_set_metadata_with_only_metadata_body_succeeds(self):
         """
         When setting metadata with a body that looks like
-        ``{'metadata': {<valid metadata}}``, a 200 is received with a valid
+        ``{'metadata': {<valid metadata>}}``, a 200 is received with a valid
         response body.
         """
         response, body = self.set_metadata({"metadata": {}})
@@ -939,16 +938,16 @@ class NovaAPIMetadataTests(SynchronousTestCase):
 
     def test_set_metadata_with_invalid_json_body_fails(self):
         """
-        When setting metadata with an invalid request body, it should return
-        an HTTP status code of 400:malformed request body
+        When setting metadata with an invalid request body (not a dict), it
+        should return an HTTP status code of 400:malformed request body
         """
         self.assert_malformed_body(*self.set_metadata("meh"))
 
     def test_set_metadata_with_invalid_metadata_object(self):
         """
-        When ``set_metadata`` is passed metadata with too many items, it
-        should return an HTTP status code of 403 and an error message saying
-        there are too many items.
+        When ``set_metadata`` is passed a dictionary with the metadata key,
+        but the metadata is not a dict, it should return an HTTP status code
+        of 400: malformed request body.
         """
         self.assert_malformed_body(
             *self.set_metadata({"metadata": "not metadata"}))
@@ -956,8 +955,7 @@ class NovaAPIMetadataTests(SynchronousTestCase):
     def test_set_metadata_without_metadata_key(self):
         """
         When ``set_metadata`` is passed metadata with the wrong key, it
-        should return an HTTP status code of 403 and an error message saying
-        there are too many items.
+        should return an HTTP status code of 400: malformed request body.
         """
         self.assert_malformed_body(
             *self.set_metadata({"meta": {"wrong": "metadata key"}}))
@@ -1090,7 +1088,7 @@ class NovaAPIMetadataTests(SynchronousTestCase):
             *self.set_metadata_item(metadata, 'newkey',
                                     {"meta": {"newkey": "newval"}}))
 
-    def test_set_metadata_item_repace_existing_metadata(self):
+    def test_set_metadata_item_replace_existing_metadata(self):
         """
         If there are already the maximum number of metadata items on the
         server, but ``set_metadata_item`` is called with an already existing

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -891,6 +891,13 @@ class NovaAPIMetadataTests(SynchronousTestCase):
             }
         })
 
+    def test_set_metadata_with_invalid_json_body_fails(self):
+        """
+        When setting metadata with an invalid request body, it should return
+        an HTTP status code of 400:malformed request body
+        """
+        self.assert_malformed_body(*self.set_metadata("meh"))
+
     def test_set_metadata_with_invalid_metadata_object(self):
         """
         When ``set_metadata`` is passed metadata with too many items, it
@@ -951,6 +958,13 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         self.assertEqual(response.code, 200)
         self.assertEqual(body, {'meta': {'key': 'value'}})
         self.assertEqual(self.get_created_server_metadata(), {'key': 'value'})
+
+    def test_set_metadata_item_with_invalid_json_body_fails(self):
+        """
+        When setting metadata item with an invalid request body, it should
+        return an HTTP status code of 400:malformed request body
+        """
+        self.assert_malformed_body(*self.set_metadata_item({}, "meh", "meh"))
 
     def test_set_metadata_item_with_too_many_keys_and_values(self):
         """


### PR DESCRIPTION
This PR:

1.  Adds a handler for:  `GET /servers/<server_id>/metadata`
1.  Adds a handler for:  `PUT /servers/<server_id>/metadata`, which is required by Autoscale
1.  Adds a handler for:  `PUT /servers/<server_id>/metadata/key`, which is required by Autoscale
1.  Adds support for validating nova metadata on create
1.  Fixes a bug with metadata behaviors not handling null metadata (which is accepted by nova)
1.  Places the OS DISK Config message in one place.