### PR TITLE
Refactor auth API to use credential objects

### DIFF
--- a/mimic/imimic.py
+++ b/mimic/imimic.py
@@ -23,3 +23,22 @@ class IAPIMock(Interface):
         """
         Get a resource for the given region.
         """
+
+
+class ICredential(Interface):
+    """
+    An :obj:`ICredential` provides identity authentication credentials.
+    """
+    def get_session(session_store):  # pragma:nocover
+        """
+        Get a session corresponding to the user and tenant from the given
+        session store.
+
+        :param session_store: The store of all sessions for all tenants for
+            all plugins across all regions.
+        :type session_store: :class:`mimic.session.SessionStore`
+
+        :return: A session corresponding to the user and plugin data for a
+            single tenant for all plugins across all regions.
+        :rtype: :class:`mimic.session.SessionStore`
+        """

--- a/mimic/model/identity.py
+++ b/mimic/model/identity.py
@@ -89,8 +89,10 @@ class PasswordCredentials(object):
 
         :return: a class:`PasswordCredentials` object
         """
-        tenant_id = (json_blob['auth'].get('tenantName', None) or
-                     json_blob['auth'].get('tenantId', None))
+        tenant_id = json_blob['auth'].get('tenantName')
+        if tenant_id is None:
+            tenant_id = json_blob['auth'].get('tenantId')
+
         username = json_blob['auth']['passwordCredentials']['username']
         password = json_blob['auth']['passwordCredentials']['password']
         return cls(username=username, password=password, tenant_id=tenant_id)
@@ -139,8 +141,10 @@ class APIKeyCredentials(object):
         :return: a class:`APIKeyCredentials` object
         """
         creds = json_blob['auth']
-        tenant_id = (creds.get('tenantName', None) or
-                     creds.get('tenantId', None))
+        tenant_id = creds.get('tenantName')
+        if tenant_id is None:
+            tenant_id = creds.get('tenantId')
+
         username = creds['RAX-KSKEY:apiKeyCredentials']['username']
         api_key = creds['RAX-KSKEY:apiKeyCredentials']['apiKey']
         return cls(username=username, api_key=api_key, tenant_id=tenant_id)
@@ -183,8 +187,10 @@ class TokenCredentials(object):
 
         :return: a class:`TokenCredentials` object
         """
-        tenant_id = (json_blob['auth'].get('tenantName', None) or
-                     json_blob['auth'].get('tenantId', None))
+        tenant_id = json_blob['auth'].get('tenantName')
+        if tenant_id is None:
+            tenant_id = json_blob['auth'].get('tenantId')
+
         token = json_blob['auth']['token']['id']
         return cls(token=token, tenant_id=tenant_id)
 

--- a/mimic/model/identity.py
+++ b/mimic/model/identity.py
@@ -28,9 +28,9 @@ class IdentitySession(object):
                           validator=validators.instance_of(bool))
 
 
-class ICredentials(Interface):
+class ICredential(Interface):
     """
-    An :obj:`ICredentials` provides identity authentication credentials.
+    An :obj:`ICredential` provides identity authentication credentials.
     """
     def get_session(session_store):  # pragma:nocover
         """
@@ -41,7 +41,7 @@ class ICredentials(Interface):
         """
 
 
-@implementer(ICredentials)
+@implementer(ICredential)
 @attributes
 class PasswordCredentials(object):
     """
@@ -90,7 +90,7 @@ class PasswordCredentials(object):
         return cls(username=username, password=password, tenant_id=tenant_id)
 
 
-@implementer(ICredentials)
+@implementer(ICredential)
 @attributes
 class APIKeyCredentials(object):
     """
@@ -140,7 +140,7 @@ class APIKeyCredentials(object):
         return cls(username=username, api_key=api_key, tenant_id=tenant_id)
 
 
-@implementer(ICredentials)
+@implementer(ICredential)
 @attributes
 class TokenCredentials(object):
     """
@@ -185,7 +185,7 @@ class TokenCredentials(object):
         return cls(token=token, tenant_id=tenant_id)
 
 
-@implementer(ICredentials)
+@implementer(ICredential)
 @attributes
 class ImpersonationCredentials(object):
     """

--- a/mimic/model/identity.py
+++ b/mimic/model/identity.py
@@ -3,6 +3,8 @@ Models relating to identity.
 """
 from attr import attributes, attr, validators
 
+from zope.interface import Interface, implementer
+
 
 @attributes
 class IdentitySession(object):
@@ -20,3 +22,166 @@ class IdentitySession(object):
 
     identity_admin = attr(default=False,
                           validator=validators.instance_of(bool))
+
+
+class ICredentials(Interface):
+    """
+    An :obj:`ICredentials` provides identity authentication credentials.
+    """
+    def get_session(session_store):  # pragma:nocover
+        """
+        Get a session corresponding to the user and tenant from the given
+        session store.
+
+        :param session_store: a :class:`mimic.session.SessionStore`
+        """
+
+    def from_json(json_blob):  # pragma:nocover
+        """
+        Given a JSON dictionary containing credentials, creates a ICrednetials
+        object.
+        """
+
+
+@implementer(ICredentials)
+@attributes
+class PasswordCredentials(object):
+    """
+    An object representing username/password + optional tenant credentials
+    """
+    username = attr()
+    password = attr()
+    tenant_id = attr(default=None)
+
+    def get_session(self, session_store):
+        """
+        Get a session corresponding to the user and tenant from the given
+        session store.
+
+        :param session_store: a :class:`mimic.session.SessionStore`
+        """
+        return session_store.session_for_username_password(
+            self.username, self.password, self.tenant_id)
+
+    @classmethod
+    def from_json(cls, json_blob):
+        """
+        Given an authentication JSON blob, which should look like:
+
+        ```
+        {
+            "auth": {
+                "passwordCredentials": {
+                    "username": "user",
+                    "password": "pass"
+                },
+                "tenantId": "111111"
+            }
+        }
+        ```
+
+        ``"tenantId"`` is interchanable with ``"tenantName"``, and is
+        optional.
+
+        :return: a class:`PasswordCredentials` object
+        """
+        tenant_id = (json_blob['auth'].get('tenantName', None) or
+                     json_blob['auth'].get('tenantId', None))
+        username = json_blob['auth']['passwordCredentials']['username']
+        password = json_blob['auth']['passwordCredentials']['password']
+        return cls(username=username, password=password, tenant_id=tenant_id)
+
+
+@implementer(ICredentials)
+@attributes
+class APIKeyCredentials(object):
+    """
+    An object representing username/api-key + optional tenant credentials
+    """
+    username = attr()
+    api_key = attr()
+    tenant_id = attr(default=None)
+
+    def get_session(self, session_store):
+        """
+        Get a session corresponding to the user and tenant from the given
+        session store.
+
+        :param session_store: a :class:`mimic.session.SessionStore`
+        """
+        return session_store.session_for_api_key(
+            self.username, self.api_key, self.tenant_id)
+
+    @classmethod
+    def from_json(cls, json_blob):
+        """
+        Given an authentication JSON blob, which should look like:
+
+        ```
+        {
+            "auth": {
+                "RAX-KSKEY:apiKeyCredentials": {
+                    "username": "user",
+                    "apiKey": "key"
+                },
+                "tenantId": "111111"
+            }
+        }
+        ```
+
+        ``"tenantId"`` is interchanable with ``"tenantName"``, and is
+        optional.
+
+        :return: a class:`APIKeyCredentials` object
+        """
+        creds = json_blob['auth']
+        tenant_id = (creds.get('tenantName', None) or
+                     creds.get('tenantId', None))
+        username = creds['RAX-KSKEY:apiKeyCredentials']['username']
+        api_key = creds['RAX-KSKEY:apiKeyCredentials']['apiKey']
+        return cls(username=username, api_key=api_key, tenant_id=tenant_id)
+
+
+@implementer(ICredentials)
+@attributes
+class TokenCredentials(object):
+    """
+    An object representing token + optional tenant credentials
+    """
+    token = attr()
+    tenant_id = attr(validator=validators.instance_of(basestring))
+
+    def get_session(self, session_store):
+        """
+        Get a session corresponding to the user and tenant from the given
+        session store.
+
+        :param session_store: a :class:`mimic.session.SessionStore`
+        """
+        return session_store.session_for_token(self.token, self.tenant_id)
+
+    @classmethod
+    def from_json(cls, json_blob):
+        """
+        Given an authentication JSON blob, which should look like:
+
+        ```
+        {
+            "auth": {
+                "token": {
+                    "id": "my_token"
+                },
+                "tenantId": "111111"
+            }
+        }
+        ```
+
+        ``"tenantId"`` is interchanable with ``"tenantName"``, and is
+        optional.
+
+        :return: a class:`APIKeyCredentials` object
+        """
+        tenant_id = (json_blob['auth'].get('tenantName', None) or
+                     json_blob['auth'].get('tenantId', None))
+        token = json_blob['auth']['token']['id']
+        return cls(token=token, tenant_id=tenant_id)

--- a/mimic/model/identity.py
+++ b/mimic/model/identity.py
@@ -7,7 +7,9 @@ from attr import Factory, attributes, attr, validators
 
 from six import string_types, text_type
 
-from zope.interface import Interface, implementer
+from zope.interface import implementer
+
+from mimic.imimic import ICredential
 
 
 @attributes
@@ -26,25 +28,6 @@ class IdentitySession(object):
 
     identity_admin = attr(default=False,
                           validator=validators.instance_of(bool))
-
-
-class ICredential(Interface):
-    """
-    An :obj:`ICredential` provides identity authentication credentials.
-    """
-    def get_session(session_store):  # pragma:nocover
-        """
-        Get a session corresponding to the user and tenant from the given
-        session store.
-
-        :param session_store: The store of all sessions for all tenants for
-            all plugins across all regions.
-        :type session_store: :class:`mimic.session.SessionStore`
-
-        :return: A session corresponding to the user and plugin data for a
-            single tenant for all plugins across all regions.
-        :rtype: :class:`mimic.session.SessionStore`
-        """
 
 
 @implementer(ICredential)


### PR DESCRIPTION
Split off from #283.
Part of #262.

This creates credential objects for authenticating against Identity, and uses those in the auth api.

Was hoping to just use the objects in the existing code, but determining whether tenant ID is present is handled in the credentials objects, which means if there was an error creating the credentials object, then it's an invalid input error/bad request and should return a 400.

Adding in that logic made the function too complex and it failed to lint. Hence the more heavyweight refactoring of `get_token_and_service_catalog`