### PR TITLE
Generate an ID for each behavior that is added.

### DIFF
--- a/mimic/model/behaviors.py
+++ b/mimic/model/behaviors.py
@@ -2,10 +2,9 @@
 General-purpose utilities for customizing response behavior.
 """
 import re
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import attr
-
 
 
 @attr.s

--- a/mimic/model/behaviors.py
+++ b/mimic/model/behaviors.py
@@ -1,17 +1,21 @@
 """
 General-purpose utilities for customizing response behavior.
 """
-
 import re
-from characteristic import attributes, Attribute
+from uuid import UUID, uuid4
+
+import attr
 
 
-@attributes(['name', 'predicate'])
+
+@attr.s
 class Criterion(object):
     """
     A criterion evaluates a predicate (callable object returning boolean)
     against an attribute with the given name.
     """
+    name = attr.ib()
+    predicate = attr.ib()
 
     def evaluate(self, attributes):
         """
@@ -22,13 +26,14 @@ class Criterion(object):
         return self.predicate(attributes[self.name])
 
 
-@attributes(['criteria'])
+@attr.s
 class CriteriaCollection(object):
     """
     A CriteriaCollection is a collection of Criterion which implements the same
     interface (``evaluate(attributes)``) by evaluating each of the Criterion
     objects it comprises and returning True if they all match.
     """
+    criteria = attr.ib()
 
     def evaluate(self, attributes):
         """
@@ -48,8 +53,7 @@ def regexp_predicate(value):
     return re.compile(value).match
 
 
-@attributes([Attribute("_behaviors", default_factory=dict),
-             Attribute("_criteria", default_factory=dict)])
+@attr.s
 class EventDescription(object):
     """
     A collection of behaviors which might be responses for a given event, and
@@ -59,6 +63,8 @@ class EventDescription(object):
         :obj:`BehaviorRegistry.behavior_for_attributes` if no registered
         criteria match.
     """
+    _behaviors = attr.ib(default=attr.Factory(dict))
+    _criteria = attr.ib(default=attr.Factory(dict))
 
     def declare_behavior_creator(self, name):
         """
@@ -129,30 +135,36 @@ class EventDescription(object):
         return CriteriaCollection(criteria=list(create_criteria()))
 
 
-@attributes(["event",
-             Attribute("registered_behaviors", default_factory=list)])
+@attr.s
 class BehaviorRegistry(object):
     """
     A registry of behavior.
 
-    :ivar EventDescription event: The set of criteria and behaviors that this
-        registry is operating for.
+    :ivar EventDescription event: The event this registry is operating for.
+    :ivar registered_behaviors: The set of criteria and behaviors to use for
+        this event.  Currently this is just a list of tuples of
+        (behavior, criteria, and uuid).
     """
+    event = attr.ib()
+    registered_behaviors = attr.ib(default=attr.Factory(list))
 
     def register_from_json(self, json_payload):
         """
         Register a behavior with the given JSON payload from a request.
         """
+        behavior_id = uuid4()
         self.registered_behaviors.append(
             (self.event.create_behavior(json_payload["name"],
                                         json_payload["parameters"]),
-             self.event.create_criteria(json_payload["criteria"])))
+             self.event.create_criteria(json_payload["criteria"]),
+             behavior_id))
+        return behavior_id
 
     def behavior_for_attributes(self, attributes):
         """
         Retrive a previously-registered behavior given the set of attributes.
         """
-        for behavior, criteria in self.registered_behaviors:
+        for behavior, criteria, _ in self.registered_behaviors:
             if criteria.evaluate(attributes):
                 return behavior
         return self.event.default_behavior

--- a/mimic/rest/nova_api.py
+++ b/mimic/rest/nova_api.py
@@ -151,14 +151,19 @@ class NovaControlApiRegion(object):
                     "message": "Stuff is broken, what"
                 }
             }
+
+        The response looks like:
+
+            {
+                "id": "this-is-a-uuid-here"
+            }
         """
         behavior_description = json.loads(request.content.read())
         region_collection = self._collection_from_tenant(tenant_id)
-        region_collection.create_behavior_registry.register_from_json(
-            behavior_description
-        )
+        behavior_id = (region_collection.create_behavior_registry
+                       .register_from_json(behavior_description))
         request.setResponseCode(CREATED)
-        return b''
+        return json.dumps({'id': text_type(behavior_id)})
 
     @app.route("/v2/<string:tenant_id>/attributes/", methods=['POST'])
     def change_attributes(self, request, tenant_id):

--- a/mimic/rest/nova_api.py
+++ b/mimic/rest/nova_api.py
@@ -152,7 +152,7 @@ class NovaControlApiRegion(object):
                 }
             }
 
-        The response looks like:
+        The response looks like::
 
             {
                 "id": "this-is-a-uuid-here"

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -1374,12 +1374,13 @@ class NovaAPINegativeTests(SynchronousTestCase):
         criterion = {"name": name,
                      "parameters": parameters,
                      "criteria": criteria}
-        set_criteria = request(self, self.root, "POST",
-                               self.nova_control_endpoint +
-                               "/behaviors/creation/",
-                               json.dumps(criterion))
-        set_criteria_response = self.successResultOf(set_criteria)
-        self.assertEqual(set_criteria_response.code, 201)
+        set_criteria = json_request(self, self.root, "POST",
+                                    self.nova_control_endpoint +
+                                    "/behaviors/creation/",
+                                    json.dumps(criterion))
+        response, body = self.successResultOf(set_criteria)
+        self.assertEqual(response.code, 201)
+        self.assertTrue(body.get("id"))
 
     def test_create_server_failure_using_behaviors(self):
         """

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -5,6 +5,9 @@ Tests for :mod:`nova_api` and :mod:`nova_objects`.
 import json
 from urllib import urlencode
 from urlparse import parse_qs
+from uuid import UUID
+
+from six import string_types
 
 from testtools.matchers import (
     ContainsDict, Equals, MatchesDict, MatchesListwise, StartsWith)
@@ -1380,7 +1383,9 @@ class NovaAPINegativeTests(SynchronousTestCase):
                                     json.dumps(criterion))
         response, body = self.successResultOf(set_criteria)
         self.assertEqual(response.code, 201)
-        self.assertTrue(body.get("id"))
+        behavior_id = body.get("id")
+        self.assertIsInstance(behavior_id, string_types)
+        self.assertEqual(UUID(behavior_id).version, 4)
 
     def test_create_server_failure_using_behaviors(self):
         """


### PR DESCRIPTION
Part of #271.

In the interest of smaller PRs, this PR only returns the UUID when the behavior is created and does not support listing or deleting by ID.

But it is actually not that small, because I also snuck in a conversion of `behaviors.py` from `characteristic` to `attrs` (since otherwise this would be like 5 lines).