### PR TITLE
reboot actions

### DIFF
--- a/mimic/model/nova_objects.py
+++ b/mimic/model/nova_objects.py
@@ -906,6 +906,10 @@ class RegionalServerCollection(object):
 
                 http_action_request.setResponseCode(202)
                 return b''
+
+            else:
+                return dumps(bad_request("Argument 'type' for reboot is not HARD or SOFT",
+                                         http_action_request))
         else:
             return dumps(bad_request("There is no such action currently supported", http_action_request))
 

--- a/mimic/model/nova_objects.py
+++ b/mimic/model/nova_objects.py
@@ -858,7 +858,7 @@ class RegionalServerCollection(object):
                     server.update_status,
                     u"ACTIVE")
                 return b''
-            if reboot_type == 'SOFT':
+            elif reboot_type == 'SOFT':
                 server.status = 'REBOOT'
                 http_action_request.setResponseCode(202)
                 server.collection.clock.callLater(

--- a/mimic/model/nova_objects.py
+++ b/mimic/model/nova_objects.py
@@ -866,6 +866,9 @@ class RegionalServerCollection(object):
                     server.update_status,
                     u"ACTIVE")
                 return b''
+            else:
+                return dumps(bad_request("Argument 'type' for reboot is not HARD or SOFT",
+                                         http_action_request))
         else:
             return dumps(bad_request("There is no such action currently supported", http_action_request))
 

--- a/mimic/model/nova_objects.py
+++ b/mimic/model/nova_objects.py
@@ -624,36 +624,6 @@ def active_then_error(parameters):
     return fail_later
 
 
-@server_creation.declare_behavior_creator("soft-reboot-then-active")
-def soft_reboot_then_active(parameters):
-
-    duration = parameters["duration"]
-
-    @default_with_hook
-    def reboot_to_active_later(server):
-        server.update_status(u"REBOOT")
-        server.collection.clock.callLater(
-            duration,
-            server.update_status,
-            u"ACTIVE")
-    return reboot_to_active_later
-
-
-@server_creation.declare_behavior_creator("hard-reboot-then-active")
-def hard_reboot_then_active(parameters):
-
-    duration = parameters["duration"]
-
-    @default_with_hook
-    def hard_reboot_to_active_later(server):
-        server.update_status(u"HARD_REBOOT")
-        server.collection.clock.callLater(
-            duration,
-            server.update_status,
-            u"ACTIVE")
-    return hard_reboot_to_active_later
-
-
 def metadata_to_creation_behavior(metadata):
     """
     Examine the metadata given to a server creation request, and return a

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -169,6 +169,7 @@ class NovaAPITests(SynchronousTestCase):
             self, [nova_api, NovaControlApi(nova_api=nova_api)]
         )
         self.root = self.helper.root
+        self.clock = self.helper.clock
         self.uri = self.helper.uri
         self.server_name = 'test_server'
 
@@ -687,6 +688,80 @@ class NovaAPITests(SynchronousTestCase):
         reverted_server_response_body = self.successResultOf(
             treq.json_content(reverted_server_response))
         self.assertEqual(reverted_server_response_body['server']['flavor']['id'], '2')
+
+    def test_reboot_server(self):
+        """
+        A hard reboot of a server sets the server status to HARD_REBOOT and returns a 202
+        A soft reboot of a server sets the server status to REBOOT and returns a 202
+        After some amount of time the server will go back to ACTIVE state
+        The clock is being used to advance time and verify that status changes from the
+            a reboot state to active.  The current time interval being used in hardcoded
+            in the route for now. In the future we need to refactor to allow different
+            durations to be set including a zero duration which would allow the server to
+            skip the intermediary state of HARD_REBOOT or REBOOT and go straight to ACTIVE
+        If the 'type' attribute is left out of the request, a response body is returned
+            with code of 400
+        http://docs.rackspace.com/servers/api/v2/cs-devguide/content/Reboot_Server-d1e3371.html
+        """
+        no_reboot_type_request = json.dumps({"reboot": {"missing_type": "SOFT"}})
+        response, body = self.successResultOf(json_request(
+            self, self.root, "POST",
+            self.uri + '/servers/' + self.server_id + '/action', no_reboot_type_request))
+        self.assertEqual(response.code, 400)
+        self.assertEqual(body, {
+            "badRequest": {
+                "message": "Missing argument 'type' for reboot",
+                "code": 400
+            }
+        })
+
+        # Soft reboot tests
+        soft_reboot_request = json.dumps({"reboot": {"type": "SOFT"}})
+        soft_reboot = request(
+            self, self.root, "POST",
+            self.uri + '/servers/' + self.server_id + '/action', soft_reboot_request)
+        soft_reboot_response = self.successResultOf(soft_reboot)
+        self.assertEqual(soft_reboot_response.code, 202)
+
+        soft_reboot_server = request(
+            self, self.root, "GET", self.uri + '/servers/' + self.server_id)
+        soft_reboot_server_response = self.successResultOf(soft_reboot_server)
+        soft_reboot_server_response_body = self.successResultOf(
+            treq.json_content(soft_reboot_server_response))
+        self.assertEqual(soft_reboot_server_response_body['server']['status'], 'REBOOT')
+
+        # Advance the clock 3 seconds and check status
+        self.clock.advance(3)
+        rebooted_server = request(
+            self, self.root, "GET", self.uri + '/servers/' + self.server_id)
+        rebooted_server_response = self.successResultOf(rebooted_server)
+        rebooted_server_response_body = self.successResultOf(
+            treq.json_content(rebooted_server_response))
+        self.assertEqual(rebooted_server_response_body['server']['status'], 'ACTIVE')
+
+        # Hard Reboot Tests
+        hard_reboot_request = json.dumps({"reboot": {"type": "HARD"}})
+        hard_reboot = request(
+            self, self.root, "POST",
+            self.uri + '/servers/' + self.server_id + '/action', hard_reboot_request)
+        hard_reboot_response = self.successResultOf(hard_reboot)
+        self.assertEqual(hard_reboot_response.code, 202)
+
+        hard_reboot_server = request(
+            self, self.root, "GET", self.uri + '/servers/' + self.server_id)
+        hard_reboot_server_response = self.successResultOf(hard_reboot_server)
+        hard_reboot_server_response_body = self.successResultOf(
+            treq.json_content(hard_reboot_server_response))
+        self.assertEqual(hard_reboot_server_response_body['server']['status'], 'HARD_REBOOT')
+
+        # Advance clock 6 seconds and check server status
+        self.clock.advance(6)
+        rebooted_server = request(
+            self, self.root, "GET", self.uri + '/servers/' + self.server_id)
+        rebooted_server_response = self.successResultOf(rebooted_server)
+        rebooted_server_response_body = self.successResultOf(
+            treq.json_content(rebooted_server_response))
+        self.assertEqual(rebooted_server_response_body['server']['status'], 'ACTIVE')
 
 
 class NovaAPIChangesSinceTests(SynchronousTestCase):

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -732,15 +732,13 @@ class NovaAPITests(SynchronousTestCase):
         soft_reboot = request(
             self, self.root, "POST",
             self.uri + '/servers/' + self.server_id + '/action', soft_reboot_request)
+
         soft_reboot_response = self.successResultOf(soft_reboot)
         self.assertEqual(soft_reboot_response.code, 202)
 
-        soft_reboot_server = request(
-            self, self.root, "GET", self.uri + '/servers/' + self.server_id)
-        soft_reboot_server_response = self.successResultOf(soft_reboot_server)
-        soft_reboot_server_response_body = self.successResultOf(
-            treq.json_content(soft_reboot_server_response))
-        self.assertEqual(soft_reboot_server_response_body['server']['status'], 'REBOOT')
+        response, body = self.successResultOf(json_request(
+            self, self.root, "GET", self.uri + '/servers/' + self.server_id))
+        self.assertEqual(body['server']['status'], 'REBOOT')
 
         # Advance the clock 3 seconds and check status
         self.clock.advance(3)

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -715,6 +715,18 @@ class NovaAPITests(SynchronousTestCase):
             }
         })
 
+        wrong_reboot_type_request = json.dumps({"reboot": {"type": "FIRM"}})
+        response, body = self.successResultOf(json_request(
+            self, self.root, "POST",
+            self.uri + '/servers/' + self.server_id + '/action', wrong_reboot_type_request))
+        self.assertEqual(response.code, 400)
+        self.assertEqual(body, {
+            "badRequest": {
+                "message": "Argument 'type' for reboot is not HARD or SOFT",
+                "code": 400
+            }
+        })
+
         # Soft reboot tests
         soft_reboot_request = json.dumps({"reboot": {"type": "SOFT"}})
         soft_reboot = request(


### PR DESCRIPTION
There are some hard coded times in nova_objects  that allow for the setting of intermediary states that occur when a server is rebooted.  I am going to file an issue to address the durations in the future. We will need to devise a way to allow for the duration to be set to any number including 0.  A 0 duration should skip the intermediary server state and just invoke an immediate "ACTIVE" state. 