### PR TITLE
Identity behavior api

### DIFF
--- a/mimic/model/behaviors.py
+++ b/mimic/model/behaviors.py
@@ -38,7 +38,8 @@ class Criterion(object):
         and evaluate it against this Criterion's predicate, returning True if
         it matches and False otherwise.
         """
-        return self.predicate(attributes[self.name])
+        return (self.name in attributes and
+                self.predicate(attributes[self.name]))
 
 
 @attr.s

--- a/mimic/resource.py
+++ b/mimic/resource.py
@@ -91,7 +91,7 @@ class MimicRoot(object):
             "now": seconds_to_timestamp(self.clock.seconds())
         })
 
-    @app.route("/mimic/v1.1/behaviors", branch=True)
+    @app.route("/mimic/v1.1/IdentityControlAPI/behaviors", branch=True)
     def handle_identity_behaviors(self, request):
         """
         Handle creating/deleting behaviors for mimic identity.

--- a/mimic/resource.py
+++ b/mimic/resource.py
@@ -7,8 +7,13 @@ import json
 from twisted.web.resource import NoResource
 
 from mimic.canned_responses.mimic_presets import get_presets
+from mimic.model.behaviors import BehaviorRegistryCollection
 from mimic.rest.mimicapp import MimicApp
-from mimic.rest.auth_api import AuthApi, base_uri_from_request
+from mimic.rest.auth_api import (
+    AuthApi,
+    AuthControlApiBehaviors,
+    base_uri_from_request
+)
 from mimic.rest.noit_api import NoitApi
 from mimic.rest import fastly_api
 from mimic.util.helper import seconds_to_timestamp
@@ -30,6 +35,7 @@ class MimicRoot(object):
         """
         self.core = core
         self.clock = clock
+        self.identity_behavior_registry = BehaviorRegistryCollection()
 
     @app.route("/", methods=["GET"])
     def help(self, request):
@@ -45,7 +51,8 @@ class MimicRoot(object):
         """
         Get the identity ...
         """
-        return AuthApi(self.core).app.resource()
+        return AuthApi(self.core,
+                       self.identity_behavior_registry).app.resource()
 
     @app.route("/noit", branch=True)
     def get_noit_api(self, request):
@@ -83,6 +90,14 @@ class MimicRoot(object):
             "advanced": amount,
             "now": seconds_to_timestamp(self.clock.seconds())
         })
+
+    @app.route("/mimic/v1.1/behaviors", branch=True)
+    def handle_identity_behaviors(self, request):
+        """
+        Handle creating/deleting behaviors for mimic identity.
+        """
+        api = AuthControlApiBehaviors(self.identity_behavior_registry)
+        return api.app.resource()
 
     @app.route("/mimicking/<string:service_id>/<string:region_name>",
                branch=True)

--- a/mimic/rest/auth_api.py
+++ b/mimic/rest/auth_api.py
@@ -15,6 +15,8 @@ from mimic.canned_responses.auth import (
     format_timestamp,
     impersonator_user_role)
 from mimic.canned_responses.mimic_presets import get_presets
+from mimic.core import MimicCore
+from mimic.model.behaviors import make_behavior_api
 from mimic.model.identity import (
     APIKeyCredentials,
     ImpersonationCredentials,
@@ -156,11 +158,14 @@ def authenticate_failure_behavior(parameters):
 class AuthApi(object):
     """
     Rest endpoints for mocked Auth api.
-    """
-    core = attr.ib()
-    registry_collection = attr.ib(default=attr.Factory(
-        lambda: BehaviorRegistryCollection()))
 
+    :ivar core: an instance of :class:`mimic.core.MimicCore`
+    :ivar registry_collection: an instance of
+        :class:`mimic.model.behaviors.BehaviorRegistryCollection`
+    """
+    core = attr.ib(validator=attr.validators.instance_of(MimicCore))
+    registry_collection = attr.ib(
+        validator=attr.validators.instance_of(BehaviorRegistryCollection))
     app = MimicApp()
 
     @app.route('/v2.0/tokens', methods=['POST'])
@@ -332,3 +337,12 @@ def base_uri_from_request(request):
     :rtype: ``str``
     """
     return str(URLPath.fromRequest(request).click('/'))
+
+
+AuthControlApiBehaviors = make_behavior_api({'auth': authentication})
+"""
+Handlers for CRUD operations on authentication behaviors.
+
+:ivar registry_collection: an instance of
+    :class:`mimic.model.behaviors.BehaviorRegistryCollection`
+"""

--- a/mimic/rest/auth_api.py
+++ b/mimic/rest/auth_api.py
@@ -28,17 +28,36 @@ from mimic.util.helper import invalid_resource
 
 from mimic.model.behaviors import (
     BehaviorRegistryCollection,
-    EventDescription
+    Criterion,
+    EventDescription,
+    regexp_predicate
 )
 
 Request.defaultContentType = 'application/json'
-
 
 authentication = EventDescription()
 """
 Event refers to authenticating against Identity using a username/password,
 username/api-key, token, or getting an impersonation token.
 """
+
+
+@authentication.declare_criterion("username")
+def username_criterion(value):
+    """
+    Return a Criterion which matches the given regular expression string
+    against the ``"username"`` attribute.
+    """
+    return Criterion(name='username', predicate=regexp_predicate(value))
+
+
+@authentication.declare_criterion("tenant_id")
+def tenant_id_criterion(value):
+    """
+    Return a Criterion which matches the given regular expression string
+    against the ``"tenant_Id"`` attribute.
+    """
+    return Criterion(name='tenant_id', predicate=regexp_predicate(value))
 
 
 @authentication.declare_default_behavior

--- a/mimic/test/test_auth.py
+++ b/mimic/test/test_auth.py
@@ -7,8 +7,6 @@ import json
 from twisted.trial.unittest import SynchronousTestCase
 from twisted.internet.task import Clock
 
-from zope.interface import implementer
-
 from mimic.canned_responses.auth import (
     get_token, HARD_CODED_TOKEN, HARD_CODED_USER_ID,
     HARD_CODED_USER_NAME, HARD_CODED_ROLES,
@@ -19,8 +17,7 @@ from mimic.catalog import Entry, Endpoint
 from mimic.core import MimicCore
 from mimic.resource import MimicRoot
 from mimic.test.behavior_tests import (
-    IBehaviorAPITestHelper,
-    make_behavior_tests,
+    behavior_tests_helper_class,
     register_behavior
 )
 from mimic.test.dummy import ExampleAPI
@@ -1105,8 +1102,7 @@ class AuthIntegrationTests(SynchronousTestCase):
 auth_behavior_endpoint = "http://mybase/mimic/v1.1/behaviors/auth"
 
 
-@make_behavior_tests
-@implementer(IBehaviorAPITestHelper)
+@behavior_tests_helper_class
 class IdentityAuthBehaviorControlPlane(object):
     """
     Helper object used to generate tests for Nova create server behavior

--- a/mimic/test/test_auth.py
+++ b/mimic/test/test_auth.py
@@ -1153,13 +1153,6 @@ class IdentityAuthBehaviorControlPlane(object):
         self.test_case.assertEquals(response.code, 200)
         self.test_case.assertIn('access', body)
 
-    @classmethod
-    def from_test_case(cls, test_case):
-        """
-        Construct and return a :class:`IdentityAuthBehaviorControlPlane`
-        """
-        return cls(test_case)
-
 
 class IdentityBehaviorInjectionTests(SynchronousTestCase):
     """
@@ -1224,7 +1217,7 @@ class IdentityBehaviorInjectionTests(SynchronousTestCase):
             self.assertEqual(response.code, 403)
             self.assertEqual(body, {"unauthorized": fail_params})
 
-        # token auth with that username succeeds
+        # impersonation with that username succeeds
         response, body = impersonate_user(self, root, username="failme")
         self.assertEqual(response.code, 200)
 
@@ -1237,7 +1230,6 @@ class IdentityBehaviorInjectionTests(SynchronousTestCase):
         fail_params = {"message": "Failure of JSON", "code": 500,
                        "type": "string"}
 
-        # tenant auths fail
         register_behavior(self, root, auth_behavior_endpoint,
                           behavior_name="fail",
                           criteria=[{"username": "failme"}],

--- a/mimic/test/test_auth.py
+++ b/mimic/test/test_auth.py
@@ -331,24 +331,6 @@ def impersonate_user(test_case, root,
     ))
 
 
-def use_auth_behavior(test_case, root, name, parameters, criteria):
-    """
-    Use the given behavior for authentication.
-    """
-    criterion = {"name": name,
-                 "parameters": parameters,
-                 "criteria": criteria}
-
-    set_criteria = request(
-        test_case, root, "POST",
-        self.helper.auth.get_service_endpoint(
-            "cloudServersBehavior", "ORD") +
-                           "/behaviors/creation/",
-                           json.dumps(criterion))
-    set_criteria_response = self.successResultOf(set_criteria)
-    self.assertEqual(set_criteria_response.code, 201)
-
-
 class GetAuthTokenAPITests(SynchronousTestCase):
 
     """
@@ -482,29 +464,6 @@ class GetAuthTokenAPITests(SynchronousTestCase):
         self.assertTrue(urls[0].startswith('http://mybase/'),
                         '{0} does not start with "http://mybase"'
                         .format(urls[0]))
-
-    def test_failure_injection_auth_with_username_password(self):
-        """
-        Creating a behavior for identity returning a failure response when
-        authenticating with a username and password.
-        """
-        self.use_creation_behavior("build", {"duration": 4.0}, [])
-        self.do_timing_test(metadata={},
-                            before=u"BUILD",
-                            delay=5.0,
-                            after=u"ACTIVE")
-
-    def test_server_active_then_error_behavior(self):
-        """
-        When a server is created with the :obj:`active-then-error` behavior, it
-        will go into the "error" state after the specified ``duration`` number
-        of seconds.
-        """
-        self.use_creation_behavior("active-then-error", {"duration": 7.0}, [])
-        self.do_timing_test(metadata={},
-                            before=u"ACTIVE",
-                            delay=8.0,
-                            after=u"ERROR")
 
 
 class GetEndpointsForTokenTests(SynchronousTestCase):

--- a/mimic/test/test_auth.py
+++ b/mimic/test/test_auth.py
@@ -331,6 +331,24 @@ def impersonate_user(test_case, root,
     ))
 
 
+def use_auth_behavior(test_case, root, name, parameters, criteria):
+    """
+    Use the given behavior for authentication.
+    """
+    criterion = {"name": name,
+                 "parameters": parameters,
+                 "criteria": criteria}
+
+    set_criteria = request(
+        test_case, root, "POST",
+        self.helper.auth.get_service_endpoint(
+            "cloudServersBehavior", "ORD") +
+                           "/behaviors/creation/",
+                           json.dumps(criterion))
+    set_criteria_response = self.successResultOf(set_criteria)
+    self.assertEqual(set_criteria_response.code, 201)
+
+
 class GetAuthTokenAPITests(SynchronousTestCase):
 
     """
@@ -464,6 +482,29 @@ class GetAuthTokenAPITests(SynchronousTestCase):
         self.assertTrue(urls[0].startswith('http://mybase/'),
                         '{0} does not start with "http://mybase"'
                         .format(urls[0]))
+
+    def test_failure_injection_auth_with_username_password(self):
+        """
+        Creating a behavior for identity returning a failure response when
+        authenticating with a username and password.
+        """
+        self.use_creation_behavior("build", {"duration": 4.0}, [])
+        self.do_timing_test(metadata={},
+                            before=u"BUILD",
+                            delay=5.0,
+                            after=u"ACTIVE")
+
+    def test_server_active_then_error_behavior(self):
+        """
+        When a server is created with the :obj:`active-then-error` behavior, it
+        will go into the "error" state after the specified ``duration`` number
+        of seconds.
+        """
+        self.use_creation_behavior("active-then-error", {"duration": 7.0}, [])
+        self.do_timing_test(metadata={},
+                            before=u"ACTIVE",
+                            delay=8.0,
+                            after=u"ERROR")
 
 
 class GetEndpointsForTokenTests(SynchronousTestCase):

--- a/mimic/test/test_auth.py
+++ b/mimic/test/test_auth.py
@@ -1099,7 +1099,8 @@ class AuthIntegrationTests(SynchronousTestCase):
         self.assertEqual(username_from_api_key, username_from_token)
 
 
-auth_behavior_endpoint = "http://mybase/mimic/v1.1/behaviors/auth"
+auth_behavior_endpoint = (
+    "http://mybase/mimic/v1.1/IdentityControlAPI/behaviors/auth")
 
 
 @behavior_tests_helper_class

--- a/mimic/test/test_auth.py
+++ b/mimic/test/test_auth.py
@@ -1197,7 +1197,7 @@ class IdentityBehaviorInjectionTests(SynchronousTestCase):
         # token auth with that tenant ID succeeds
         response, body = authenticate_with_token(
             self, root, tenant_id="123456")
-        self.assertEqual(response, 200)
+        self.assertEqual(response.code, 200)
 
     def test_tenant_id_criteria_works_on_all_auth_methods_with_tenant(self):
         """
@@ -1217,7 +1217,7 @@ class IdentityBehaviorInjectionTests(SynchronousTestCase):
         # tenant auths fail
         register_behavior(self, root, auth_behavior_endpoint,
                           behavior_name="fail",
-                          criteria=[{"username": "failme"}],
+                          criteria=[{"tenant_id": "123456"}],
                           parameters=fail_params)
         for auth_func in (authenticate_with_username_password,
                           authenticate_with_api_key,
@@ -1228,4 +1228,4 @@ class IdentityBehaviorInjectionTests(SynchronousTestCase):
 
         # token auth with that username succeeds
         response, body = impersonate_user(self, root, username="failme")
-        self.assertEqual(response, 200)
+        self.assertEqual(response.code, 200)


### PR DESCRIPTION
Use the behavior api generics to add a identity behavior control panel. Also add failure injection for identity.

Fixes #262