### PR TITLE
RFR: Use nova specific error body generation functions

### DIFF
--- a/mimic/model/nova_objects.py
+++ b/mimic/model/nova_objects.py
@@ -20,7 +20,7 @@ from mimic.util.helper import (
 from mimic.model.behaviors import (
     BehaviorRegistry, EventDescription, Criterion, regexp_predicate
 )
-from twisted.web.http import ACCEPTED
+from twisted.web.http import ACCEPTED, BAD_REQUEST, FORBIDDEN, NOT_FOUND
 
 
 @attributes(['nova_message'])
@@ -69,7 +69,7 @@ def bad_request(message, request):
 
     :return: dictionary representing the error body.
     """
-    return _nova_error_message("badRequest", message, 400, request)
+    return _nova_error_message("badRequest", message, BAD_REQUEST, request)
 
 
 def not_found(message, request):
@@ -82,7 +82,7 @@ def not_found(message, request):
 
     :return: dictionary representing the error body.
     """
-    return _nova_error_message("itemNotFound", message, 404, request)
+    return _nova_error_message("itemNotFound", message, NOT_FOUND, request)
 
 
 def forbidden(message, request):
@@ -95,7 +95,7 @@ def forbidden(message, request):
 
     :return: dictionary representing the error body.
     """
-    return _nova_error_message("forbidden", message, 403, request)
+    return _nova_error_message("forbidden", message, FORBIDDEN, request)
 
 
 @attributes(["collection", "server_id", "server_name", "metadata",

--- a/mimic/model/nova_objects.py
+++ b/mimic/model/nova_objects.py
@@ -665,8 +665,6 @@ class RegionalServerCollection(object):
         if server is None:
             return dumps(not_found("Instance could not be found",
                                    http_delete_request))
-            http_delete_request.setResponseCode(404)
-            return b''
         if 'delete_server_failure' in server.metadata:
             srvfail = loads(server.metadata['delete_server_failure'])
             if srvfail['times']:

--- a/mimic/model/nova_objects.py
+++ b/mimic/model/nova_objects.py
@@ -14,14 +14,13 @@ from six import string_types
 from mimic.util.helper import (
     seconds_to_timestamp,
     invalid_resource,
-    not_found_response,
     random_string,
 )
 
 from mimic.model.behaviors import (
     BehaviorRegistry, EventDescription, Criterion, regexp_predicate
 )
-from twisted.web.http import ACCEPTED, NOT_FOUND
+from twisted.web.http import ACCEPTED
 
 
 @attributes(['nova_message'])
@@ -71,6 +70,32 @@ def bad_request(message, request):
     :return: dictionary representing the error body.
     """
     return _nova_error_message("badRequest", message, 400, request)
+
+
+def not_found(message, request):
+    """
+    Return a 404 error body associated with a Nova not found error.
+    Also sets the response code on the request.
+
+    :param str message: The message to include in the bad request body.
+    :param request: The request on which to set the response code.
+
+    :return: dictionary representing the error body.
+    """
+    return _nova_error_message("itemNotFound", message, 404, request)
+
+
+def forbidden(message, request):
+    """
+    Return a 403 error body associated with a Nova forbidden error.
+    Also sets the response code on the request.
+
+    :param str message: The message to include in the bad request body.
+    :param request: The request on which to set the response code.
+
+    :return: dictionary representing the error body.
+    """
+    return _nova_error_message("forbidden", message, 403, request)
 
 
 @attributes(["collection", "server_id", "server_name", "metadata",
@@ -532,22 +557,28 @@ class RegionalServerCollection(object):
     def request_read(self, http_get_request, server_id, absolutize_url):
         """
         Request the information / details for an individual server.
+
+        Not found response verified against Rackspace Cloud Servers as of
+        2015-04-30.
         """
         server = self.server_by_id(server_id)
         if server is None:
-            http_get_request.setResponseCode(404)
-            return dumps(not_found_response('servers'))
+            return dumps(not_found("Instance could not be found",
+                                   http_get_request))
         return dumps({"server": server.detail_json(absolutize_url)})
 
     def request_ips(self, http_get_ips_request, server_id):
         """
         Request the addresses JSON for a specific server.
+
+        Not found response verified against Rackspace Cloud Servers as of
+        2015-04-30.
         """
         http_get_ips_request.setResponseCode(200)
         server = self.server_by_id(server_id)
         if server is None:
-            http_get_ips_request.setResponseCode(NOT_FOUND)
-            return None
+            return dumps(not_found("Instance does not exist",
+                                   http_get_ips_request))
         return dumps({"addresses": server.addresses_json()})
 
     def request_list(self, http_get_request, include_details, absolutize_url,
@@ -626,9 +657,14 @@ class RegionalServerCollection(object):
     def request_delete(self, http_delete_request, server_id):
         """
         Delete a server with the given ID.
+
+        Not found response verified against Rackspace Cloud Servers as of
+        2015-04-30.
         """
         server = self.server_by_id(server_id)
         if server is None:
+            return dumps(not_found("Instance could not be found",
+                                   http_delete_request))
             http_delete_request.setResponseCode(404)
             return b''
         if 'delete_server_failure' in server.metadata:

--- a/mimic/test/test_util.py
+++ b/mimic/test/test_util.py
@@ -84,20 +84,6 @@ class TestHelperTests(SynchronousTestCase):
             request(self, Resource(), b"POST", b"", u"not bytes")
         )
 
-    def test_bad_request(self):
-        """
-        ``bad_request`` provides a well-formed error body for HTTP errors.
-
-        The ``illegal_response`` function constructs a hash with a message and
-        HTTP response code, for the convenience of expressing error details in
-        JSON format.  However, it doesn't provide the full envelop expected by
-        Nova clients.
-        """
-        d = helper.bad_request("The cake is a lie.", 404)
-        self.assertTrue(d.get("badRequest", None))
-        self.assertEqual(d["badRequest"]["code"], 404)
-        self.assertEqual(d["badRequest"]["message"], "The cake is a lie.")
-
 
 class TestRandomString(SynchronousTestCase):
     """

--- a/mimic/util/helper.py
+++ b/mimic/util/helper.py
@@ -75,14 +75,13 @@ def seconds_to_timestamp(seconds, format=fmt):
 
 def not_found_response(resource='servers'):
     """
-    Return a 404 response body for Nova, depending on the resource.  Expects
-    resource to be one of "servers", "images", or "flavors".
+    Return a 404 response body, depending on the resource.  Expects
+    resource to be one of "images", "flavors", "loadbalancer", or "node".
 
     If the resource is unrecognized, defaults to
     "The resource culd not be found."
     """
     message = {
-        'servers': "Instance could not be found",
         'images': "Image not found.",
         'flavors': "The resource could not be found.",
         'loadbalancer': "Load balancer not found",
@@ -105,15 +104,6 @@ def invalid_resource(message, response_code=400):
     code.  Defaults response code to 400, if not provided.
     """
     return {"message": message, "code": response_code}
-
-
-def bad_request(message, response_code=400):
-    """
-    Returns the given message within in bad request body, and sets the response
-    code to given response code.  Defaults response code to 400, if not
-    provided.
-    """
-    return {"badRequest": invalid_resource(message, response_code)}
 
 
 def set_resource_status(updated_time, time_delta, status='ACTIVE',


### PR DESCRIPTION
Like nova specific not-found, bad request, forbidden, etc. functions that also set the HTTP code.  Part of #222.