### PR TITLE
pin the version of cryptography used by the mac app

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 klein==15.0.0
+cryptography==0.8.2
 twisted==15.0.0
 jsonschema==2.0
 treq==15.0.0


### PR DESCRIPTION
The release today hard depends on idna.  While this should be installed, it sadly breaks py2app due to something about the syntax.