### PR TITLE
Add an endpoint for deleting a create server behavior by ID

### DIFF
--- a/mimic/model/behaviors.py
+++ b/mimic/model/behaviors.py
@@ -184,6 +184,6 @@ class BehaviorRegistry(object):
         for i, behaviors in enumerate(self.registered_behaviors):
             b, c, b_id = behaviors
             if b_id == behavior_id:
-                self.registered_behaviors.pop(i)
+                del self.registered_behaviors[i]
                 return
         raise NoSuchBehaviorError(behavior_id=behavior_id)

--- a/mimic/model/behaviors.py
+++ b/mimic/model/behaviors.py
@@ -2,9 +2,18 @@
 General-purpose utilities for customizing response behavior.
 """
 import re
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import attr
+
+
+@attr.s
+class NoSuchBehaviorError(Exception):
+    """
+    An exception that is raised when attempting to access or delete a
+    non-existant behavior based on ID.
+    """
+    behavior_id = attr.ib(validator=attr.validators.instance_of(UUID))
 
 
 @attr.s
@@ -167,3 +176,14 @@ class BehaviorRegistry(object):
             if criteria.evaluate(attributes):
                 return behavior
         return self.event.default_behavior
+
+    def remove_behavior_by_id(self, behavior_id):
+        """
+        Remove a previously-registered behavior given the behavior's ID.
+        """
+        for i, behaviors in enumerate(self.registered_behaviors):
+            b, c, b_id = behaviors
+            if b_id == behavior_id:
+                self.registered_behaviors.pop(i)
+                return
+        raise NoSuchBehaviorError(behavior_id=behavior_id)

--- a/mimic/rest/nova_api.py
+++ b/mimic/rest/nova_api.py
@@ -3,7 +3,7 @@
 Defines create, delete, get, list servers and get images and flavors.
 """
 
-from uuid import uuid4
+from uuid import UUID, uuid4
 import json
 
 from characteristic import attributes
@@ -16,13 +16,14 @@ from twisted.web.server import Request
 from twisted.python.urlpath import URLPath
 
 from twisted.plugin import IPlugin
-from twisted.web.http import CREATED, BAD_REQUEST
+from twisted.web.http import CREATED, BAD_REQUEST, NO_CONTENT, NOT_FOUND
 
 from mimic.canned_responses.nova import get_limit, get_image, get_flavor
 from mimic.rest.mimicapp import MimicApp
 from mimic.catalog import Entry
 from mimic.catalog import Endpoint
 from mimic.imimic import IAPIMock
+from mimic.model.behaviors import NoSuchBehaviorError
 from mimic.model.nova_objects import (
     BadRequestError, GlobalServerCollections, LimitError, Server,
     bad_request, forbidden, not_found)
@@ -164,6 +165,28 @@ class NovaControlApiRegion(object):
                        .register_from_json(behavior_description))
         request.setResponseCode(CREATED)
         return json.dumps({'id': text_type(behavior_id)})
+
+    @app.route(
+        '/v2/<string:tenant_id>/behaviors/creation/<string:behavior_id>',
+        methods=['DELETE'])
+    def delete_creation_behavior(self, request, tenant_id, behavior_id):
+        """
+        Remove a registered create-server behavior with the specified ID.
+
+        The response is a 204 with no body if successful.
+
+        If the behavior does not exist, the response is a 404 with no body.
+        """
+        region_collection = self._collection_from_tenant(tenant_id)
+        try:
+            region_collection.create_behavior_registry.remove_behavior_by_id(
+                UUID(behavior_id)
+            )
+        except (ValueError, NoSuchBehaviorError):
+            request.setResponseCode(NOT_FOUND)
+        else:
+            request.setResponseCode(NO_CONTENT)
+        return b''
 
     @app.route("/v2/<string:tenant_id>/attributes/", methods=['POST'])
     def change_attributes(self, request, tenant_id):


### PR DESCRIPTION
Which would allow a test to clean up injected error behavior.

Part of #271 