### PR TITLE
Sequence behavior

### DIFF
--- a/mimic/model/nova_objects.py
+++ b/mimic/model/nova_objects.py
@@ -4,6 +4,7 @@ Model objects for the Nova mimic.
 
 import re
 
+from itertools import cycle
 from characteristic import attributes, Attribute
 from random import randrange
 from json import loads, dumps
@@ -537,7 +538,7 @@ def sequence(parameters):
     other behaviors.
     """
     behavior_specification = parameters["behaviors"]
-    behavior_objects = [
+    behavior_objects = cycle([
         (
             server_creation.create_behavior(behavior["name"],
                                             behavior["parameters"])
@@ -545,14 +546,11 @@ def sequence(parameters):
             else server_creation.default_behavior
         )
         for behavior in behavior_specification
-    ]
+    ])
 
     def rotating_behavior(collection, http, json, absolutize_url):
-        current = behavior_objects[rotating_behavior.index]
-        rotating_behavior.index += 1
-        rotating_behavior.index %= len(behavior_objects)
+        current = next(behavior_objects)
         return current(collection, http, json, absolutize_url)
-    rotating_behavior.index = 0
     return rotating_behavior
 
 

--- a/mimic/model/nova_objects.py
+++ b/mimic/model/nova_objects.py
@@ -534,8 +534,34 @@ def sequence(parameters):
     Sometimes a sequence of behaviors occur when you try to create a server in
     a predictable pattern.
 
+    Each time the criterion for the behavior is matched, the next behavior.
+
     Takes one parameter, ``behaviors``, which is a list of specifications of
-    other behaviors.
+    other behaviors, similar to those specified in the request to create a
+    behavior, with the addition of a behavior with a name of "default" that
+    means default success.
+
+    Note that the behavior specifications here do not need a criterion, since
+    the criterion is specified for the behavior overall, and each behavior is
+    unconditionally executed in sequence.
+
+    For example, to specify an alternating sequence of success and then
+    failure::
+
+        {
+            "behaviors": [
+                {
+                    "name": "default"
+                },
+                {
+                    "name": "fail",
+                    "parameters": {
+                        "code": 500,
+                        "message": "synthetic error"
+                    }
+                }
+            ]
+        }
     """
     behavior_specification = parameters["behaviors"]
     behavior_objects = cycle([

--- a/mimic/model/nova_objects.py
+++ b/mimic/model/nova_objects.py
@@ -534,19 +534,21 @@ def sequence(parameters):
     Sometimes a sequence of behaviors occur when you try to create a server in
     a predictable pattern.
 
-    Each time the criterion for the behavior is matched, the next behavior.
-
     Takes one parameter, ``behaviors``, which is a list of specifications of
     other behaviors, similar to those specified in the request to create a
     behavior, with the addition of a behavior with a name of "default" that
     means default success.
 
+    Each time the criterion for this behavior is matched, the next behavior is
+    executed, looping back to the beginning when the list of behaviors is
+    exhausted.  In other words, this creation behavior is stateful.
+
     Note that the behavior specifications here do not need a criterion, since
     the criterion is specified for the behavior overall, and each behavior is
     unconditionally executed in sequence.
 
-    For example, to specify an alternating sequence of success and then
-    failure::
+    For example, to specify an alternating sequence of success and then failure
+    when the criterion for the ``sequence`` behavior is matched::
 
         {
             "behaviors": [

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -1347,12 +1347,11 @@ class NovaAPINegativeTests(SynchronousTestCase):
             name="sequenced_server_name")
         self.assertEqual(create_server_response_1.code, 500)
         self.assertEqual(create_server_response_2.code, 404)
-        self.assertEqual(create_server_response_3.code, 201)
+        self.assertEqual(create_server_response_3.code, 202)
         self.assertEqual(create_server_response_4.code, 500)
 
         # We should have created 1 server from the above actions.
         self.assertEqual(server_count(), 1)
-
 
     def test_modify_status_non_existent_server(self):
         """

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -1298,6 +1298,62 @@ class NovaAPINegativeTests(SynchronousTestCase):
         self.assertEqual(resp.code, 200)
         self.assertEqual(len(list_body['servers']), 1)
 
+    def test_create_sequence_behavior(self):
+        """
+        :func:`create_server` responds with each behavior in sequence,
+        repeatedly, as specified to the "sequence" behavior.
+        """
+        def server_count():
+            resp, list_body = self.successResultOf(json_request(
+                self, self.root, "GET", self.uri + '/servers'))
+            self.assertEqual(resp.code, 200)
+            return len(list_body['servers'])
+
+        # Just to make sure, we have no servers to start with.
+        self.assertEqual(server_count(), 0)
+        self.use_creation_behavior(
+            "sequence",
+            {
+                "behaviors": [
+                    {
+                        "name": "fail",
+                        "parameters": {
+                            "code": 500,
+                            "message": "lol"
+                        }
+                    },
+                    {
+                        "name": "fail",
+                        "parameters": {
+                            "code": 404,
+                            "message": "wut"
+                        }
+                    },
+                    {
+                        "name": "default",
+                        "parameters": {}
+                    }
+                ]
+            },
+            [{"server_name": "sequenced_server_name"}]
+        )
+        create_server_response_1 = self.create_server(
+            name="sequenced_server_name")
+        create_server_response_2 = self.create_server(
+            name="sequenced_server_name")
+        create_server_response_3 = self.create_server(
+            name="sequenced_server_name")
+        create_server_response_4 = self.create_server(
+            name="sequenced_server_name")
+        self.assertEqual(create_server_response_1.code, 500)
+        self.assertEqual(create_server_response_2.code, 404)
+        self.assertEqual(create_server_response_3.code, 201)
+        self.assertEqual(create_server_response_4.code, 500)
+
+        # We should have created 1 server from the above actions.
+        self.assertEqual(server_count(), 1)
+
+
     def test_modify_status_non_existent_server(self):
         """
         When using the ``.../attributes`` endpoint, if a non-existent server is


### PR DESCRIPTION
This is a part of the fix for #204, because it doesn't provide the specified `repeat` option; it just always repeats. I wonder if we should do it that way; perhaps we should have different names for the different things you do when you get to the end?