### PR TITLE
Use codecov instead of coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ script:
   - ./.travis/run.sh
 
 after_success:
-  - source ~/.venv/bin/activate && coveralls
+  - "source ~/.venv/bin/activate && codecov"
 
 notifications:
   irc:

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -42,7 +42,7 @@ else
     source ~/.venv/bin/activate
     pip install wheel
     pip wheel cryptography lxml
-    pip install tox coveralls
+    pip install tox codecov
     tox --recreate --notest
 
     # If "installdeps" fails, "tox" exits with an error, and the "set -e" above

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ In order to use Mimic with most other projects you just need to override the Aut
 #### Build status: ####
 [![Build Status](https://travis-ci.org/rackerlabs/mimic.svg?branch=master)](https://travis-ci.org/rackerlabs/mimic)
 
-[![Coverage Status](https://coveralls.io/repos/rackerlabs/mimic/badge.png)](https://coveralls.io/r/rackerlabs/mimic)
+[![codecov.io](http://codecov.io/github/rackerlabs/mimic/coverage.svg?branch=master)](http://codecov.io/github/rackerlabs/mimic?branch=master)
 
 ## Compute ##
 


### PR DESCRIPTION
Codecov provides unified coverage reports across all the tox environments, and does branch coverage not just line coverage like coveralls.