### PR TITLE
testtools 1.8 came out yesterday, and it's broken

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def setup_options(name, version):
             "six>=1.6.0",
             "xmltodict>=0.9.1",
             "attrs>=15.0.0",
-            "testtools>=1.7.1"
+            "testtools>=1.7.1,<1.8.0"
         ],
         package_dir={"mimic": "mimic"},
         packages=find_packages(exclude=[]) + ["twisted.plugins"],


### PR DESCRIPTION
Something to do with `USER_BASE` not being importable?  It's not
entirely clear what the issue is, but it looks like it might be an issue
with py2app:

https://bitbucket.org/ronaldoussoren/py2app/issue/111/user_base-cannot-be-imported