### PR TITLE
Create clb ctrl api

### DIFF
--- a/mimic/model/clb_objects.py
+++ b/mimic/model/clb_objects.py
@@ -21,6 +21,11 @@ class BadKeysError(Exception):
     doesn't exist.
     """
     def __init__(self, msg, keys):
+        """
+        Exception constructor.
+
+        :param list keys: The set of keys that are considered bad.
+        """
         super(BadKeysError, self).__init__(msg)
         self.keys = keys
 

--- a/mimic/model/clb_objects.py
+++ b/mimic/model/clb_objects.py
@@ -37,6 +37,7 @@ class RegionalCLBCollection(object):
         """
         self.lbs = {}
         self.meta = {}
+        self.returnOverrides = {}
 
     def add_load_balancer(self, tenant_id, lb_info, lb_id, current_timestamp):
         """
@@ -78,11 +79,22 @@ class RegionalCLBCollection(object):
 
         return {'loadBalancer': new_lb}, 202
 
+    def set_return_override(self, lb_id, statusCode):
+        """
+        Sets the return override for a load balancer (statusCode != 0)
+        or removes it (statusCode == 0).
+        """
+        self.returnOverrides[lb_id] = statusCode
+
     def get_load_balancers(self, lb_id, current_timestamp):
         """
         Returns the load balancers with the given lb id, with response
         code 200. If no load balancers are found returns 404.
         """
+        print("RegionalCLBCollection({})".format(self))
+        if lb_id in self.returnOverrides:
+            return "Response overridden", self.returnOverrides[lb_id]
+
         if lb_id in self.lbs:
             _verify_and_update_lb_state(self, lb_id, False, current_timestamp)
             log.msg(self.lbs[lb_id]["status"])

--- a/mimic/model/clb_objects.py
+++ b/mimic/model/clb_objects.py
@@ -14,19 +14,20 @@ from mimic.canned_responses.loadbalancer import (load_balancer_example,
                                                  _delete_node)
 
 
+@attributes(["keys"])
 class BadKeysError(Exception):
     """
     When trying to alter the settings of a load balancer, this exception will
     be raised if you attempt to alter an attribute which doesn't exist.
     """
-    def __init__(self, msg, keys):
-        """
-        Exception constructor.
 
-        :param list keys: The set of keys that are considered bad.
-        """
-        super(BadKeysError, self).__init__(msg)
-        self.keys = keys
+
+@attributes(["value", "accepted_values"])
+class BadValueError(Exception):
+    """
+    When trying to alter the settings of a load balancer, this exception will
+    be raised if you attempt to set a valid attribute to an invalid setting.
+    """
 
 
 def _prep_for_list(lb_list):
@@ -113,7 +114,7 @@ class RegionalCLBCollection(object):
             if k not in supported_keys:
                 badKeys.append(k)
         if len(badKeys) > 0:
-            raise BadKeysError("Attempt to alter a bad attribute", badKeys)
+            raise BadKeysError("Attempt to alter a bad attribute", keys=badKeys)
 
         if "status" in kvpairs:
             supported_statuses = [
@@ -121,10 +122,11 @@ class RegionalCLBCollection(object):
             ]
             s = kvpairs["status"]
             if s not in supported_statuses:
-                raise ValueError(
-                    "Unsupported status {} not one of {}".format(
+                raise BadValueError(
+                    "Unsupported status {0} not one of {1}".format(
                         s, supported_statuses
-                    )
+                    ),
+                    value=s, accepted_values=supported_statuses
                 )
 
         self.lbs[lb_id].update(kvpairs)

--- a/mimic/model/clb_objects.py
+++ b/mimic/model/clb_objects.py
@@ -91,7 +91,6 @@ class RegionalCLBCollection(object):
         Returns the load balancers with the given lb id, with response
         code 200. If no load balancers are found returns 404.
         """
-        print("RegionalCLBCollection({})".format(self))
         if lb_id in self.returnOverrides:
             return "Response overridden", self.returnOverrides[lb_id]
 

--- a/mimic/model/clb_objects.py
+++ b/mimic/model/clb_objects.py
@@ -52,10 +52,17 @@ class RegionalCLBCollection(object):
         """
         Returns the cloud load balancer identified by clb_id.
         """
+        return self.lbs[clb_id]
+
+    def __contains__(self, clb_id):
+        """
+        Returns true if the CLB ID is registered with our list of load
+        balancers.
+        """
         for i in self.lbs:
             if i == clb_id:
-                return self.lbs[i]
-        raise KeyError(clb_id)
+                return True
+        return False
 
     def add_load_balancer(self, tenant_id, lb_info, lb_id, current_timestamp):
         """

--- a/mimic/model/clb_objects.py
+++ b/mimic/model/clb_objects.py
@@ -17,8 +17,7 @@ from mimic.canned_responses.loadbalancer import (load_balancer_example,
 class BadKeysError(Exception):
     """
     When trying to alter the settings of a load balancer, this exception will
-    be raised if you misspell or otherwise attempt to alter an attribute which
-    doesn't exist.
+    be raised if you attempt to alter an attribute which doesn't exist.
     """
     def __init__(self, msg, keys):
         """

--- a/mimic/model/clb_objects.py
+++ b/mimic/model/clb_objects.py
@@ -19,10 +19,8 @@ def _prep_for_list(lb_list):
     Removes tenant id and changes the nodes list to 'nodeCount' set to the
     number of node on the LB
     """
-    entries_to_keep = (
-        'name', 'protocol', 'id', 'port', 'algorithm', 'status', 'timeout',
-        'created', 'virtualIps', 'updated', 'nodeCount'
-    )
+    entries_to_keep = ('name', 'protocol', 'id', 'port', 'algorithm', 'status', 'timeout',
+                       'created', 'virtualIps', 'updated', 'nodeCount')
     filtered_lb_list = []
     for each in lb_list:
         filtered_lb_list.append(
@@ -42,27 +40,12 @@ class RegionalCLBCollection(object):
         self.lbs = {}
         self.meta = {}
 
-    def __len__(self):
-        """
-        The number of cloud load balancers in this collection.
-        """
-        return len(self.lbs)
-
-    def __getitem__(self, clb_id):
-        """
-        Returns the cloud load balancer identified by clb_id.
-        """
-        return self.lbs[clb_id]
-
-    def __contains__(self, clb_id):
+    def lb_in_region(self, clb_id):
         """
         Returns true if the CLB ID is registered with our list of load
         balancers.
         """
-        for i in self.lbs:
-            if i == clb_id:
-                return True
-        return False
+        return clb_id in self.lbs
 
     def add_load_balancer(self, tenant_id, lb_info, lb_id, current_timestamp):
         """

--- a/mimic/plugins/loadbalancer_plugin.py
+++ b/mimic/plugins/loadbalancer_plugin.py
@@ -1,6 +1,7 @@
 """
 Plugin for Rackspace cloud load balancer mock.
 """
-from mimic.rest.loadbalancer_api import LoadBalancerApi
+from mimic.rest.loadbalancer_api import LoadBalancerApi, LoadBalancerControlApi
 
 loadbalancer = LoadBalancerApi()
+loadbalancer_control = LoadBalancerControlApi()

--- a/mimic/plugins/loadbalancer_plugin.py
+++ b/mimic/plugins/loadbalancer_plugin.py
@@ -4,4 +4,4 @@ Plugin for Rackspace cloud load balancer mock.
 from mimic.rest.loadbalancer_api import LoadBalancerApi, LoadBalancerControlApi
 
 loadbalancer = LoadBalancerApi()
-loadbalancer_control = LoadBalancerControlApi()
+loadbalancer_control = LoadBalancerControlApi(lb_api=loadbalancer)

--- a/mimic/rest/loadbalancer_api.py
+++ b/mimic/rest/loadbalancer_api.py
@@ -13,7 +13,7 @@ from mimic.imimic import IAPIMock
 from mimic.catalog import Entry
 from mimic.catalog import Endpoint
 
-from mimic.model.clb_objects import GlobalCLBCollections
+from mimic.model.clb_objects import GlobalCLBCollections, BadKeysError
 from random import randrange
 
 from mimic.util.helper import invalid_resource, json_dump

--- a/mimic/rest/loadbalancer_api.py
+++ b/mimic/rest/loadbalancer_api.py
@@ -41,8 +41,6 @@ class LoadBalancerApi(object):
         """
         Cloud load balancer entries.
         """
-        # TODO: actually add some entries so load balancers show up in the
-        # service catalog.
         return [
             Entry(tenant_id, "rax:load-balancer", "cloudLoadBalancers",
                   [
@@ -142,7 +140,7 @@ class LoadBalancerControlRegion(object):
         return (self.api_mock.lb_api._get_session(self.session_store, tenant_id)
                 .collection_for_region(self.region))
 
-    @app.route('/v2/<string:tenant_id>/loadbalancer/<string:clb_id>/returnOverride/<int:statusCode>', methods=['POST'])
+    @app.route('/v2/<string:tenant_id>/loadbalancer/<int:clb_id>/returnOverride/<int:statusCode>', methods=['POST'])
     def returnOverride(self, request, tenant_id, clb_id, statusCode):
         """
         Configures the indicated cloud load balancer to always return the given status code,

--- a/mimic/rest/loadbalancer_api.py
+++ b/mimic/rest/loadbalancer_api.py
@@ -117,21 +117,6 @@ class LoadBalancerControlRegion(object):
 
     app = MimicApp()
 
-    def session(self, tenant_id):
-        """
-        Gets a session for a particular tenant, creating one if there isn't
-        one.
-        """
-        tenant_session = self._session_store.session_for_tenant_id(tenant_id)
-        clb_global_collection = tenant_session.data_for_api(
-            self._api_mock,
-            lambda: GlobalCLBCollections(
-                tenant_id=tenant_id,
-                clock=self._session_store.clock))
-        clb_region_collection = clb_global_collection.collection_for_region(
-            self.region_name)
-        return clb_region_collection
-
     def _collection_from_tenant(self, tenant_id):
         """
         Retrieve the server collection for this region for the given tenant.

--- a/mimic/rest/loadbalancer_api.py
+++ b/mimic/rest/loadbalancer_api.py
@@ -27,7 +27,6 @@ Request.defaultContentType = 'application/json'
 class LoadBalancerApi(object):
     """
     This class registers the load balancer API in the service catalog.
-    It does NOT implement individual endpoints.
     """
     def __init__(self, regions=["ORD"]):
         """
@@ -81,7 +80,7 @@ class LoadBalancerApi(object):
 class LoadBalancerControlApi(object):
     """
     This class registers the load balancer controller API in the service
-    catalog.  It does NOT implement individual endpoints.
+    catalog.
     """
     def catalog_entries(self, tenant_id):
         """

--- a/mimic/rest/loadbalancer_api.py
+++ b/mimic/rest/loadbalancer_api.py
@@ -121,7 +121,10 @@ class LoadBalancerControlRegion(object):
         return (self.api_mock.lb_api._get_session(self.session_store, tenant_id)
                 .collection_for_region(self.region))
 
-    @app.route('/v2/<string:tenant_id>/loadbalancer/<int:clb_id>/setAttr', methods=['POST'])
+    @app.route(
+        '/v2/<string:tenant_id>/loadbalancer/<int:clb_id>/attributes',
+        methods=['PATCH']
+    )
     def set_attributes(self, request, tenant_id, clb_id):
         """
         Alters the supported attributes of the CLB to supported values.  To

--- a/mimic/rest/loadbalancer_api.py
+++ b/mimic/rest/loadbalancer_api.py
@@ -64,6 +64,8 @@ class LoadBalancerControlApi(object):
     """
     Rest endpoints for mocked Load Balancer controller api.
     """
+    app = MimicApp()
+
     def __init__(self, regions=["ORD"]):
         """
         Create an API with the specified regions.
@@ -92,6 +94,16 @@ class LoadBalancerControlApi(object):
         lbc_region = LoadBalancerControlRegion(self, uri_prefix,
                                                session_store, region)
         return lbc_region.app.resource()
+
+    @app.route('/v2/<string:unused_tenant_id>/loadbalancer/<string:clb_id>/returnOverride/<int:statusCode>', methods=['POST'])
+    def returnOverride(self, request, clb_id, statusCode):
+        """
+        Configures the indicated cloud load balancer to always return the given status code,
+        regardless of operation invoked.  To return back to normal behavior, use 0 for the
+        status code.
+        """
+        request.setResponseCode(422)
+        return "You are NOT a teapot."
 
 
 class LoadBalancerControlRegion(object):

--- a/mimic/rest/loadbalancer_api.py
+++ b/mimic/rest/loadbalancer_api.py
@@ -34,7 +34,6 @@ class LoadBalancerApi(object):
         Create an API with the specified regions.
         """
         self._regions = regions
-        self.session_store = None
 
     def catalog_entries(self, tenant_id):
         """
@@ -54,7 +53,6 @@ class LoadBalancerApi(object):
         Get an :obj:`twisted.web.iweb.IResource` for the given URI prefix;
         implement :obj:`IAPIMock`.
         """
-        self.session_store = session_store
         lb_region = LoadBalancerRegion(self, uri_prefix, session_store,
                                        region)
         return lb_region.app.resource()
@@ -105,7 +103,7 @@ class LoadBalancerControlApi(object):
         implement :obj:`IAPIMock`.
         """
         lbc_region = LoadBalancerControlRegion(api_mock=self, uri_prefix=uri_prefix,
-                                               session_store=self.lb_api.session_store, region=region)
+                                               session_store=session_store, region=region)
         return lbc_region.app.resource()
 
 

--- a/mimic/rest/loadbalancer_api.py
+++ b/mimic/rest/loadbalancer_api.py
@@ -148,7 +148,6 @@ class LoadBalancerControlRegion(object):
         any original values yourself.
         """
         regional_lbs = self._collection_from_tenant(tenant_id)
-        print("Looking for CLB {}".format(clb_id))
         if clb_id not in regional_lbs:
             request.setResponseCode(404)
             return json.dumps({
@@ -174,7 +173,7 @@ class LoadBalancerControlRegion(object):
                     "code": 400,
                 })
 
-        regional_lbs[clb_id].set_attributes(clb_id, content)
+        regional_lbs.set_attributes(clb_id, content)
         request.setResponseCode(204)
         return b''
 

--- a/mimic/rest/loadbalancer_api.py
+++ b/mimic/rest/loadbalancer_api.py
@@ -163,19 +163,17 @@ class LoadBalancerControlRegion(object):
             request.setResponseCode(400)
             return json.dumps(invalid_resource("Invalid JSON request body"))
 
-        if "status" in content:
-            if content["status"] not in [
-                "ACTIVE", "ERROR", "PENDING_DELETE", "PENDING_UPDATE"
-            ]:
-                request.setResponseCode(400)
-                return json.dumps({
-                    "message": "Invalid status.",
-                    "code": 400,
-                })
-
-        regional_lbs.set_attributes(clb_id, content)
-        request.setResponseCode(204)
-        return b''
+        try:
+            regional_lbs.set_attributes(clb_id, content)
+        except BadKeysError, bke:
+            request.setResponseCode(400)
+            return json.dumps({
+                "message": str(bke),
+                "code": 400,
+            })
+        else:
+            request.setResponseCode(204)
+            return b''
 
 
 class LoadBalancerRegion(object):

--- a/mimic/rest/loadbalancer_api.py
+++ b/mimic/rest/loadbalancer_api.py
@@ -72,7 +72,7 @@ class LoadBalancerApi(object):
         """
         return (
             session_store.session_for_tenant_id(tenant_id)
-            .data_for_api(self, lambda: GlobalServerCollections(
+            .data_for_api(self, lambda: GlobalCLBCollections(
                 tenant_id=tenant_id,
                 clock=session_store.clock
             ))

--- a/mimic/rest/loadbalancer_api.py
+++ b/mimic/rest/loadbalancer_api.py
@@ -135,7 +135,7 @@ class LoadBalancerControlRegion(object):
         if not regional_lbs.lb_in_region(clb_id):
             request.setResponseCode(404)
             return json.dumps({
-                "message": "Tenant {} doesn't own load balancer {}".format(
+                "message": "Tenant {0} doesn't own load balancer {1}".format(
                     tenant_id, clb_id
                 ),
                 "code": 404,

--- a/mimic/rest/loadbalancer_api.py
+++ b/mimic/rest/loadbalancer_api.py
@@ -148,7 +148,7 @@ class LoadBalancerControlRegion(object):
         any original values yourself.
         """
         regional_lbs = self._collection_from_tenant(tenant_id)
-        if clb_id not in regional_lbs:
+        if not regional_lbs.lb_in_region(clb_id):
             request.setResponseCode(404)
             return json.dumps({
                 "message": "Tenant {} doesn't own load balancer {}".format(

--- a/mimic/rest/loadbalancer_api.py
+++ b/mimic/rest/loadbalancer_api.py
@@ -13,7 +13,9 @@ from mimic.imimic import IAPIMock
 from mimic.catalog import Entry
 from mimic.catalog import Endpoint
 
-from mimic.model.clb_objects import GlobalCLBCollections, BadKeysError
+from mimic.model.clb_objects import (
+    GlobalCLBCollections, BadKeysError, BadValueError
+)
 from random import randrange
 
 from mimic.util.helper import invalid_resource, json_dump
@@ -153,6 +155,12 @@ class LoadBalancerControlRegion(object):
             request.setResponseCode(400)
             return json.dumps({
                 "message": str(bke),
+                "code": 400,
+            })
+        except BadValueError, bve:
+            request.setResponseCode(400)
+            return json.dumps({
+                "message": str(bve),
                 "code": 400,
             })
         else:

--- a/mimic/test/test_core.py
+++ b/mimic/test/test_core.py
@@ -30,7 +30,7 @@ class CoreBuildingTests(SynchronousTestCase):
         """
         core = MimicCore.fromPlugins(Clock())
         plugin_apis = set((
-            glance_plugin.glance
+            glance_plugin.glance,
             loadbalancer_plugin.loadbalancer,
             loadbalancer_plugin.loadbalancer_control,
             maas_plugin.maas,

--- a/mimic/test/test_core.py
+++ b/mimic/test/test_core.py
@@ -31,7 +31,7 @@ class CoreBuildingTests(SynchronousTestCase):
         core = MimicCore.fromPlugins(Clock())
         plugin_apis = set((
             nova_plugin.nova, loadbalancer_plugin.loadbalancer,
-            loadbalancer_plugin.loadbalancer_control swift_plugin.swift,
+            loadbalancer_plugin.loadbalancer_control, swift_plugin.swift,
             queue_plugin.queue, maas_plugin.maas,
             rackconnect_v3_plugin.rackconnect, nova_plugin.nova_control_api,
             glance_plugin.glance

--- a/mimic/test/test_core.py
+++ b/mimic/test/test_core.py
@@ -30,11 +30,15 @@ class CoreBuildingTests(SynchronousTestCase):
         """
         core = MimicCore.fromPlugins(Clock())
         plugin_apis = set((
-            nova_plugin.nova, loadbalancer_plugin.loadbalancer,
-            loadbalancer_plugin.loadbalancer_control, swift_plugin.swift,
-            queue_plugin.queue, maas_plugin.maas,
-            rackconnect_v3_plugin.rackconnect, nova_plugin.nova_control_api,
             glance_plugin.glance
+            loadbalancer_plugin.loadbalancer,
+            loadbalancer_plugin.loadbalancer_control,
+            maas_plugin.maas,
+            nova_plugin.nova,
+            nova_plugin.nova_control_api,
+            queue_plugin.queue,
+            rackconnect_v3_plugin.rackconnect,
+            swift_plugin.swift,
         ))
         self.assertEqual(
             plugin_apis,

--- a/mimic/test/test_core.py
+++ b/mimic/test/test_core.py
@@ -29,10 +29,13 @@ class CoreBuildingTests(SynchronousTestCase):
         :class:`MimicCore`, the nova and loadbalancer plugins are included.
         """
         core = MimicCore.fromPlugins(Clock())
-        plugin_apis = set((nova_plugin.nova, loadbalancer_plugin.loadbalancer,
-                           swift_plugin.swift, queue_plugin.queue,
-                           maas_plugin.maas, rackconnect_v3_plugin.rackconnect,
-                           nova_plugin.nova_control_api, glance_plugin.glance))
+        plugin_apis = set((
+            nova_plugin.nova, loadbalancer_plugin.loadbalancer,
+            loadbalancer_plugin.loadbalancer_control swift_plugin.swift,
+            queue_plugin.queue, maas_plugin.maas,
+            rackconnect_v3_plugin.rackconnect, nova_plugin.nova_control_api,
+            glance_plugin.glance
+        ))
         self.assertEqual(
             plugin_apis,
             set(core._uuid_to_api.values()))

--- a/mimic/test/test_loadbalancer.py
+++ b/mimic/test/test_loadbalancer.py
@@ -112,7 +112,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
 
     def test_lb_status_changes_as_requested(self):
         """
-        Clients can ``POST`` to the ``.../loadbalancer/<lb-id>/setAttr``
+        Clients can ``PATCH`` to the ``.../loadbalancer/<lb-id>/attributes``
         :obj:`LoadBalancerControlApi` endpoint in order to change the
         ``status`` attribute on the load balancer identified by the given
         load-balancer ID for the same tenant in the :obj:`LoadBalancerApi`.
@@ -123,7 +123,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
         ctl_uri = self.helper.auth.get_service_endpoint("cloudLoadBalancerControl", "ORD")
         lb_id = self._create_loadbalancer('test_lb')
         set_attributes_req = request(
-            self, self.root, "POST", "{}/loadbalancer/{}/setAttr".format(
+            self, self.root, "PATCH", "{0}/loadbalancer/{1}/setAttr".format(
                 ctl_uri, lb_id
             ),
             '{"status": "PENDING_DELETE"}'

--- a/mimic/test/test_loadbalancer.py
+++ b/mimic/test/test_loadbalancer.py
@@ -120,7 +120,6 @@ class LoadbalancerAPITests(SynchronousTestCase):
         This attribute controls the status code returned when the load balancer
         is retrieved by a ``GET`` request.
         """
-        api_uri = self.uri
         ctl_uri = self.helper.auth.get_service_endpoint("cloudLoadBalancerControl", "ORD")
         lb_id = self._create_loadbalancer('test_lb')
         set_attributes_req = request(

--- a/mimic/test/test_loadbalancer.py
+++ b/mimic/test/test_loadbalancer.py
@@ -112,8 +112,13 @@ class LoadbalancerAPITests(SynchronousTestCase):
 
     def test_lb_status_changes_as_requested(self):
         """
-        Perhaps a bit mislabeled, this test exercises the endpoint that causes
-        a load balancer to return a specific status.
+        Clients can ``POST`` to the ``.../loadbalancer/<lb-id>/setAttr``
+        :obj:`LoadBalancerControlApi` endpoint in order to change the
+        ``status`` attribute on the load balancer identified by the given
+        load-balancer ID for the same tenant in the :obj:`LoadBalancerApi`.
+
+        This attribute controls the status code returned when the load balancer
+        is retrieved by a ``GET`` request.
         """
         api_uri = self.uri
         ctl_uri = self.helper.auth.get_service_endpoint("cloudLoadBalancerControl", "ORD")

--- a/mimic/test/test_loadbalancer.py
+++ b/mimic/test/test_loadbalancer.py
@@ -109,6 +109,16 @@ class LoadbalancerAPITests(SynchronousTestCase):
         create_lb_response_body = self.successResultOf(treq.json_content(create_lb_response))
         return create_lb_response_body['loadBalancer']['id']
 
+    def test_return_override(self):
+        """
+        Perhaps a bit mislabeled, this test exercises the endpoint that causes a load balancer to return a specific response code for all
+        requests.
+        """
+        input_lb_id = 13579  # taken from above
+        return_override_req = request(self, self.root, "POST", "{}/loadbalancer/{}/returnOverride/{}".format(self.uri, input_lb_id, 422))
+        return_override_resp = self.successResultOf(return_override_req)
+        self.assertEqual(return_override_resp.code, 204)
+
     def test_multiple_regions_multiple_endpoints(self):
         """
         API object created with multiple regions has multiple entries

--- a/mimic/test/test_loadbalancer.py
+++ b/mimic/test/test_loadbalancer.py
@@ -123,7 +123,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
         ctl_uri = self.helper.auth.get_service_endpoint("cloudLoadBalancerControl", "ORD")
         lb_id = self._create_loadbalancer('test_lb')
         set_attributes_req = request(
-            self, self.root, "PATCH", "{0}/loadbalancer/{1}/setAttr".format(
+            self, self.root, "PATCH", "{0}/loadbalancer/{1}/attributes".format(
                 ctl_uri, lb_id
             ),
             '{"status": "PENDING_DELETE"}'

--- a/mimic/test/test_loadbalancer.py
+++ b/mimic/test/test_loadbalancer.py
@@ -11,6 +11,7 @@ from mimic.test.fixtures import APIMockHelper, TenantAuthentication
 from mimic.rest.loadbalancer_api import LoadBalancerApi, LoadBalancerControlApi
 from mimic.test.helpers import request_with_content, request
 from mimic.util.helper import EMPTY_RESPONSE
+import attr
 
 
 class ResponseGenerationTests(SynchronousTestCase):
@@ -76,6 +77,19 @@ class ResponseGenerationTests(SynchronousTestCase):
         self.assertEqual(actual, lb_example)
 
 
+@attr.s
+class _CLBChangeResponseAndID(object):
+    """
+    A simple data structure intended to conveniently communicate the results
+    of issuing a CLB control plane request.
+    """
+    resp = attr.ib()
+    "The response returned from the .../attributes PATCH request."
+
+    lb_id = attr.ib()
+    "The CLB ID used for the purposes of performing the test."
+
+
 class LoadbalancerAPITests(SynchronousTestCase):
     """
     Tests for the Loadbalancer plugin API
@@ -110,6 +124,36 @@ class LoadbalancerAPITests(SynchronousTestCase):
         create_lb_response_body = self.successResultOf(treq.json_content(create_lb_response))
         return create_lb_response_body['loadBalancer']['id']
 
+    def _patch_attributes_request(self, lb_id_offset=0, status_key=None):
+        """
+        Creates a CLB for the tenant, then attempts to patch its status using
+        the CLB control plane endpoint.
+
+        :param int lb_id_offset: Defaults to 0.  If provided, the CLB that is
+            created for the tenant will be referenced in the patch request
+            offset by this much.
+        :param str status_key: Defaults to '"status"'.  If provided, the patch
+            will be made against this member of the CLB's state.
+
+        :return: An instance of _CLBChangeResponseAndID.  The `resp` attribute
+            will refer to Mimic's response object; `code` will be set to the
+            HTTP result code from the request.
+        """
+        ctl_uri = self.helper.auth.get_service_endpoint(
+            "cloudLoadBalancerControl", "ORD"
+        )
+        lb_id = self._create_loadbalancer('test_lb') + lb_id_offset
+        status_key = status_key or '"status"'
+        set_attributes_req = request(
+            self, self.root, "PATCH", "{0}/loadbalancer/{1}/attributes".format(
+                ctl_uri, lb_id
+            ),
+            '{{{0}: "PENDING_DELETE"}}'.format(status_key)
+        )
+        return _CLBChangeResponseAndID(
+            resp=self.successResultOf(set_attributes_req), lb_id=lb_id
+        )
+
     def test_lb_status_changes_as_requested(self):
         """
         Clients can ``PATCH`` to the ``.../loadbalancer/<lb-id>/attributes``
@@ -120,24 +164,40 @@ class LoadbalancerAPITests(SynchronousTestCase):
         This attribute controls the status code returned when the load balancer
         is retrieved by a ``GET`` request.
         """
-        ctl_uri = self.helper.auth.get_service_endpoint("cloudLoadBalancerControl", "ORD")
-        lb_id = self._create_loadbalancer('test_lb')
-        set_attributes_req = request(
-            self, self.root, "PATCH", "{0}/loadbalancer/{1}/attributes".format(
-                ctl_uri, lb_id
-            ),
-            '{"status": "PENDING_DELETE"}'
-        )
-        set_attributes_resp = self.successResultOf(set_attributes_req)
-        self.assertEqual(set_attributes_resp.code, 204)
+        r = self._patch_attributes_request()
+        self.assertEqual(r.resp.code, 204)
 
-        get_lb = request(self, self.root, "GET", self.uri + '/loadbalancers/' + str(lb_id))
+        get_lb = request(self, self.root, "GET", self.uri + '/loadbalancers/' + str(r.lb_id))
         get_lb_response = self.successResultOf(get_lb)
         get_lb_response_body = self.successResultOf(
             treq.json_content(get_lb_response)
         )["loadBalancer"]
         self.assertEqual(get_lb_response.code, 200)
         self.assertEqual(get_lb_response_body["status"], "PENDING_DELETE")
+
+    def test_lb_status_change_with_illegal_json(self):
+        """
+        In the event the user sends a malformed request body to the
+        .../attributes endpoint, we should get back a 400 Bad Request.
+        """
+        r = self._patch_attributes_request(status_key="\"status'")
+        self.assertEqual(r.resp.code, 400)
+
+    def test_lb_status_change_with_bad_keys(self):
+        """
+        In the event the user sends a request to alter a key which isn't
+        supported, we should get back a 400 Bad Request as well.
+        """
+        r = self._patch_attributes_request(status_key="\"stats\"")
+        self.assertEqual(r.resp.code, 400)
+
+    def test_lb_status_change_against_undefined_clb(self):
+        """
+        In the event the user sends a request to alter a key on a load balancer
+        which doesn't belong to the requestor, we should get back a 404 code.
+        """
+        r = self._patch_attributes_request(lb_id_offset=1000)
+        self.assertEqual(r.resp.code, 404)
 
     def test_multiple_regions_multiple_endpoints(self):
         """

--- a/mimic/test/test_loadbalancer.py
+++ b/mimic/test/test_loadbalancer.py
@@ -118,18 +118,20 @@ class LoadbalancerAPITests(SynchronousTestCase):
         api_uri = self.uri
         ctl_uri = self.helper.auth.get_service_endpoint("cloudLoadBalancerControl", "ORD")
         lb_id = self._create_loadbalancer('test_lb')
-        return_override_req = request(
+        set_attributes_req = request(
             self, self.root, "POST", "{}/loadbalancer/{}/setAttr".format(
                 ctl_uri, lb_id
             ),
             '{"status": "PENDING_DELETE"}'
         )
-        return_override_resp = self.successResultOf(return_override_req)
-        self.assertEqual(return_override_resp.code, 204)
+        set_attributes_resp = self.successResultOf(set_attributes_req)
+        self.assertEqual(set_attributes_resp.code, 204)
 
         get_lb = request(self, self.root, "GET", self.uri + '/loadbalancers/' + str(lb_id))
         get_lb_response = self.successResultOf(get_lb)
-        get_lb_response_body = self.successResultOf(treq.json_content(get_lb_response))
+        get_lb_response_body = self.successResultOf(
+            treq.json_content(get_lb_response)
+        )["loadBalancer"]
         self.assertEqual(get_lb_response.code, 200)
         self.assertEqual(get_lb_response_body["status"], "PENDING_DELETE")
 


### PR DESCRIPTION
This PR allows a client to alter a CLB's status setting from within an integration test.