### PR TITLE
Fix some CLB  bugs

### DIFF
--- a/mimic/canned_responses/loadbalancer.py
+++ b/mimic/canned_responses/loadbalancer.py
@@ -49,8 +49,6 @@ def _delete_node(store, lb_id, node_id):
             if each.id == node_id:
                 index = store.lbs[lb_id]["nodes"].index(each)
                 del store.lbs[lb_id]["nodes"][index]
-                if not store.lbs[lb_id]["nodes"]:
-                    del store.lbs[lb_id]["nodes"]
                 store.lbs[lb_id].update({"nodeCount": len(store.lbs[lb_id].get("nodes", []))})
                 return True
     return False
@@ -73,7 +71,10 @@ def _lb_without_tenant(store, lb_id):
     tenant_id
     """
     new_lb = deepcopy(store.lbs[lb_id])
-    new_lb["nodes"] = [node.as_json() for node in store.lbs[lb_id]["nodes"]]
+    if new_lb["nodes"]:
+        new_lb["nodes"] = [node.as_json() for node in new_lb["nodes"]]
+    else:
+        del new_lb["nodes"]
     del new_lb["tenant_id"]
     del new_lb["nodeCount"]
     return new_lb

--- a/mimic/test/test_loadbalancer.py
+++ b/mimic/test/test_loadbalancer.py
@@ -327,7 +327,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
                               "port": 80, "condition": "ENABLED"}
                              for i in range(1, 4)])
         list_resp, list_body = self.successResultOf(json_request(
-            self, self.root,  "GET", self.uri + '/loadbalancers'))
+            self, self.root, "GET", self.uri + '/loadbalancers'))
         self.assertEqual(list_resp.code, 200)
         self.assertEqual(len(list_body['loadBalancers']), 2)
 

--- a/mimic/test/test_loadbalancer.py
+++ b/mimic/test/test_loadbalancer.py
@@ -113,7 +113,18 @@ class LoadbalancerAPITests(SynchronousTestCase):
 
     def _create_loadbalancer(self, name=None, api_helper=None, nodes=None):
         """
-        Helper method to create a load balancer and return the lb_id
+        Helper method to create a load balancer and return the lb_id.
+
+        :param str name: The name fo the load balancer, defaults to 'test_lb'
+        :param api_helper: An instance of :class:`APIMockHelper` - defaults to
+            the one created by setup, but if different regions need to be
+            created, for instance, your test may make a different helper, and
+            so that helper can be passed here.
+        :param list nodes: A list of nodes to create the load balancer with -
+            defaults to creating a load balancer with no nodes.
+
+        :return: Load balancer ID
+        :rtype: int
         """
         api_helper = api_helper or self.helper
         lb_body = {
@@ -234,9 +245,8 @@ class LoadbalancerAPITests(SynchronousTestCase):
 
     def test_add_load_balancer(self):
         """
-        Test to verify :func:`add_load_balancer` on
-        ``POST /v1.0/<tenant_id>/loadbalancers``.  If created without nodes,
-        no node information appears in the response.
+        If created without nodes, no node information appears in the response
+        when making a request to ``POST /v1.0/<tenant_id>/loadbalancers``.
         """
         lb_name = 'mimic_lb'
         resp, body = self.successResultOf(json_request(

--- a/mimic/test/test_loadbalancer.py
+++ b/mimic/test/test_loadbalancer.py
@@ -111,25 +111,26 @@ class LoadbalancerAPITests(SynchronousTestCase):
         self.root = self.helper.root
         self.uri = self.helper.uri
 
-    def _create_loadbalancer(self, name=None, api_helper=None):
+    def _create_loadbalancer(self, name=None, api_helper=None, nodes=None):
         """
         Helper method to create a load balancer and return the lb_id
         """
         api_helper = api_helper or self.helper
+        lb_body = {
+            "loadBalancer": {
+                "name": name or "test_lb",
+                "protocol": "HTTP",
+                "virtualIps": [{"type": "PUBLIC"}]
+            }
+        }
+        if nodes is not None:
+            lb_body['loadBalancer']['nodes'] = nodes
 
-        create_lb = request(
+        resp, body = self.successResultOf(json_request(
             self, api_helper.root, "POST", api_helper.uri + '/loadbalancers',
-            json.dumps({
-                "loadBalancer": {
-                    "name": name or "test_lb",
-                    "protocol": "HTTP",
-                    "virtualIps": [{"type": "PUBLIC"}]
-                }
-            })
-        )
-        create_lb_response = self.successResultOf(create_lb)
-        create_lb_response_body = self.successResultOf(treq.json_content(create_lb_response))
-        return create_lb_response_body['loadBalancer']['id']
+            lb_body
+        ))
+        return body['loadBalancer']['id']
 
     def _patch_attributes_request(
         self, lb_id_offset=0, status_key=None, status_val=None
@@ -233,23 +234,25 @@ class LoadbalancerAPITests(SynchronousTestCase):
 
     def test_add_load_balancer(self):
         """
-        Test to verify :func:`add_load_balancer` on ``POST /v1.0/<tenant_id>/loadbalancers``
+        Test to verify :func:`add_load_balancer` on
+        ``POST /v1.0/<tenant_id>/loadbalancers``.  If created without nodes,
+        no node informatino appears in the response.
         """
         lb_name = 'mimic_lb'
-        create_lb = request(
+        resp, body = self.successResultOf(json_request(
             self, self.root, "POST", self.uri + '/loadbalancers',
-            json.dumps({
+            {
                 "loadBalancer": {
                     "name": lb_name,
                     "protocol": "HTTP",
                     "virtualIps": [{"type": "PUBLIC"}]
                 }
-            })
-        )
-        create_lb_response = self.successResultOf(create_lb)
-        create_lb_response_body = self.successResultOf(treq.json_content(create_lb_response))
-        self.assertEqual(create_lb_response.code, 202)
-        self.assertEqual(create_lb_response_body['loadBalancer']['name'], lb_name)
+            }
+        ))
+        self.assertEqual(resp.code, 202)
+        self.assertEqual(body['loadBalancer']['name'], lb_name)
+        self.assertNotIn("nodeCount", body["loadBalancer"])
+        self.assertNotIn("nodes", body["loadBalancer"])
 
     def test_add_load_balancer_request_with_no_body_causes_bad_request(self):
         """
@@ -269,13 +272,13 @@ class LoadbalancerAPITests(SynchronousTestCase):
 
     def test_add_load_balancer_with_nodes(self):
         """
-        Test to verify :func:`add_load_balancer` on ``POST /v1.0/<tenant_id>/loadbalancers``,
-        with nodes
+        Test to verify :func:`add_load_balancer` on
+        ``POST /v1.0/<tenant_id>/loadbalancers`` with nodes.
         """
         lb_name = 'mimic_lb'
-        create_lb = request(
+        resp, body = self.successResultOf(json_request(
             self, self.root, "POST", self.uri + '/loadbalancers',
-            json.dumps({
+            {
                 "loadBalancer": {
                     "name": lb_name,
                     "protocol": "HTTP",
@@ -289,12 +292,11 @@ class LoadbalancerAPITests(SynchronousTestCase):
                                "condition": "ENABLED",
                                "type": "SECONDARY"}]
                 }
-            })
-        )
-        create_lb_response = self.successResultOf(create_lb)
-        create_lb_response_body = self.successResultOf(treq.json_content(create_lb_response))
-        self.assertEqual(create_lb_response.code, 202)
-        self.assertEqual(len(create_lb_response_body['loadBalancer']['nodes']), 2)
+            }
+        ))
+        self.assertEqual(resp.code, 202)
+        self.assertNotIn("nodeCount", body['loadBalancer'])
+        self.assertEqual(len(body['loadBalancer']['nodes']), 2)
 
     def test_list_loadbalancers(self):
         """
@@ -312,6 +314,28 @@ class LoadbalancerAPITests(SynchronousTestCase):
         self.assertTrue(list_lb_response_body['loadBalancers'][1]['id'] in [test1_id, test2_id])
         self.assertTrue(list_lb_response_body['loadBalancers'][0]['id'] !=
                         list_lb_response_body['loadBalancers'][1]['id'])
+
+    def test_list_loadbalancers_have_no_nodes(self):
+        """
+        Test to verify that nodes does not appear on the load balancers when
+        listing, even if they do have nodes.  "nodeCount" is present for all
+        the load balancers, though.
+        """
+        self._create_loadbalancer('no_nodes')
+        self._create_loadbalancer(
+            '3nodes', nodes=[{"address": "1.1.1.{0}".format(i),
+                              "port": 80, "condition": "ENABLED"}
+                             for i in range(1, 4)])
+        list_resp, list_body = self.successResultOf(json_request(
+            self, self.root,  "GET", self.uri + '/loadbalancers'))
+        self.assertEqual(list_resp.code, 200)
+        self.assertEqual(len(list_body['loadBalancers']), 2)
+
+        for lb in list_body['loadBalancers']:
+            self.assertNotIn("nodes", lb)
+            self.assertEqual(
+                lb['nodeCount'],
+                0 if lb['name'] == 'no_nodes' else 3)
 
     def test_delete_loadbalancer(self):
         """
@@ -336,10 +360,28 @@ class LoadbalancerAPITests(SynchronousTestCase):
         self.assertTrue(len(list_lb_response_body['loadBalancers']), 1)
         self.assertTrue(list_lb_response_body['loadBalancers'][0]['id'] == test2_id)
 
-    def test_get_loadbalancer(self):
+    def test_get_loadbalancer_no_nodes(self):
         """
         Test to verify :func:`get_load_balancers` with on
-        ``GET /v1.0/<tenant_id>/loadbalancers\<loadbalancer_id``
+        ``GET /v1.0/<tenant_id>/loadbalancers\<loadbalancer_id>``.  If there
+        are no nodes on the load balancer, "nodes" but not "nodeCount"
+        appears in the response.
+        """
+        lb_id = self._create_loadbalancer(
+            nodes=[{"address": "1.2.3.4", "port": 80, "condition": "ENABLED"}])
+        resp, body = self.successResultOf(json_request(
+            self, self.root, "GET", self.uri + '/loadbalancers/' + str(lb_id)))
+        self.assertEqual(resp.code, 200)
+        self.assertEqual(body['loadBalancer']['id'], lb_id)
+        self.assertNotIn('nodeCount', body['loadBalancer'])
+        self.assertEqual(len(body['loadBalancer']['nodes']), 1)
+
+    def test_get_loadbalancer_with_nodes(self):
+        """
+        Test to verify :func:`get_load_balancers` with on
+        ``GET /v1.0/<tenant_id>/loadbalancers\<loadbalancer_id`>`  If there
+        are nodes on the load balancer, then both "ndoeCount" and "nodes"
+        appear in the response.
         """
         lb_id = self._create_loadbalancer()
         get_lb = request(self, self.root, "GET", self.uri + '/loadbalancers/' + str(lb_id))
@@ -719,6 +761,13 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
             + str(self.node[0]["id"]))
         delete_node_response = self.successResultOf(delete_nodes)
         self.assertEqual(delete_node_response.code, 202)
+
+        # assert that it lists correctly after
+        list_nodes_resp, list_nodes_body = self.successResultOf(json_request(
+            self, self.root, "GET", self.uri + '/loadbalancers/' +
+            str(self.lb_id) + '/nodes'))
+        self.assertEqual(list_nodes_resp.code, 200)
+        self.assertEqual(len(list_nodes_body["nodes"]), 0)
 
     def test_delete_node_on_non_existant_loadbalancer(self):
         """

--- a/mimic/test/test_loadbalancer.py
+++ b/mimic/test/test_loadbalancer.py
@@ -236,7 +236,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
         """
         Test to verify :func:`add_load_balancer` on
         ``POST /v1.0/<tenant_id>/loadbalancers``.  If created without nodes,
-        no node informatino appears in the response.
+        no node information appears in the response.
         """
         lb_name = 'mimic_lb'
         resp, body = self.successResultOf(json_request(
@@ -272,8 +272,8 @@ class LoadbalancerAPITests(SynchronousTestCase):
 
     def test_add_load_balancer_with_nodes(self):
         """
-        Test to verify :func:`add_load_balancer` on
-        ``POST /v1.0/<tenant_id>/loadbalancers`` with nodes.
+        Making a request to ``POST /v1.0/<tenant_id>/loadbalancers`` with
+        nodes adds the nodes to the load balancer.
         """
         lb_name = 'mimic_lb'
         resp, body = self.successResultOf(json_request(
@@ -317,9 +317,9 @@ class LoadbalancerAPITests(SynchronousTestCase):
 
     def test_list_loadbalancers_have_no_nodes(self):
         """
-        Test to verify that nodes does not appear on the load balancers when
-        listing, even if they do have nodes.  "nodeCount" is present for all
-        the load balancers, though.
+        When listing load balancers, nodes do not appear even if the load
+        balanacer has nodes.  "nodeCount" is present for all the load
+        balancers, whether or not there are nodes on the load balancer.
         """
         self._create_loadbalancer('no_nodes')
         self._create_loadbalancer(
@@ -360,12 +360,11 @@ class LoadbalancerAPITests(SynchronousTestCase):
         self.assertTrue(len(list_lb_response_body['loadBalancers']), 1)
         self.assertTrue(list_lb_response_body['loadBalancers'][0]['id'] == test2_id)
 
-    def test_get_loadbalancer_no_nodes(self):
+    def test_get_loadbalancer_with_nodes(self):
         """
-        Test to verify :func:`get_load_balancers` with on
-        ``GET /v1.0/<tenant_id>/loadbalancers\<loadbalancer_id>``.  If there
-        are no nodes on the load balancer, "nodes" but not "nodeCount"
-        appears in the response.
+        If there are nodes on the load balancer, "nodes" (but not "nodeCount")
+        appears in the response when making a request to
+        ``GET /v1.0/<tenant_id>/loadbalancers/<loadbalancer_id>``.
         """
         lb_id = self._create_loadbalancer(
             nodes=[{"address": "1.2.3.4", "port": 80, "condition": "ENABLED"}])
@@ -376,19 +375,19 @@ class LoadbalancerAPITests(SynchronousTestCase):
         self.assertNotIn('nodeCount', body['loadBalancer'])
         self.assertEqual(len(body['loadBalancer']['nodes']), 1)
 
-    def test_get_loadbalancer_with_nodes(self):
+    def test_get_loadbalancer_no_nodes(self):
         """
-        Test to verify :func:`get_load_balancers` with on
-        ``GET /v1.0/<tenant_id>/loadbalancers\<loadbalancer_id`>`  If there
-        are nodes on the load balancer, then both "ndoeCount" and "nodes"
-        appear in the response.
+        If there are no nodes on the load balancer, then neither "nodeCount"
+        nor "nodes" appear in the response when making a request to
+        ``GET /v1.0/<tenant_id>/loadbalancers/<loadbalancer_id>``
         """
         lb_id = self._create_loadbalancer()
-        get_lb = request(self, self.root, "GET", self.uri + '/loadbalancers/' + str(lb_id))
-        get_lb_response = self.successResultOf(get_lb)
-        get_lb_response_body = self.successResultOf(treq.json_content(get_lb_response))
-        self.assertEqual(get_lb_response.code, 200)
-        self.assertEqual(get_lb_response_body['loadBalancer']['id'], lb_id)
+        resp, body = self.successResultOf(json_request(
+            self, self.root, "GET", self.uri + '/loadbalancers/' + str(lb_id)))
+        self.assertEqual(resp.code, 200)
+        self.assertEqual(body['loadBalancer']['id'], lb_id)
+        self.assertNotIn('nodeCount', body['loadBalancer'])
+        self.assertNotIn('nodes', body['loadBalancer'])
 
     def test_get_non_existant_loadbalancer(self):
         """


### PR DESCRIPTION
These were introduced by the node model change:

1.  When GET-ing a load balancer, if there are no nodes, the "nodes" attribute does not appear.
1.  When deleting a node, previously it deleted the "nodes" attribute from the whole LB.  We want to leave it and just filter it out when returning responses.