### PR TITLE
Provide a default authentication behavior

### DIFF
--- a/mimic/imimic.py
+++ b/mimic/imimic.py
@@ -2,7 +2,7 @@
 Interfaces for Mimic.
 """
 
-from zope.interface import Interface
+from zope.interface import Attribute, Interface
 
 
 class IAPIMock(Interface):
@@ -29,6 +29,9 @@ class ICredential(Interface):
     """
     An :obj:`ICredential` provides identity authentication credentials.
     """
+    type_key = Attribute("The type key to look for in a JSON dictionary "
+                         "representing the credential.")
+
     def get_session(session_store):  # pragma:nocover
         """
         Get a session corresponding to the user and tenant from the given

--- a/mimic/model/identity.py
+++ b/mimic/model/identity.py
@@ -44,6 +44,7 @@ class PasswordCredentials(object):
     username = attr(validator=validators.instance_of(string_types))
     password = attr(validator=validators.instance_of(string_types))
     tenant_id = attr(default=None)
+    type_key = "passwordCredentials"
 
     def get_session(self, session_store):
         """
@@ -76,8 +77,8 @@ class PasswordCredentials(object):
         if tenant_id is None:
             tenant_id = json_blob['auth'].get('tenantId')
 
-        username = json_blob['auth']['passwordCredentials']['username']
-        password = json_blob['auth']['passwordCredentials']['password']
+        username = json_blob['auth'][cls.type_key]['username']
+        password = json_blob['auth'][cls.type_key]['password']
         return cls(username=username, password=password, tenant_id=tenant_id)
 
 
@@ -95,6 +96,7 @@ class APIKeyCredentials(object):
     username = attr(validator=validators.instance_of(string_types))
     api_key = attr(validator=validators.instance_of(string_types))
     tenant_id = attr(default=None)
+    type_key = "RAX-KSKEY:apiKeyCredentials"
 
     def get_session(self, session_store):
         """
@@ -123,13 +125,12 @@ class APIKeyCredentials(object):
 
         :return: a class:`APIKeyCredentials` object
         """
-        creds = json_blob['auth']
-        tenant_id = creds.get('tenantName')
+        tenant_id = json_blob['auth'].get('tenantName')
         if tenant_id is None:
-            tenant_id = creds.get('tenantId')
+            tenant_id = json_blob['auth'].get('tenantId')
 
-        username = creds['RAX-KSKEY:apiKeyCredentials']['username']
-        api_key = creds['RAX-KSKEY:apiKeyCredentials']['apiKey']
+        username = json_blob['auth'][cls.type_key]['username']
+        api_key = json_blob['auth'][cls.type_key]['apiKey']
         return cls(username=username, api_key=api_key, tenant_id=tenant_id)
 
 
@@ -144,6 +145,7 @@ class TokenCredentials(object):
     """
     token = attr(validator=validators.instance_of(string_types))
     tenant_id = attr(validator=validators.instance_of(string_types))
+    type_key = "token"
 
     def get_session(self, session_store):
         """
@@ -174,7 +176,7 @@ class TokenCredentials(object):
         if tenant_id is None:
             tenant_id = json_blob['auth'].get('tenantId')
 
-        token = json_blob['auth']['token']['id']
+        token = json_blob['auth'][cls.type_key]['id']
         return cls(token=token, tenant_id=tenant_id)
 
 
@@ -200,6 +202,7 @@ class ImpersonationCredentials(object):
     impersonated_token = attr(
         default=Factory(lambda: 'impersonated_token_' + text_type(uuid4())),
         validator=validators.instance_of(string_types))
+    type_key = 'RAX-AUTH:impersonation'
 
     def get_session(self, session_store):
         """
@@ -229,8 +232,8 @@ class ImpersonationCredentials(object):
 
         :return: a class:`ImpersonationCredentials` object
         """
-        expires_in = json_blob['RAX-AUTH:impersonation']['expire-in-seconds']
-        username = json_blob['RAX-AUTH:impersonation']['user']['username']
+        expires_in = json_blob[cls.type_key]['expire-in-seconds']
+        username = json_blob[cls.type_key]['user']['username']
         return cls(impersonator_token=auth_token,
                    impersonated_username=username,
                    expires_in=int(expires_in))

--- a/mimic/rest/auth_api.py
+++ b/mimic/rest/auth_api.py
@@ -38,11 +38,18 @@ username/api-key, token, or getting an impersonation token.
 @authentication.declare_default_behavior
 def default_authentication_behavior(core, http_request, credentials):
     """
-    Default behavior in response to a server creation.
+    Default behavior in response to a server creation.  This will create
+    a session for the tenant if one does not already exist, and return
+    the auth token for that session.  In the case of
+    :class:`PasswordCredentials`, :class:`ApiKeyCredentials`, or
+    :class:`TokenCredentials`, also returns the service catalog.
 
     :param core: An instance of :class:`mimic.core.MimicCore`
     :param http_request: A twisted http request/response object
     :param credentials: An `mimic.model.identity.ICredentials` provider
+
+    Handles setting the response code and also
+    :return: The response body for a default authentication request.
     """
     try:
         session = credentials.get_session(core.sessions)

--- a/mimic/rest/auth_api.py
+++ b/mimic/rest/auth_api.py
@@ -126,7 +126,7 @@ class AuthApi(object):
                 if cred_type.type_key in content['auth']:
                     try:
                         cred = cred_type.from_json(content)
-                    except Exception:
+                    except (KeyError, TypeError):
                         pass
                     else:
                         behavior = (self.auth_behavior_registry


### PR DESCRIPTION
And use it for authenticating username/password/token/api key creds, and for impersonation.  The second of of #283, which got split up into multiple PRs.

Part of fixing #262 