### PR TITLE
Add a verbose logging option to mimic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,14 @@ env:
 matrix:
     include:
         - python: 2.6
-          env: TOXENV=py26
+          env: TOXENV=py26-twisted_old_logging
+          env: TOXENV=py26-twisted_new_logging
         - python: 2.7
-          env: TOXENV=py27
+          env: TOXENV=py27-twisted_old_logging
+          env: TOXENV=py27-twisted_new_logging
         - python: pypy
-          env: TOXENV=pypy
+          env: TOXENV=pypy-twisted_old_logging
+          env: TOXENV=pypy-twisted_new_logging
         - python: 2.7
           env: TOXENV=docs
         - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,15 @@ matrix:
     include:
         - python: 2.6
           env: TOXENV=py26-twisted_old_logging
+        - python: 2.6
           env: TOXENV=py26-twisted_new_logging
         - python: 2.7
           env: TOXENV=py27-twisted_old_logging
+        - python: 2.7
           env: TOXENV=py27-twisted_new_logging
         - python: pypy
           env: TOXENV=pypy-twisted_old_logging
+        - python: pypy
           env: TOXENV=pypy-twisted_new_logging
         - python: 2.7
           env: TOXENV=docs

--- a/mimic/rest/auth_api.py
+++ b/mimic/rest/auth_api.py
@@ -7,7 +7,6 @@ import time
 
 import attr
 
-from twisted.web.server import Request
 from twisted.python.urlpath import URLPath
 
 from mimic.canned_responses.auth import (
@@ -35,8 +34,6 @@ from mimic.model.behaviors import (
     EventDescription,
     regexp_predicate
 )
-
-Request.defaultContentType = 'application/json'
 
 authentication = EventDescription()
 """

--- a/mimic/rest/fastly_api.py
+++ b/mimic/rest/fastly_api.py
@@ -5,12 +5,8 @@ Defines get current customer
 
 import json
 
-from twisted.web.server import Request
-
 from mimic.rest.mimicapp import MimicApp
 from mimic.canned_responses import fastly
-
-Request.defaultContentType = 'application/json'
 
 
 class FastlyApi(object):

--- a/mimic/rest/glance_api.py
+++ b/mimic/rest/glance_api.py
@@ -7,15 +7,12 @@ import json
 from uuid import uuid4
 from six import text_type
 from zope.interface import implementer
-from twisted.web.server import Request
 from twisted.plugin import IPlugin
 from mimic.canned_responses.glance import get_images
 from mimic.rest.mimicapp import MimicApp
 from mimic.catalog import Entry
 from mimic.catalog import Endpoint
 from mimic.imimic import IAPIMock
-
-Request.defaultContentType = 'application/json'
 
 
 @implementer(IAPIMock, IPlugin)

--- a/mimic/rest/loadbalancer_api.py
+++ b/mimic/rest/loadbalancer_api.py
@@ -6,7 +6,6 @@ import json
 from uuid import uuid4
 from six import string_types, text_type
 from zope.interface import implementer
-from twisted.web.server import Request
 from twisted.plugin import IPlugin
 from mimic.rest.mimicapp import MimicApp
 from mimic.imimic import IAPIMock
@@ -21,9 +20,6 @@ from random import randrange
 
 from mimic.util.helper import invalid_resource, json_dump
 from characteristic import attributes
-
-
-Request.defaultContentType = 'application/json'
 
 
 @implementer(IAPIMock, IPlugin)

--- a/mimic/rest/maas_api.py
+++ b/mimic/rest/maas_api.py
@@ -13,7 +13,6 @@ from six import text_type
 
 from zope.interface import implementer
 
-from twisted.web.server import Request
 from twisted.plugin import IPlugin
 
 from mimic.catalog import Entry
@@ -25,9 +24,6 @@ from mimic.canned_responses.maas_agent_info import agent_info
 from mimic.canned_responses.maas_monitoring_zones import monitoring_zones
 from mimic.canned_responses.maas_alarm_examples import alarm_examples
 from mimic.util.helper import random_hex_generator
-
-
-Request.defaultContentType = 'application/json'
 
 
 class _MatchesID(object):

--- a/mimic/rest/nova_api.py
+++ b/mimic/rest/nova_api.py
@@ -11,8 +11,6 @@ from six import text_type
 
 from zope.interface import implementer
 
-from twisted.web.server import Request
-
 from twisted.python.urlpath import URLPath
 
 from twisted.plugin import IPlugin
@@ -27,8 +25,6 @@ from mimic.model.behaviors import make_behavior_api
 from mimic.model.nova_objects import (
     BadRequestError, GlobalServerCollections, LimitError, Server,
     bad_request, forbidden, not_found, server_creation)
-
-Request.defaultContentType = 'application/json'
 
 
 @implementer(IAPIMock, IPlugin)

--- a/mimic/rest/queue_api.py
+++ b/mimic/rest/queue_api.py
@@ -15,10 +15,7 @@ from mimic.catalog import Entry
 from mimic.catalog import Endpoint
 from mimic.rest.mimicapp import MimicApp
 from zope.interface import implementer
-from twisted.web.server import Request
 from random import randrange
-
-Request.defaultContentType = 'application/json'
 
 
 @implementer(IAPIMock, IPlugin)

--- a/mimic/rest/rackconnect_v3_api.py
+++ b/mimic/rest/rackconnect_v3_api.py
@@ -13,7 +13,6 @@ from six import text_type
 
 from twisted.plugin import IPlugin
 from twisted.web.http import NOT_FOUND, NOT_IMPLEMENTED
-from twisted.web.server import Request
 from zope.interface import implementer
 
 from mimic.catalog import Entry
@@ -23,7 +22,6 @@ from mimic.rest.mimicapp import MimicApp
 from mimic.util.helper import random_ipv4, seconds_to_timestamp
 
 
-Request.defaultContentType = 'application/json'
 timestamp_format = '%Y-%m-%dT%H:%M:%SZ'
 
 

--- a/mimic/tap.py
+++ b/mimic/tap.py
@@ -3,10 +3,9 @@ Twisted Application plugin for Mimic
 """
 from twisted.application.strports import service
 from twisted.application.service import MultiService
-from twisted.web.server import Site
 from twisted.python import usage
 from mimic.core import MimicCore
-from mimic.resource import MimicRoot
+from mimic.resource import MimicRoot, get_site
 from twisted.internet.task import Clock
 
 
@@ -17,7 +16,9 @@ class Options(usage.Options):
     optParameters = [['listen', 'l', '8900', 'The endpoint to listen on.']]
     optFlags = [['realtime', 'r',
                  'Make mimic advance time as real time advances; '
-                 'disable the "tick" endpoint.']]
+                 'disable the "tick" endpoint.'],
+                ['verbose', 'v',
+                 'Log more verbosely: include full requests and responses.']]
 
 
 def makeService(config):
@@ -31,7 +32,6 @@ def makeService(config):
         clock = Clock()
     core = MimicCore.fromPlugins(clock)
     root = MimicRoot(core, clock)
-    site = Site(root.app.resource())
-    site.displayTracebacks = False
+    site = get_site(root.app.resource(), logging=bool(config['verbose']))
     service(config['listen'], site).setServiceParent(s)
     return s

--- a/mimic/test/helpers.py
+++ b/mimic/test/helpers.py
@@ -17,7 +17,6 @@ from twisted.internet.error import ConnectionDone
 from twisted.internet.defer import succeed
 
 from twisted.web.client import Agent
-from twisted.web.server import Site
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import IBodyProducer
 from twisted.python.urlpath import URLPath
@@ -25,6 +24,8 @@ from twisted.python.urlpath import URLPath
 from twisted.python.failure import Failure
 
 import treq
+
+from mimic.resource import get_site
 
 
 class AbortableStringTransport(StringTransport):
@@ -90,7 +91,7 @@ class RequestTraversalAgent(object):
 
         # Now time for the server to do its job.  Ask it to build an HTTP
         # channel.
-        channel = Site(self._rootResource).buildProtocol(None)
+        channel = get_site(self._rootResource).buildProtocol(None)
 
         # Connect the channel to another in-memory transport so we can collect
         # the response.

--- a/mimic/test/test_resource.py
+++ b/mimic/test/test_resource.py
@@ -242,7 +242,6 @@ class RequestTests(SynchronousTestCase):
         """
         The default content type of all Mimic responses is application/json.
         """
-        self.patch(helpers, 'Site', get_site)
         response, _ = self.make_request_to_site()
         self.assertEqual(['application/json'],
                          response.headers.getRawHeaders('content-type'))
@@ -252,7 +251,7 @@ class RequestTests(SynchronousTestCase):
         If verbose logging is turned on, the full request and response is
         logged.
         """
-        self.patch(helpers, 'Site', partial(get_site, logging=True))
+        self.patch(helpers, 'get_site', partial(get_site, logging=True))
         logged_events = []
         addObserver(logged_events.append)
         self.addCleanup(removeObserver, logged_events.append)

--- a/mimic/test/test_resource.py
+++ b/mimic/test/test_resource.py
@@ -1,11 +1,29 @@
+import re
+
+from functools import partial
+
 from twisted.internet.task import Clock
 from twisted.trial.unittest import SynchronousTestCase
 
+try:
+    from twisted.logger.globalLogPublisher import addObserver, removeObserver
+except ImportError:
+    from twisted.python.log import addObserver, removeObserver
+
+try:
+    from twisted.logger import formatEvent as get_log_message
+except ImportError:
+    from twisted.python.log import textFromEventDict as get_log_message
+
 from mimic.canned_responses.mimic_presets import get_presets
 from mimic.core import MimicCore
-from mimic.resource import MimicRoot
+from mimic.resource import MimicRoot, get_site
 from mimic.test.dummy import ExampleAPI
-from mimic.test.helpers import json_request, request, request_with_content
+from mimic.test import helpers
+
+json_request = helpers.json_request
+request = helpers.request
+request_with_content = helpers.request_with_content
 
 
 def one_api(testCase, core):
@@ -197,3 +215,67 @@ class RootAndPresetTests(SynchronousTestCase):
         response = self.successResultOf(request(
             self, root, "POST", "/sendgrid/mail.send.json"))
         self.assertEqual(200, response.code)
+
+
+class RequestTests(SynchronousTestCase):
+    """
+    Tests for :obj:`mimic.resource.MimicRequest` and
+    :obj:`mimic.resource.MimicRequest`, and :obj:`mimic.resource.get_site`.
+    """
+    def make_request_to_site(self):
+        """
+        Make a request and return the response.
+        """
+        core = MimicCore(Clock(), [ExampleAPI('response!')])
+        root = MimicRoot(core).app.resource()
+
+        # get the region and service id registered for the example API
+        (region, service_id) = one_api(self, core)
+        url = "/mimicking/{0}/{1}".format(service_id, region)
+        response = self.successResultOf(request(
+            self, root, "GET", url, headers={"one": ["two"]}
+        ))
+        return (response, url)
+
+    def test_default_content_type(self):
+        """
+        The default content type of all Mimic responses is application/json.
+        """
+        self.patch(helpers, 'Site', get_site)
+        response, _ = self.make_request_to_site()
+        self.assertEqual(['application/json'],
+                         response.headers.getRawHeaders('content-type'))
+
+    def test_verbose_logging(self):
+        """
+        If verbose logging is turned on, the full request and response is
+        logged.
+        """
+        self.patch(helpers, 'Site', partial(get_site, logging=True))
+        logged_events = []
+        addObserver(logged_events.append)
+        self.addCleanup(removeObserver, logged_events.append)
+
+        response, url = self.make_request_to_site()
+
+        self.assertEqual(2, len(logged_events))
+        self.assertTrue(all([not event['isError'] for event in logged_events]))
+
+        messages = [get_log_message(event) for event in logged_events]
+        header_pattern = (
+            'Headers: \{{("\S+": \[".+"\], )*{0}(, "\S+": \[".+"\])*\}}')
+        request_regex = re.compile("\n".join([
+            "^Received request: GET {0}".format(url),
+            header_pattern.format('"One": \["two"\]'),
+            "\s*$"
+        ]))
+        response_regex = re.compile("\n".join([
+            "^Responding with 200 for: GET {0}".format(url),
+            header_pattern.format('"Content-Type": \["application/json"\]'),
+            "\nresponse\!\s*$"
+        ]))
+
+        self.assertNotEqual(None, request_regex.match(messages[0]),
+                            messages[0])
+        self.assertNotEqual(None, response_regex.match(messages[1]),
+                            messages[1])

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py26, py27, pypy}-twisted_{old_logging, new_logging}, docs, lint
+envlist = {py26,py27,pypy}-twisted_{old_logging,new_logging}, docs, lint
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, pypy, docs, lint
+envlist = {py26, py27, pypy}-twisted_{old_logging, new_logging}, docs, lint
 
 [testenv]
 deps =
@@ -30,6 +30,8 @@ deps =
      Sphinx==1.2.3
      sphinx-rtd-theme==0.1.6
      stevedore==1.2.0
+     twisted_old_logging: twisted<15.2.0
+     twisted_new_logging: twisted>=15.2.0
 basepython = python2.7
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@ envlist = {py26,py27,pypy}-twisted_{old_logging,new_logging}, docs, lint
 [testenv]
 deps =
     coverage==3.7.1
+    twisted_old_logging: twisted<15.2.0
+    twisted_new_logging: twisted>=15.2.0
 passenv = PIP_WHEEL_DIR PIP_FIND_LINKS
 commands =
     coverage erase
@@ -30,8 +32,6 @@ deps =
      Sphinx==1.2.3
      sphinx-rtd-theme==0.1.6
      stevedore==1.2.0
-     twisted_old_logging: twisted<15.2.0
-     twisted_new_logging: twisted>=15.2.0
 basepython = python2.7
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html


### PR DESCRIPTION
So it logs all incoming requests and outgoing responses.

Fixes #362.
Fixes #202.
Addresses part of #40.