### PR TITLE
“Changes Since” filter

### DIFF
--- a/mimic/model/nova_objects.py
+++ b/mimic/model/nova_objects.py
@@ -762,7 +762,7 @@ class RegionalServerCollection(object):
 
         if changes_since is not None:
             since = timestamp_to_seconds(changes_since)
-            to_be_listed = filter(lambda s: s.update_time > since, to_be_listed)
+            to_be_listed = filter(lambda s: s.update_time >= since, to_be_listed)
 
         # marker can be passed without limit, in which case the whole server
         # list, after the server that matches the marker, is returned

--- a/mimic/model/nova_objects.py
+++ b/mimic/model/nova_objects.py
@@ -751,7 +751,8 @@ class RegionalServerCollection(object):
         """
         Request the list JSON for all servers.
 
-        :param str changes_since: ISO8601 formatted datetime
+        :param str changes_since: ISO8601 formatted datetime. Based on
+            http://docs.rackspace.com/servers/api/v2/cs-devguide/content/ChangesSince.html
 
         Note: only supports filtering by name right now, but will need to
         support more going forward.

--- a/mimic/model/nova_objects.py
+++ b/mimic/model/nova_objects.py
@@ -15,6 +15,7 @@ from six import string_types
 from mimic.util.helper import (
     seconds_to_timestamp,
     random_string,
+    timestamp_to_seconds
 )
 
 from mimic.model.behaviors import (
@@ -218,6 +219,13 @@ class Server(object):
             }
         }
 
+    def set_metadata(self, metadata):
+        """
+        Replace all metadata with given metadata
+        """
+        self.metadata = metadata
+        self.update_time = self.collection.clock.seconds()
+
     def set_metadata_item(self, key, value):
         """
         Set a metadata item on the server.
@@ -236,6 +244,15 @@ class Server(object):
                 "Invalid metadata: The input is not a string or unicode"))
 
         self.metadata[key] = value
+        self.update_time = self.collection.clock.seconds()
+
+    def update_status(self, status):
+        """
+        Update status on the server. This will also update the `update_time`
+        of the server
+        """
+        self.status = status
+        self.update_time = self.collection.clock.seconds()
 
     @classmethod
     def validate_metadata(cls, metadata, max_metadata_items=40):
@@ -549,10 +566,11 @@ def create_building_behavior(parameters):
 
     @default_with_hook
     def set_building(server):
-        server.status = u"BUILD"
+        server.update_status(u"BUILD")
         server.collection.clock.callLater(
             duration,
-            lambda: setattr(server, "status", u"ACTIVE"))
+            server.update_status,
+            u"ACTIVE")
     return set_building
 
 
@@ -567,7 +585,7 @@ def create_error_status_behavior(parameters=None):
     """
     @default_with_hook
     def set_error(server):
-        server.status = u"ERROR"
+        server.update_status(u"ERROR")
     return set_error
 
 
@@ -587,10 +605,11 @@ def active_then_error(parameters):
 
     @default_with_hook
     def fail_later(server):
-        server.status = u"ACTIVE"
+        server.update_status(u"ACTIVE")
         server.collection.clock.callLater(
             duration,
-            lambda: setattr(server, "status", u"ERROR"))
+            server.update_status,
+            u"ERROR")
     return fail_later
 
 
@@ -681,7 +700,7 @@ class RegionalServerCollection(object):
         Retrieve a :obj:`Server` object by its ID.
         """
         for server in self.servers:
-            if server.server_id == server_id:
+            if server.server_id == server_id and server.status != u"DELETED":
                 return server
 
     def request_creation(self, creation_http_request, creation_json,
@@ -728,9 +747,11 @@ class RegionalServerCollection(object):
         return dumps({"addresses": server.addresses_json()})
 
     def request_list(self, http_get_request, include_details, absolutize_url,
-                     name=u"", limit=None, marker=None):
+                     name=u"", limit=None, marker=None, changes_since=None):
         """
         Request the list JSON for all servers.
+
+        :param str changes_since: ISO8601 formatted datetime
 
         Note: only supports filtering by name right now, but will need to
         support more going forward.
@@ -738,6 +759,10 @@ class RegionalServerCollection(object):
         Pagination behavior verified against Rackspace Nova as of 2015-04-29.
         """
         to_be_listed = self.servers
+
+        if changes_since is not None:
+            since = timestamp_to_seconds(changes_since)
+            to_be_listed = filter(lambda s: s.update_time > since, to_be_listed)
 
         # marker can be passed without limit, in which case the whole server
         # list, after the server that matches the marker, is returned
@@ -770,6 +795,9 @@ class RegionalServerCollection(object):
                                          http_get_request))
 
             to_be_listed = to_be_listed[:limit]
+
+        if changes_since is None:
+            to_be_listed = filter(lambda s: s.status != u"DELETED", to_be_listed)
 
         result = {
             "servers": [
@@ -819,7 +847,7 @@ class RegionalServerCollection(object):
                 http_delete_request.setResponseCode(500)
                 return b''
         http_delete_request.setResponseCode(204)
-        self.servers.remove(server)
+        server.update_status(u"DELETED")
         return b''
 
 

--- a/mimic/rest/nova_api.py
+++ b/mimic/rest/nova_api.py
@@ -186,7 +186,7 @@ class NovaControlApiRegion(object):
             request.setResponseCode(BAD_REQUEST)
             return b''
         for server in servers:
-            server.status = statuses_description[server.server_id]
+            server.update_status(statuses_description[server.server_id])
         request.setResponseCode(CREATED)
         return b''
 
@@ -295,7 +295,8 @@ class NovaRegion(object):
                 request, include_details=True, absolutize_url=self.url,
                 name=request.args.get('name', [u""])[0],
                 limit=request.args.get('limit', [None])[0],
-                marker=request.args.get('marker', [None])[0]
+                marker=request.args.get('marker', [None])[0],
+                changes_since=request.args.get('changes-since', [None])[0]
             )
         )
 
@@ -427,7 +428,7 @@ class ServerMetadata(object):
         except LimitError as e:
             return json.dumps(forbidden(e.nova_message, request))
 
-        self._server.metadata = content['metadata']
+        self._server.set_metadata(content['metadata'])
         return json.dumps({'metadata': content['metadata']})
 
     @app.route('/<key>', methods=['PUT'])

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -604,6 +604,7 @@ class NovaAPIChangesSinceTests(SynchronousTestCase):
         Returns servers created after given time
         """
         self.assertEqual(self.list_servers(0.5), [self.server2])
+        self.assertEqual(self.list_servers(1.0), [self.server2])
 
     def test_returns_deleted_servers(self):
         """

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -71,7 +71,7 @@ def update_metdata_item(helper, server_id, key, value):
     helper.test_case.assertEqual(resp.code, 200)
 
 
-def update_metdata(helper, metadata):
+def update_metdata(helper, server_id, metadata):
     """
     Update metadata
     """

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -7,16 +7,17 @@ from urllib import urlencode
 from urlparse import parse_qs
 
 from testtools.matchers import (
-    Equals, MatchesDict, MatchesListwise, StartsWith)
+    ContainsDict, Equals, MatchesDict, MatchesListwise, StartsWith)
 
 import treq
 
 from twisted.internet.defer import gatherResults
 from twisted.trial.unittest import SynchronousTestCase
 
-from mimic.test.helpers import json_request, request, validate_link_json
+from mimic.test.helpers import json_request, request, request_with_content, validate_link_json
 from mimic.rest.nova_api import NovaApi, NovaControlApi
 from mimic.test.fixtures import APIMockHelper, TenantAuthentication
+from mimic.util.helper import seconds_to_timestamp
 
 
 def status_of_server(test_case, server_id):
@@ -45,6 +46,53 @@ def quick_create_server(helper, region="ORD"):
     return helper.test_case.successResultOf(
         treq.json_content(helper.test_case.successResultOf(response))
     )["server"]["id"]
+
+
+def delete_server(helper, server_id):
+    """
+    Delete server
+    """
+    d = request_with_content(
+        helper.test_case, helper.root, "DELETE",
+        '{}/servers/{}'.format(helper.uri, server_id))
+    resp, body = helper.test_case.successResultOf(d)
+    helper.test_case.assertEqual(resp.code, 204)
+
+
+def update_metdata_item(helper, server_id, key, value):
+    """
+    Update metadata item
+    """
+    d = request_with_content(
+        helper.test_case, helper.root, "PUT",
+        '{}/servers/{}/metadata/{}'.format(helper.uri, server_id, key),
+        json.dumps({'meta': {key: value}}))
+    resp, body = helper.test_case.successResultOf(d)
+    helper.test_case.assertEqual(resp.code, 200)
+
+
+def update_metdata(helper, metadata):
+    """
+    Update metadata
+    """
+    d = request_with_content(
+        helper.test_case, helper.root, "PUT",
+        '{}/servers/{}/metadata'.format(helper.uri, server_id),
+        json.dumps({'metadata': metadata}))
+    resp, body = helper.test_case.successResultOf(d)
+    helper.test_case.assertEqual(resp.code, 200)
+
+
+def update_status(helper, control_endpoint, server_id, status):
+    """
+    Update server status
+    """
+    d = request_with_content(
+        helper.test_case, helper.root, "POST",
+        control_endpoint + "/attributes/",
+        json.dumps({"status": {server_id: status}}))
+    resp, body = helper.test_case.successResultOf(d)
+    helper.test_case.assertEqual(resp.code, 201)
 
 
 class NovaAPITests(SynchronousTestCase):
@@ -335,6 +383,11 @@ class NovaAPITests(SynchronousTestCase):
         self.assertEqual(delete_server_response.code, 204)
         self.assertEqual(self.successResultOf(treq.content(delete_server_response)),
                          b"")
+        # Get and see if server actually got deleted
+        get_server = request(
+            self, self.root, "GET", self.uri + '/servers/' + self.server_id)
+        get_server_response = self.successResultOf(get_server)
+        self.assertEqual(get_server_response.code, 404)
 
     def test_delete_server_negative(self):
         """
@@ -499,6 +552,94 @@ class NovaAPITests(SynchronousTestCase):
         second_status = status_of_server(self, second_server_id)
         self.assertEqual(status, "ERROR")
         self.assertEqual(second_status, "BUILD")
+
+
+class NovaAPIChangesSinceTests(SynchronousTestCase):
+    """
+    Tests for listing servers with changes-since filter
+    """
+
+    def setUp(self):
+        """
+        Create a :obj:`MimicCore` with :obj:`NovaApi` as the only plugin,
+        and create a server
+        """
+        nova_api = NovaApi(["ORD", "MIMIC"])
+        helper = self.helper = APIMockHelper(
+            self, [nova_api, NovaControlApi(nova_api=nova_api)]
+        )
+        self.root = helper.root
+        self.uri = helper.uri
+        self.clock = helper.clock
+        self.control_endpoint = helper.auth.get_service_endpoint(
+            "cloudServersBehavior",
+            "ORD")
+        self.server1 = quick_create_server(helper)
+        self.clock.advance(1)
+        self.server2 = quick_create_server(helper)
+
+    def list_servers_detail(self, since):
+        changes_since = seconds_to_timestamp(since)
+        params = urlencode({"changes-since": changes_since})
+        resp, body = self.successResultOf(
+            json_request(
+                self, self.root, "GET",
+                '{}/servers/detail?{}'.format(self.uri, params)))
+        self.assertEqual(resp.code, 200)
+        return body['servers']
+
+    def list_servers(self, since):
+        servers = self.list_servers_detail(since)
+        return [s['id'] for s in servers]
+
+    def test_no_changes(self):
+        """
+        Returns no servers if nothing has changed since time given
+        """
+        self.clock.advance(3)
+        self.assertEqual(self.list_servers(2), [])
+
+    def test_returns_created_servers(self):
+        """
+        Returns servers created after given time
+        """
+        self.assertEqual(self.list_servers(0.5), [self.server2])
+
+    def test_returns_deleted_servers(self):
+        """
+        Returns DELETED servers if they've been deleted since the time given
+        """
+        self.clock.advance(1)
+        delete_server(self.helper, self.server1)
+        self.clock.advance(2)
+        matcher = MatchesListwise(
+            [ContainsDict({"status": Equals(u"DELETED"), "id": Equals(self.server1)})])
+        mismatch = matcher.match(self.list_servers_detail(1.5))
+        self.assertIsNone(mismatch)
+
+    def test_returns_updated_status_servers(self):
+        """
+        Returns servers whose status has been updated since given time
+        """
+        self.clock.advance(1)
+        update_status(self.helper, self.control_endpoint, self.server2, u"ERROR")
+        self.assertEqual(self.list_servers(1.5), [self.server2])
+
+    def test_returns_updated_metadata_servers(self):
+        """
+        Returns servers whose metadata has changes since given time
+        """
+        self.clock.advance(1)
+        update_metdata_item(self.helper, self.server1, "a", "b")
+        self.assertEqual(self.list_servers(1.5), [self.server1])
+
+    def test_returns_replaced_metadata_servers(self):
+        """
+        Returns servers whose metadata has been replaced since given time
+        """
+        self.clock.advance(1)
+        update_metdata(self.helper, self.server1, {"a": "b"})
+        self.assertEqual(self.list_servers(1.5), [self.server1])
 
 
 class NovaAPIListServerPaginationTests(SynchronousTestCase):

--- a/mimic/test/test_util.py
+++ b/mimic/test/test_util.py
@@ -12,6 +12,11 @@ class HelperTests(SynchronousTestCase):
     """
     Tests for :mod:`mimic.util.helper`
     """
+
+    matches = [(0, "1970-01-01T00:00:00.000000Z"),
+               (1.5, "1970-01-01T00:00:01.500000Z"),
+               (121.4005, "1970-01-01T00:02:01.400500Z")]
+
     def _validate_ipv4_address(self, address, *prefixes):
         nums = [int(x) for x in address.split('.')]
         self.assertEqual(4, len(nums))
@@ -50,23 +55,28 @@ class HelperTests(SynchronousTestCase):
         default format string of ``%Y-%m-%dT%H:%M:%S.%fZ`` if no format
         string is provided.
         """
-        matches = [(0, "1970-01-01T00:00:00.000000Z"),
-                   (1.5, "1970-01-01T00:00:01.500000Z"),
-                   (121.4005, "1970-01-01T00:02:01.400500Z")]
-        for match in matches:
-            self.assertEqual(match[1], helper.seconds_to_timestamp(match[0]))
+        for seconds, timestamp in self.matches:
+            self.assertEqual(timestamp, helper.seconds_to_timestamp(seconds))
 
     def test_seconds_to_timestamp_provided_timestamp(self):
         """
         :func:`helper.seconds_to_timestamp` uses the provided timestamp format
         to format the seconds.
         """
-        matches = [("%m-%d-%Y %H:%M:%S", "01-01-1970 00:00:00"),
+        formats = [("%m-%d-%Y %H:%M:%S", "01-01-1970 00:00:00"),
                    ("%Y-%m-%d", "1970-01-01"),
                    ("%H %M %S (%f)", "00 00 00 (000000)")]
-        for match in matches:
-            self.assertEqual(match[1],
-                             helper.seconds_to_timestamp(0, match[0]))
+        for fmt, timestamp in formats:
+            self.assertEqual(timestamp,
+                             helper.seconds_to_timestamp(0, fmt))
+
+    def test_timestamp_to_seconds(self):
+        """
+        :func:`helper.timestamp_to_seconds` returns a seconds since EPOCH
+        matching the corresponding timestamp given in ISO8601 format
+        """
+        for seconds, timestamp in self.matches:
+            self.assertEqual(seconds, helper.timestamp_to_seconds(timestamp))
 
 
 class TestHelperTests(SynchronousTestCase):

--- a/mimic/test/test_util.py
+++ b/mimic/test/test_util.py
@@ -75,7 +75,10 @@ class HelperTests(SynchronousTestCase):
         :func:`helper.timestamp_to_seconds` returns a seconds since EPOCH
         matching the corresponding timestamp given in ISO8601 format
         """
-        for seconds, timestamp in self.matches:
+
+        local_matches = [(0, "1970-01-01"), (0, "1970-01-01T00"),
+                         (0, "1970-01-01T00:00"), (1800, "1970-01-01T00-00:30")]
+        for seconds, timestamp in self.matches + local_matches:
             self.assertEqual(seconds, helper.timestamp_to_seconds(timestamp))
 
 

--- a/mimic/util/helper.py
+++ b/mimic/util/helper.py
@@ -7,9 +7,12 @@ Helper methods
 """
 import os
 import string
+import calendar
 from datetime import datetime, timedelta
 import json
 from random import choice, randint
+
+import iso8601
 
 from six import text_type
 
@@ -71,6 +74,18 @@ def seconds_to_timestamp(seconds, format=fmt):
     Return an ISO8601 Zulu timestamp given seconds since the epoch.
     """
     return datetime.utcfromtimestamp(seconds).strftime(format)
+
+
+def timestamp_to_seconds(timestamp):
+    """
+    Return epoch from an ISO8601 Zulu timestamp
+
+    :param str timestamp: ISO8601 formatted time
+    :return: EPOCH seconds
+    :rtype: float
+    """
+    dt = iso8601.parse_date(timestamp)
+    return calendar.timegm(dt.utctimetuple()) + dt.microsecond / 1000000.
 
 
 def not_found_response(resource='servers'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ characteristic==14.3.0
 six==1.6.1
 xmltodict==0.9.1
 attrs==15.0.0
+iso8601==0.1.10

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ def setup_options(name, version):
             "six>=1.6.0",
             "xmltodict>=0.9.1",
             "attrs>=15.0.0",
-            "testtools>=1.7.1,<1.8.0"
+            "testtools>=1.7.1,<1.8.0",
+            "iso8601>=0.1.10"
         ],
         package_dir={"mimic": "mimic"},
         packages=find_packages(exclude=[]) + ["twisted.plugins"],


### PR DESCRIPTION
Closes  #252.

- When deleting server, it is marked as DELETED instead of removing it from cache and update_time is updated with latest clock seconds
- The update_time is also updated when changing status or metadata of server
- `GET ../servers/detail` honors changes-since filter based on update_time. It was trivial to implement it for `GET ../servers` but I didn't do it due lazyness of writing similar tests. Morever, autoscale currently uses only detail call. So, `../servers` can be implemented later when required. 