### PR TITLE
Mimic identity changes for ele

### DIFF
--- a/mimic/canned_responses/mimic_presets.py
+++ b/mimic/canned_responses/mimic_presets.py
@@ -19,5 +19,19 @@ get_presets = {"loadbalancers": {"lb_building": "On create load balancer, keeps 
                            "invalid_flavor_ref": ["INVALID-FLAVOR-ID", "8888", "-4", "1"],
                            "server_error": "sets server state to error on create",
                            "server_building": "sets the server to be in building state for given time"
-                                              " in seconds"}
-               }
+                                              " in seconds"},
+               "identity": {
+                   "maas_admin_roles": {
+                       "this_is_an_impersonator_token": ["impersonator.joe", "12345"],
+                       "this_is_an_impersonator_token_also": ["impersonator.eve", "12453"],
+                       "impersonate_watson": ["impersonator.watson", "09876"],
+                       "impersonate_creator": ["impersonator.freeman", "09090"],
+                       "this_is_an_impersonator_token_also_2": ["impersonator.foonatical", "91169"],
+                       "impersonate_foo_token": ["impersonate_foo", "91111"]},
+               "racker_token": {"this_is_a_racker_token": ["racker.support", "12345"]},
+               "observer_role": ["09876"],
+               "creator_role": ["09090"],
+               "admin_role": ["9999"],
+               "token_fail_to_auth": ["never-cache-this-and-fail-to-auth"]
+}
+}

--- a/mimic/canned_responses/mimic_presets.py
+++ b/mimic/canned_responses/mimic_presets.py
@@ -21,14 +21,14 @@ get_presets = {"loadbalancers": {"lb_building": "On create load balancer, keeps 
                            "server_building": "sets the server to be in building state for given time"
                                               " in seconds"},
                "identity": {
-                   "maas_admin_roles": {
-                       "this_is_an_impersonator_token": ["impersonator.joe", "12345"],
-                       "this_is_an_impersonator_token_also": ["impersonator.eve", "12453"],
-                       "impersonate_watson": ["impersonator.watson", "09876"],
-                       "impersonate_creator": ["impersonator.freeman", "09090"],
-                       "this_is_an_impersonator_token_also_2": ["impersonator.foonatical", "91169"],
-                       "impersonate_foo_token": ["impersonate_foo", "91111"]},
-               "racker_token": {"this_is_a_racker_token": ["racker.support", "12345"]},
+                   "maas_admin_roles": [
+                       "this_is_an_impersonator_token",
+                       "this_is_an_impersonator_token_also",
+                       "impersonate_watson",
+                       "impersonate_creator",
+                       "this_is_an_impersonator_token_also_2",
+                       "impersonate_foo_token"],
+               "racker_token": ["this_is_a_racker_token"],
                "observer_role": ["09876"],
                "creator_role": ["09090"],
                "admin_role": ["9999"],

--- a/mimic/canned_responses/mimic_presets.py
+++ b/mimic/canned_responses/mimic_presets.py
@@ -21,6 +21,8 @@ get_presets = {"loadbalancers": {"lb_building": "On create load balancer, keeps 
                            "server_building": "sets the server to be in building state for given time"
                                               " in seconds"},
                "identity": {
+                   # On ``validate_token`` the tokens listed below
+                   # result in 'monitoring-service-admin' impersonator role.
                    "maas_admin_roles": [
                        "this_is_an_impersonator_token",
                        "this_is_an_impersonator_token_also",
@@ -28,10 +30,16 @@ get_presets = {"loadbalancers": {"lb_building": "On create load balancer, keeps 
                        "impersonate_creator",
                        "this_is_an_impersonator_token_also_2",
                        "impersonate_foo_token"],
-               "racker_token": ["this_is_a_racker_token"],
-               "observer_role": ["09876"],
-               "creator_role": ["09090"],
-               "admin_role": ["9999"],
-               "token_fail_to_auth": ["never-cache-this-and-fail-to-auth"]
+                   # On ``validate_token`` the tokens listed below
+                   # result in 'racker' impersonator role.
+                   "racker_token": ["this_is_a_racker_token"],
+                   # Tenants with user observer role
+                   "observer_role": ["09876"],
+                   # Tenants with user creator role
+                   "creator_role": ["09090"],
+                   # Tenants with user admin role
+                   "admin_role": ["9999"],
+                   # Tenants with this token result in a 401 when validating the token
+                   "token_fail_to_auth": ["never-cache-this-and-fail-to-auth"]
 }
 }

--- a/mimic/rest/auth_api.py
+++ b/mimic/rest/auth_api.py
@@ -201,16 +201,16 @@ class AuthApi(object):
         racker_token = get_presets["identity"]["racker_token"]
         if token_id in imp_token:
             response["access"]["RAX-AUTH:impersonator"] = {
-                "id": imp_token[token_id][1],
-                "name": imp_token[token_id][0],
+                "id": response["access"]["user"]["id"],
+                "name": response["access"]["user"]["name"],
                 "roles": [{"id": "123",
                            "name": "monitoring:service-admin"},
                           {"id": "234",
                            "name": "object-store:admin"}]}
         if token_id in racker_token:
             response["access"]["RAX-AUTH:impersonator"] = {
-                "id": racker_token[token_id][1],
-                "name": racker_token[token_id][0],
+                "id": response["access"]["user"]["id"],
+                "name": response["access"]["user"]["name"],
                 "roles": [{"id": "9",
                            "name": "Racker"}]}
         if tenant_id in get_presets["identity"]["observer_role"]:

--- a/mimic/test/test_auth.py
+++ b/mimic/test/test_auth.py
@@ -14,6 +14,15 @@ from mimic.catalog import Entry, Endpoint
 from mimic.canned_responses.mimic_presets import get_presets
 
 
+def core_and_root(api_list):
+    """
+    Given a list of APIs to load, return core and root.
+    """
+    core = MimicCore(Clock(), api_list)
+    root = MimicRoot(core).app.resource()
+    return core, root
+
+
 class ExampleCatalogEndpoint(object):
 
     def __init__(self, tenant, num, endpoint_id):
@@ -382,8 +391,7 @@ class GetAuthTokenAPITests(SynchronousTestCase):
         """
         The response for empty body request is bad_request.
         """
-        core = MimicCore(Clock(), [])
-        root = MimicRoot(core).app.resource()
+        core, root = core_and_root([])
 
         (response, json_body) = self.successResultOf(json_request(
             self, root, "POST", "/identity/v2.0/tokens", ""))
@@ -394,8 +402,7 @@ class GetAuthTokenAPITests(SynchronousTestCase):
         """
         The response for not JSON body request is bad_request.
         """
-        core = MimicCore(Clock(), [])
-        root = MimicRoot(core).app.resource()
+        core, root = core_and_root([])
 
         response = self.successResultOf(request(
             self, root, "POST", "/identity/v2.0/tokens", "{ bad request: }"))
@@ -473,8 +480,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         """
         A session is created for the token provided
         """
-        core = MimicCore(Clock(), [])
-        root = MimicRoot(core).app.resource()
+        core, root = core_and_root([])
 
         token = '1234567890'
 
@@ -491,8 +497,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         The JSON response's service catalog whose endpoints all begin with
         the same base URI as the request.
         """
-        core = MimicCore(Clock(), [ExampleAPI()])
-        root = MimicRoot(core).app.resource()
+        core, root = core_and_root([ExampleAPI()])
 
         (response, json_body) = self.successResultOf(json_request(
             self, root, "GET",
@@ -599,8 +604,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         """
         Test apiKeyCredentials
         """
-        core = MimicCore(Clock(), [ExampleAPI()])
-        root = MimicRoot(core).app.resource()
+        core, root = core_and_root([ExampleAPI()])
         (response, json_body) = self.successResultOf(json_request(
             self, root, "GET",
             "/identity/v2.0/users/1/OS-KSADM/credentials/RAX-KSKEY:apiKeyCredentials"
@@ -686,8 +690,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         :func: `get_token_and_service_catalog` returns response code 400, when
         an invalid json request body is used to authenticate.
         """
-        core = MimicCore(Clock(), [ExampleAPI()])
-        root = MimicRoot(core).app.resource()
+        core, root = core_and_root([ExampleAPI()])
 
         (response, json_body) = self.successResultOf(json_request(
             self, root, "POST", "/identity/v2.0/tokens",
@@ -706,8 +709,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         """
         Test to verify :func: `get_username`.
         """
-        core = MimicCore(Clock(), [ExampleAPI()])
-        root = MimicRoot(core).app.resource()
+        core, root = core_and_root([ExampleAPI()])
 
         (response, json_body) = self.successResultOf(json_request(
             self, root, "GET",
@@ -730,8 +732,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         """
         The response for empty body request is bad_request.
         """
-        core = MimicCore(Clock(), [])
-        root = MimicRoot(core).app.resource()
+        core, root = core_and_root([])
 
         (response, json_body) = self.successResultOf(json_request(
             self, root, "POST", "http://mybase/identity/v2.0/RAX-AUTH/impersonation-tokens", ""))
@@ -742,8 +743,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         """
         The response for not JSON body request is bad_request.
         """
-        core = MimicCore(Clock(), [])
-        root = MimicRoot(core).app.resource()
+        core, root = core_and_root([])
 
         response = self.successResultOf(request(
             self, root, "POST", "http://mybase/identity/v2.0/RAX-AUTH/impersonation-tokens",
@@ -755,8 +755,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         """
         Test to verify :func: `validate_token`.
         """
-        core = MimicCore(Clock(), [ExampleAPI()])
-        root = MimicRoot(core).app.resource()
+        core, root = core_and_root([ExampleAPI()])
 
         (response, json_body) = self.successResultOf(json_request(
             self, root, "GET",
@@ -773,8 +772,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         Test to verify :func: `validate_token` when tenant_id is not
         provided using the argument `belongsTo`
         """
-        core = MimicCore(Clock(), [ExampleAPI()])
-        root = MimicRoot(core).app.resource()
+        core, root = core_and_root([ExampleAPI()])
 
         (response, json_body) = self.successResultOf(json_request(
             self, root, "GET",
@@ -788,8 +786,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         """
         Test to verify :func: `validate_token` and then authenticate
         """
-        core = MimicCore(Clock(), [ExampleAPI()])
-        root = MimicRoot(core).app.resource()
+        core, root = core_and_root([ExampleAPI()])
 
         (response1, json_body1) = self.successResultOf(json_request(
             self, root, "GET",
@@ -811,8 +808,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         """
         Test to verify :func: `validate_token` and then authenticate
         """
-        core = MimicCore(Clock(), [ExampleAPI()])
-        root = MimicRoot(core).app.resource()
+        core, root = core_and_root([ExampleAPI()])
 
         # Authenticate the impersonator (admin user)
         (response0, json_body0) = authenticate_with_token(
@@ -850,8 +846,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         """
         Test to verify :func: `validate_token` and then authenticate
         """
-        core = MimicCore(Clock(), [ExampleAPI()])
-        root = MimicRoot(core).app.resource()
+        core, root = core_and_root([ExampleAPI()])
 
         # Authenticate the impersonator (admin user 1)
         (response0, json_body0) = authenticate_with_token(
@@ -921,8 +916,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         Test to verify :func: `validate_token` when the token_id provided
         is of an maas admin user specified in `mimic_presets`.
         """
-        core = MimicCore(Clock(), [ExampleAPI()])
-        root = MimicRoot(core).app.resource()
+        core, root = core_and_root([ExampleAPI()])
 
         (response, json_body) = self.successResultOf(json_request(
             self, root, "GET",
@@ -937,8 +931,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         Test to verify :func: `validate_token` when the token_id provided
         is of a racker specified in `mimic_presets`.
         """
-        core = MimicCore(Clock(), [ExampleAPI()])
-        root = MimicRoot(core).app.resource()
+        core, root = core_and_root([ExampleAPI()])
 
         (response, json_body) = self.successResultOf(json_request(
             self, root, "GET",
@@ -953,8 +946,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         Test to verify :func: `validate_token` when the token_id provided
         is invalid, as specified in `mimic_presets`.
         """
-        core = MimicCore(Clock(), [ExampleAPI()])
-        root = MimicRoot(core).app.resource()
+        core, root = core_and_root([ExampleAPI()])
         token = get_presets["identity"]["token_fail_to_auth"][0]
 
         (response, json_body) = self.successResultOf(json_request(
@@ -968,8 +960,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         Test to verify :func: `validate_token` when the tenant_id provided
         is of an observer role, as specified in `mimic_presets`.
         """
-        core = MimicCore(Clock(), [ExampleAPI()])
-        root = MimicRoot(core).app.resource()
+        core, root = core_and_root([ExampleAPI()])
         token = get_presets["identity"]["observer_role"][0]
 
         (response, json_body) = self.successResultOf(json_request(
@@ -987,8 +978,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         Test to verify :func: `validate_token` when the tenant_id provided
         is of an creator role, as specified in `mimic_presets`.
         """
-        core = MimicCore(Clock(), [ExampleAPI()])
-        root = MimicRoot(core).app.resource()
+        core, root = core_and_root([ExampleAPI()])
         token = get_presets["identity"]["creator_role"][0]
 
         (response, json_body) = self.successResultOf(json_request(
@@ -1006,8 +996,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         Test to verify :func: `validate_token` when the tenant_id provided
         is of an admin role, as specified in `mimic_presets`.
         """
-        core = MimicCore(Clock(), [ExampleAPI()])
-        root = MimicRoot(core).app.resource()
+        core, root = core_and_root([ExampleAPI()])
         token = get_presets["identity"]["admin_role"][0]
 
         (response, json_body) = self.successResultOf(json_request(
@@ -1037,8 +1026,7 @@ class AuthIntegrationTests(SynchronousTestCase):
         tenant, then attempt to impersonate that user.  The tenant IDs should
         be the same.  This is an autoscale regression test.
         """
-        core = MimicCore(Clock(), [ExampleAPI()])
-        root = MimicRoot(core).app.resource()
+        core, root = core_and_root([ExampleAPI()])
         tenant_id = "111111"
 
         # authenticate as that user - this is not strictly necessary, since


### PR DESCRIPTION
This a temporary change that implements only a few rbac like roles (required by ele tests). This should  exist only until RBAC is globally applied for users within mimic.

Eventually tests within ele are going to be changed to hit the mimic identity's control plane to specify the role/behavior expected for a tenant.