### PR TITLE
includes support for list images though the servers api using glance_…

### DIFF
--- a/mimic/canned_responses/glance.py
+++ b/mimic/canned_responses/glance.py
@@ -1,7 +1,8 @@
 """
 Cannned responses for glance images
 """
-from mimic.canned_responses.json.glance.glance_images_json import images
+from mimic.canned_responses.json.glance.glance_images_json import (images,
+                                                                   image_schema)
 
 
 def get_images():
@@ -9,3 +10,10 @@ def get_images():
     Canned response for glance images list call
     """
     return images
+
+
+def get_image_schema():
+    """
+    Canned response for GET glance image schema API call
+    """
+    return image_schema

--- a/mimic/canned_responses/json/glance/glance_images_json.py
+++ b/mimic/canned_responses/json/glance/glance_images_json.py
@@ -49,3 +49,174 @@ images = {
     "schema": "/v2/schemas/images",
     "first": "/v2/images?limit=1000"
 }
+
+
+image_schema = {
+    "additionalProperties": {
+        "type": "string"
+    },
+    "name": "image",
+    "links": [
+        {
+            "href": "{self}",
+            "rel": "self"
+        },
+        {
+            "href": "{file}",
+            "rel": "enclosure"
+        },
+        {
+            "href": "{schema}",
+            "rel": "describedby"
+        }
+    ],
+    "properties": {
+        "status": {
+            "enum": [
+                "queued",
+                "saving",
+                "active",
+                "killed",
+                "deleted",
+                "pending_delete"
+            ],
+            "type": "string",
+            "description": "Status of the image (READ-ONLY)"
+        },
+        "schema": {
+            "type": "string",
+            "description": "(READ-ONLY)"
+        },
+        "file": {
+            "type": "string",
+            "description": "(READ-ONLY)"
+        },
+        "direct_url": {
+            "type": "string",
+            "description": "URL to access the image file kept in external store (READ-ONLY)"
+        },
+        "name": {
+            "type": ["null",
+                     "string"],
+            "description": "Descriptive name for the image",
+            "maxLength": 255},
+        "tags": {
+            "items": {
+                "type": "string",
+                "maxLength": 255},
+            "type": "array",
+            "description": "List of strings related to the image"
+        },
+        "locations": {
+            "items": {
+                "required": ["url",
+                             "metadata"],
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "maxLength": 255},
+                    "metadata": {
+                        "type": "object"
+                    }}},
+            "type": "array",
+            "description": "A set of URLs to access the image file kept in external store"
+        },
+        "checksum": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "description": "md5 hash of image contents. (READ-ONLY)",
+            "maxLength": 32
+        },
+        "created_at": {
+            "type": "string",
+            "description": "Date and time of image registration (READ-ONLY)"
+        },
+        "disk_format": {
+            "enum": [
+                None,
+                "ami",
+                "ari",
+                "aki",
+                "vhd",
+                "vmdk",
+                "raw",
+                "qcow2",
+                "vdi",
+                "iso"
+            ],
+            "type": [
+                "null",
+                "string"
+            ],
+            "description": "Format of the disk"
+        },
+        "updated_at": {
+            "type": "string",
+            "description": "Date and time of the last image modification (READ-ONLY)"
+        },
+        "visibility": {
+            "enum": [
+                "public",
+                "private"
+            ],
+            "type": "string",
+            "description": "Scope of image accessibility"
+        },
+        "self": {
+            "type": "string",
+            "description": "(READ-ONLY)"
+        },
+        "min_disk": {
+            "type": "integer",
+            "description": "Amount of disk space (in GB) required to boot image."
+        },
+        "protected": {
+            "type": "boolean",
+            "description": "If true, image will not be deletable."
+        },
+        "min_ram": {
+            "type": "integer",
+            "description": "Amount of ram (in MB) required to boot image."
+        },
+        "container_format": {
+            "enum": [
+                None,
+                "ami",
+                "ari",
+                "aki",
+                "bare",
+                "ovf",
+                "ova"
+            ],
+            "type": [
+                "null",
+                "string"
+            ],
+            "description": "Format of the container"
+        },
+        "owner": {
+            "type": ["null",
+                     "string"],
+            "description": "Owner of the image",
+            "maxLength": 255},
+        "virtual_size": {
+            "type": ["null",
+                     "integer"],
+            "description": "Virtual size of image in bytes (READ-ONLY)"
+        },
+        "id": {
+            "pattern": "^([0-9a-fA-F]){8}-([0-9a-fA-F]){4}-([0-9a-fA-F]){4}-([0-9a-fA-F])" +
+                       "{4}-([0-9a-fA-F]){12}$",
+            "type": "string",
+            "description": "An identifier for the image"
+        },
+        "size": {
+            "type": [
+                "null",
+                "integer"
+            ],
+            "description": "Size of image file in bytes (READ-ONLY)"
+        }}}

--- a/mimic/canned_responses/nova.py
+++ b/mimic/canned_responses/nova.py
@@ -14,19 +14,6 @@ from mimic.canned_responses.mimic_presets import get_presets
 from mimic.util.helper import not_found_response
 
 
-def get_image(image_id):
-    """
-    Canned response for get image.  The image id provided is substituted in the
-    response, if not one of the invalid image ids specified in mimic_presets.
-    """
-    if (
-            image_id in get_presets['servers']['invalid_image_ref'] or
-            image_id.endswith('Z')
-    ):
-        return not_found_response('images'), 404
-    return {'image': {'status': 'ACTIVE', 'id': image_id, 'name': 'mimic-test-image'}}, 200
-
-
 def get_flavor(flavor_id):
     """
     Canned response for get flavor.

--- a/mimic/canned_responses/nova.py
+++ b/mimic/canned_responses/nova.py
@@ -3,6 +3,7 @@
 Canned responses for nova's GET limits API
 """
 
+
 def get_limit():
     """
     Canned response for limits for servers. Returns only the absolute limits

--- a/mimic/core.py
+++ b/mimic/core.py
@@ -14,6 +14,7 @@ from mimic.imimic import IAPIMock
 from mimic.session import SessionStore
 from mimic.util.helper import random_hex_generator
 from mimic.model.mailgun_objects import MessageStore
+from mimic.model.glance_objects import GlanceAdminImageStore
 
 
 class MimicCore(object):
@@ -37,6 +38,7 @@ class MimicCore(object):
         self._uuid_to_api = {}
         self.sessions = SessionStore(clock)
         self.message_store = MessageStore()
+        self.glance_admin_image_store = GlanceAdminImageStore()
 
         for api in apis:
             this_api_id = ((api.__class__.__name__) + '-' +

--- a/mimic/model/glance_objects.py
+++ b/mimic/model/glance_objects.py
@@ -13,7 +13,7 @@ random_image_list = [
     {"id": str(uuid4()), "name": "OnMetal - Debian 8 (Jessie)", "distro": "linux"},
     {"id": str(uuid4()), "name": "OnMetal - Fedora 21", "distro": "linux"},
     {"id": str(uuid4()), "name": "OnMetal - Fedora 22", "distro": "linux"},
-    {"id": str(uuid4()), "name": "Ubuntu 14.04 LTS (Trusty Tahr)", "distro": "linux"},
+    {"id": str(uuid4()), "name": "OnMetal - Ubuntu 14.04 LTS (Trusty Tahr)", "distro": "linux"},
     {"id": str(uuid4()), "name": "OnMetal - CoreOS (Stable)", "distro": "linux"},
     {"id": str(uuid4()), "name": "OnMetal - Ubuntu 12.04 LTS (Precise Pangolin)",
      "distro": "linux"},

--- a/mimic/model/glance_objects.py
+++ b/mimic/model/glance_objects.py
@@ -30,14 +30,27 @@ class Image(object):
     """
     A Image object
     """
-    common_static_defaults = {
-        "min_ram": 256,
+
+    static_server_image_defaults = {
+        "minRam": 256,
+        "minDisk": 00,
+    }
+
+    static_glance_defaults = {
         "flavor_classes": "*",
+        "min_ram": 256,
+        "min_disk": 00,
+        "container_format": None,
+        "owner": "00000",
+        "size": 10000,
+        "tags": [],
+        "visibility": "public",
+        "checksum": "0000",
+        "protected": False,
         "disk_format": None,
         "ssh_user": "mimic",
         "schema": "/v2/schemas/image",
         "auto_disk_config": "disabled",
-        "min_disk": 00,
         "virtual_size": None,
         "visibility": "public"
     }
@@ -62,16 +75,6 @@ class Image(object):
         "auto_disk_config": "True",
         "com.rackspace__1__source": "kickstart",
         "com.rackspace__1__ui_default_show": "True"
-    }
-
-    static_image_defaults = {
-        "container_format": None,
-        "owner": "00000",
-        "size": 10000,
-        "tags": [],
-        "visibility": "public",
-        "checksum": "0000",
-        "protected": False
     }
 
     def links_json(self, absolutize_url):
@@ -103,11 +106,11 @@ class Image(object):
         returned by either a GET on this individual image through the
         servers api.
         """
-        template = self.common_static_defaults.copy()
+        template = self.static_server_image_defaults.copy()
         template.update({
             "id": self.image_id,
             "name": self.name,
-            "status": self.status,
+            "status": self.status.upper(),
             "links": self.links_json(absolutize_url),
             "progress": 100,
             "OS-DCF:diskConfig": "AUTO",
@@ -136,8 +139,7 @@ class Image(object):
         returned by either a GET on this individual image or a member in the
         list returned by the list-details request.
         """
-        template = self.common_static_defaults.copy()
-        template.update(self.static_image_defaults)
+        template = self.static_glance_defaults.copy()
         template.update(self.static_metadata)
         template.update({
             "id": self.image_id,

--- a/mimic/model/glance_objects.py
+++ b/mimic/model/glance_objects.py
@@ -23,7 +23,7 @@ random_image_list = [
 
 @attributes(["image_id", "name", "distro",
              Attribute("tenant_id", default_value=None),
-             Attribute("status", default_value='ACTIVE')])
+             Attribute("status", default_value='active')])
 class Image(object):
     """
     A Image object
@@ -31,7 +31,7 @@ class Image(object):
     common_static_defaults = {
         "min_ram": 256,
         "flavor_classes": "*",
-        "disk_format": "mimic",
+        "disk_format": None,
         "ssh_user": "mimic",
         "schema": "/v2/schemas/image",
         "auto_disk_config": "disabled",
@@ -119,12 +119,12 @@ class Image(object):
         }
 
     static_image_defaults = {
-        "container_format": "mimic",
-        "owner": 00000,
+        "container_format": None,
+        "owner": "00000",
         "size": 10000,
         "tags": [],
         "visibility": "public",
-        "checksum": 0000,
+        "checksum": "0000",
         "protected": False
     }
 

--- a/mimic/model/glance_objects.py
+++ b/mimic/model/glance_objects.py
@@ -1,0 +1,102 @@
+"""
+Model objects for the Glance mimic.
+"""
+from characteristic import attributes, Attribute
+
+
+@attributes(["image_id", "name", "distro", "tenant_id",
+             Attribute("status", default_value='ACTIVE')])
+class Image(object):
+    """
+    A Image object
+    """
+    common_static_defaults = {
+        "min_ram": 256,
+        "flavor_classes": "*",
+        "disk_format": "mimic",
+        "ssh_user": "mimic",
+        "schema": "/v2/schemas/image",
+        "auto_disk_config": "disabled",
+        "min_disk": 00,
+        "virtual_size": None,
+        "created": "1972-01-01_15-59-11",
+        "updated": "1972-01-01_15-59-11"
+    }
+
+    static_metadata = {
+        "com.rackspace__1__build_rackconnect": "1",
+        "com.rackspace__1__options": "0",
+        "flavor_classes": "*",
+        "vm_mode": "xen",
+        "com.rackspace__1__release_id": "000",
+        "com.rackspace__1__build_core": "1",
+        "image_type": "base",
+        "org.openstack__1__os_version": "0.1",
+        "com.rackspace__1__platform_target": "MimicCloud",
+        "com.rackspace__1__build_managed": "1",
+        "org.openstack__1__architecture": "x64",
+        "com.rackspace__1__visible_core": "1",
+        "com.rackspace__1__release_build_date": "1972-01-01_15-59-11",
+        "com.rackspace__1__visible_rackconnect": "1",
+        "com.rackspace__1__release_version": "1",
+        "com.rackspace__1__visible_managed": "1",
+        "cache_in_nova": "True",
+        "com.rackspace__1__build_config_options": "mimic",
+        "auto_disk_config": "True",
+        "com.rackspace__1__source": "kickstart",
+        "com.rackspace__1__ui_default_show": "True"
+    }
+
+    def links_json(self, absolutize_url):
+        """
+        Create a JSON-serializable data structure describing the links to this
+        image.
+        """
+        return [
+            {
+                "href": absolutize_url("v2/{0}/images/{1}"
+                                       .format(self.tenant_id, self.image_id)),
+                "rel": "self"
+            },
+            {
+                "href": absolutize_url("{0}/images/{1}"
+                                       .format(self.tenant_id, self.image_id)),
+                "rel": "bookmark"
+            },
+            {
+                "href": absolutize_url("/images/{0}".format(self.image_id)),
+                "rel": "alternate",
+                "type": "application/vnd.openstack.image"
+            }
+        ]
+
+    def get_server_image_details_json(self, absolutize_url):
+        """
+        JSON-serializable object representation of this image, as
+        returned by either a GET on this individual image through the
+        servers api.
+        """
+        template = self.common_static_defaults.copy()
+        template.update({
+            "id": self.image_id,
+            "name": self.name,
+            "status": self.status,
+            "links": self.links_json(absolutize_url),
+            "progress": 100,
+            "OS-DCF:diskConfig": "AUTO",
+            "OS-EXT-IMG-SIZE:size": 100000,
+            "metadata": self.static_metadata
+        })
+        if self.distro != "windows":
+            template["metadata"]["os_distro"] = self.distro
+        return template
+
+    def brief_json(self, absolutize_url):
+        """
+        Brief JSON-serializable version of this image.
+        """
+        return {
+            "name": self.name,
+            "id": self.image_id,
+            "links": self.links_json(absolutize_url)
+        }

--- a/mimic/model/glance_objects.py
+++ b/mimic/model/glance_objects.py
@@ -13,6 +13,8 @@ random_image_list = [
     {"id": str(uuid4()), "name": "OnMetal - Debian 8 (Jessie)", "distro": "linux"},
     {"id": str(uuid4()), "name": "OnMetal - Fedora 21", "distro": "linux"},
     {"id": str(uuid4()), "name": "OnMetal - Fedora 22", "distro": "linux"},
+    {"id": str(uuid4()), "name": "Ubuntu 14.04 LTS (Trusty Tahr)", "distro": "linux"},
+    {"id": str(uuid4()), "name": "OnMetal - CoreOS (Stable)", "distro": "linux"},
     {"id": str(uuid4()), "name": "OnMetal - Ubuntu 12.04 LTS (Precise Pangolin)",
      "distro": "linux"},
     {"id": str(uuid4()), "name": "Ubuntu 14.04 LTS (Trusty Tahr)", "distro": "linux"},

--- a/mimic/model/glance_objects.py
+++ b/mimic/model/glance_objects.py
@@ -64,6 +64,16 @@ class Image(object):
         "com.rackspace__1__ui_default_show": "True"
     }
 
+    static_image_defaults = {
+        "container_format": None,
+        "owner": "00000",
+        "size": 10000,
+        "tags": [],
+        "visibility": "public",
+        "checksum": "0000",
+        "protected": False
+    }
+
     def links_json(self, absolutize_url):
         """
         Create a JSON-serializable data structure describing the links to this
@@ -119,16 +129,6 @@ class Image(object):
             "id": self.image_id,
             "links": self.links_json(absolutize_url)
         }
-
-    static_image_defaults = {
-        "container_format": None,
-        "owner": "00000",
-        "size": 10000,
-        "tags": [],
-        "visibility": "public",
-        "checksum": "0000",
-        "protected": False
-    }
 
     def get_image_json(self):
         """

--- a/mimic/model/nova_objects.py
+++ b/mimic/model/nova_objects.py
@@ -8,7 +8,6 @@ from characteristic import attributes, Attribute
 from random import randrange
 from json import loads, dumps
 from urllib import urlencode
-from uuid import uuid4
 
 from six import string_types
 
@@ -18,7 +17,7 @@ from mimic.util.helper import (
     timestamp_to_seconds
 )
 from mimic.canned_responses.mimic_presets import get_presets
-from mimic.model.glance_objects import Image
+from mimic.model.glance_objects import Image, random_image_list
 from mimic.model.behaviors import (
     BehaviorRegistryCollection, EventDescription, Criterion, regexp_predicate
 )
@@ -931,20 +930,7 @@ class RegionalServerCollection(object):
         """
         Creates a list of images.
         """
-        images = [{"id": str(uuid4()), "name": "OnMetal - CentOS 6", "distro": "linux"},
-                  {"id": str(uuid4()), "name": "OnMetal - CentOS 7", "distro": "linux"},
-                  {"id": str(uuid4()), "name": "OnMetal - CoreOS (Alpha)", "distro": "linux"},
-                  {"id": str(uuid4()), "name": "OnMetal - CoreOS (Beta)", "distro": "linux"},
-                  {"id": str(uuid4()), "name": "OnMetal - Debian 7 (Wheezy)", "distro": "linux"},
-                  {"id": str(uuid4()), "name": "OnMetal - Debian 8 (Jessie)", "distro": "linux"},
-                  {"id": str(uuid4()), "name": "OnMetal - Fedora 21", "distro": "linux"},
-                  {"id": str(uuid4()), "name": "OnMetal - Fedora 22", "distro": "linux"},
-                  {"id": str(uuid4()), "name": "OnMetal - Ubuntu 12.04 LTS (Precise Pangolin)",
-                   "distro": "linux"},
-                  {"id": str(uuid4()), "name": "Ubuntu 14.04 LTS (Trusty Tahr)", "distro": "linux"},
-                  {"id": str(uuid4()), "name": "Ubuntu 15.04 (Vivid Vervet)", "distro": "linux"},
-                  {"id": str(uuid4()), "name": "Windows Server 2012 R2", "distro": "windows"}]
-        for each_image in images:
+        for each_image in random_image_list:
             if not self.image_by_name(each_image['name']):
                 image = Image(image_id=each_image['id'], name=each_image['name'],
                               distro=each_image['distro'], tenant_id=self.tenant_id)

--- a/mimic/model/nova_objects.py
+++ b/mimic/model/nova_objects.py
@@ -8,6 +8,7 @@ from characteristic import attributes, Attribute
 from random import randrange
 from json import loads, dumps
 from urllib import urlencode
+from uuid import uuid4
 
 from six import string_types
 
@@ -16,7 +17,8 @@ from mimic.util.helper import (
     random_string,
     timestamp_to_seconds
 )
-
+from mimic.canned_responses.mimic_presets import get_presets
+from mimic.model.glance_objects import Image
 from mimic.model.behaviors import (
     BehaviorRegistryCollection, EventDescription, Criterion, regexp_predicate
 )
@@ -643,6 +645,7 @@ def metadata_to_creation_behavior(metadata):
 @attributes(
     ["tenant_id", "region_name", "clock",
      Attribute("servers", default_factory=list),
+     Attribute("image_store", default_factory=list),
      Attribute(
          "behavior_registry_collection",
          default_factory=lambda: BehaviorRegistryCollection())]
@@ -905,6 +908,80 @@ class RegionalServerCollection(object):
 
         else:
             return dumps(bad_request("There is no such action currently supported", http_action_request))
+
+    # Server Images
+
+    def image_by_id(self, image_id):
+        """
+        Retrieve a :obj:`Image` object by its ID.
+        """
+        for image in self.image_store:
+            if image.image_id == image_id and image.status != u"DELETED":
+                return image
+
+    def image_by_name(self, image_name):
+        """
+        Retrieve a :obj:`Image` object by its ID.
+        """
+        for image in self.image_store:
+            if image.name == image_name:
+                return image
+
+    def _create_random_list_of_images(self):
+        """
+        Creates a list of images.
+        """
+        images = [{"id": str(uuid4()), "name": "OnMetal - CentOS 6", "distro": "linux"},
+                  {"id": str(uuid4()), "name": "OnMetal - CentOS 7", "distro": "linux"},
+                  {"id": str(uuid4()), "name": "OnMetal - CoreOS (Alpha)", "distro": "linux"},
+                  {"id": str(uuid4()), "name": "OnMetal - CoreOS (Beta)", "distro": "linux"},
+                  {"id": str(uuid4()), "name": "OnMetal - Debian 7 (Wheezy)", "distro": "linux"},
+                  {"id": str(uuid4()), "name": "OnMetal - Debian 8 (Jessie)", "distro": "linux"},
+                  {"id": str(uuid4()), "name": "OnMetal - Fedora 21", "distro": "linux"},
+                  {"id": str(uuid4()), "name": "OnMetal - Fedora 22", "distro": "linux"},
+                  {"id": str(uuid4()), "name": "OnMetal - Ubuntu 12.04 LTS (Precise Pangolin)",
+                   "distro": "linux"},
+                  {"id": str(uuid4()), "name": "Ubuntu 14.04 LTS (Trusty Tahr)", "distro": "linux"},
+                  {"id": str(uuid4()), "name": "Ubuntu 15.04 (Vivid Vervet)", "distro": "linux"},
+                  {"id": str(uuid4()), "name": "Windows Server 2012 R2", "distro": "windows"}]
+        for each_image in images:
+            if not self.image_by_name(each_image['name']):
+                image = Image(image_id=each_image['id'], name=each_image['name'],
+                              distro=each_image['distro'], tenant_id=self.tenant_id)
+                self.image_store.append(image)
+
+    def list_server_image(self, include_details, absolutize_url):
+        """
+        Return a list of images with details.
+        """
+        self._create_random_list_of_images()
+        result = {
+            "images": [
+                image.brief_json(absolutize_url) if not include_details
+                else image.get_server_image_details_json(absolutize_url)
+                for image in self.image_store
+            ]
+        }
+        return dumps(result)
+
+    def get_image(self, http_get_request, image_id, absolutize_url):
+        """
+        Return a image object if one exists from the list `/images` api,
+        else creates and adds the image to the :obj: `images_store`.
+        If the `image_id` is listed in `mimic.canned_responses.mimic_presets`,
+        then will return 404.
+        """
+        if (
+            image_id in get_presets['servers']['invalid_image_ref'] or
+            image_id.endswith('Z')
+        ):
+            return dumps(not_found("Image not found.", http_get_request))
+        image = self.image_by_id(image_id)
+        if image is None:
+            image = Image(image_id=image_id, name='mimic-test-image-coreos-instance',
+                          distro='linux', tenant_id=self.tenant_id)
+            self.image_store.append(image)
+        return dumps({"image": image.get_server_image_details_json(absolutize_url)})
 
 
 @attributes(["tenant_id", "clock",

--- a/mimic/resource.py
+++ b/mimic/resource.py
@@ -33,7 +33,7 @@ from mimic.rest.auth_api import (
     base_uri_from_request
 )
 from mimic.rest.noit_api import NoitApi
-from mimic.rest import fastly_api, mailgun_api
+from mimic.rest import fastly_api, mailgun_api, glance_api
 from mimic.util.helper import seconds_to_timestamp
 
 
@@ -148,6 +148,13 @@ class MimicRoot(object):
             # workaround for https://github.com/twisted/klein/issues/56
             return NoResource()
         return service_object
+
+    @app.route("/glance", branch=True)
+    def glance_admin_api(self, request):
+        """
+        Mock got the glance admin api
+        """
+        return glance_api.GlanceAdminApi(self.core).app.resource()
 
 
 class MimicRequest(Request, object):

--- a/mimic/rest/glance_api.py
+++ b/mimic/rest/glance_api.py
@@ -7,10 +7,7 @@ import json
 from uuid import uuid4
 from six import text_type
 from zope.interface import implementer
-
 from twisted.plugin import IPlugin
-from twisted.python.urlpath import URLPath
-
 from mimic.canned_responses.glance import get_images
 from mimic.rest.mimicapp import MimicApp
 from mimic.catalog import Entry
@@ -64,21 +61,6 @@ class GlanceMock(object):
         self._session_store = session_store
         self._name = name
 
-    def url(self, suffix):
-        """
-        Generate a URL to an object within the Glance URL hierarchy, given the
-        part of the URL that comes after.
-        """
-        return str(URLPath.fromString(self.uri_prefix).child(suffix))
-
-    def _region_collection_for_tenant(self, tenant_id):
-        """
-        Get the given server-cache object for the given tenant, creating one if
-        there isn't one.
-        """
-        return (self._api_mock._get_session(self._session_store, tenant_id)
-                .collection_for_region(self._name))
-
     app = MimicApp()
 
     @app.route('/v2/<string:tenant_id>/images', methods=['GET'])
@@ -87,4 +69,5 @@ class GlanceMock(object):
         Returns a list of glance images. Currently there is no provision
         for shared versus unshared images in the response
         """
+        request.setResponseCode(200)
         return json.dumps(get_images())

--- a/mimic/rest/glance_api.py
+++ b/mimic/rest/glance_api.py
@@ -7,7 +7,10 @@ import json
 from uuid import uuid4
 from six import text_type
 from zope.interface import implementer
+
 from twisted.plugin import IPlugin
+from twisted.python.urlpath import URLPath
+
 from mimic.canned_responses.glance import get_images
 from mimic.rest.mimicapp import MimicApp
 from mimic.catalog import Entry
@@ -61,6 +64,21 @@ class GlanceMock(object):
         self._session_store = session_store
         self._name = name
 
+    def url(self, suffix):
+        """
+        Generate a URL to an object within the Glance URL hierarchy, given the
+        part of the URL that comes after.
+        """
+        return str(URLPath.fromString(self.uri_prefix).child(suffix))
+
+    def _region_collection_for_tenant(self, tenant_id):
+        """
+        Get the given server-cache object for the given tenant, creating one if
+        there isn't one.
+        """
+        return (self._api_mock._get_session(self._session_store, tenant_id)
+                .collection_for_region(self._name))
+
     app = MimicApp()
 
     @app.route('/v2/<string:tenant_id>/images', methods=['GET'])
@@ -69,5 +87,4 @@ class GlanceMock(object):
         Returns a list of glance images. Currently there is no provision
         for shared versus unshared images in the response
         """
-        request.setResponseCode(200)
         return json.dumps(get_images())

--- a/mimic/rest/glance_api.py
+++ b/mimic/rest/glance_api.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 from six import text_type
 from zope.interface import implementer
 from twisted.plugin import IPlugin
-from mimic.canned_responses.glance import get_images
+from mimic.canned_responses.glance import get_images, get_image_schema
 from mimic.rest.mimicapp import MimicApp
 from mimic.catalog import Entry
 from mimic.catalog import Endpoint
@@ -71,3 +71,32 @@ class GlanceMock(object):
         """
         request.setResponseCode(200)
         return json.dumps(get_images())
+
+
+class GlanceAdminApi(object):
+    """
+    Rest endpoints for mocked Glance Admin API.
+    """
+
+    app = MimicApp()
+
+    def __init__(self, core):
+        """
+        :param MimicCore core: The core to which this Glance Admin API will be
+        communicating.
+        """
+        self.core = core
+
+    @app.route('/v2/images', methods=['GET'])
+    def get_images_for_admin(self, request):
+        """
+        Returns a list of glance images.
+        """
+        return json.dumps(self.core.glance_admin_image_store.list_images())
+
+    @app.route('/v2/schemas/image', methods=['GET'])
+    def get_image_schema_for_admin(self, request):
+        """
+        Returns the glance image schema.
+        """
+        return json.dumps(get_image_schema())

--- a/mimic/rest/nova_api.py
+++ b/mimic/rest/nova_api.py
@@ -16,7 +16,7 @@ from twisted.python.urlpath import URLPath
 from twisted.plugin import IPlugin
 from twisted.web.http import CREATED, BAD_REQUEST
 
-from mimic.canned_responses.nova import get_limit, get_image, get_flavor
+from mimic.canned_responses.nova import get_limit, get_flavor
 from mimic.rest.mimicapp import MimicApp
 from mimic.catalog import Entry
 from mimic.catalog import Endpoint
@@ -298,9 +298,30 @@ class NovaRegion(object):
         """
         Returns a get image response, for any given imageid
         """
-        response_data = get_image(image_id)
-        request.setResponseCode(response_data[1])
-        return json.dumps(response_data[0])
+        return (
+            self._region_collection_for_tenant(tenant_id)
+            .get_image(request, image_id, absolutize_url=self.url)
+        )
+
+    @app.route('/v2/<string:tenant_id>/images/detail', methods=['GET'])
+    def get_server_image_list_with_details(self, request, tenant_id):
+        """
+        Returns a image list.
+        """
+        return (
+            self._region_collection_for_tenant(tenant_id)
+            .list_server_image(include_details=True, absolutize_url=self.url)
+        )
+
+    @app.route('/v2/<string:tenant_id>/images', methods=['GET'])
+    def get_server_image_list(self, request, tenant_id):
+        """
+        Returns a image list.
+        """
+        return (
+            self._region_collection_for_tenant(tenant_id)
+            .list_server_image(include_details=False, absolutize_url=self.url)
+        )
 
     @app.route('/v2/<string:tenant_id>/flavors/<string:flavor_id>', methods=['GET'])
     def get_flavor(self, request, tenant_id, flavor_id):

--- a/mimic/test/test_glance.py
+++ b/mimic/test/test_glance.py
@@ -1,15 +1,23 @@
 import treq
 import json
+
 from twisted.trial.unittest import SynchronousTestCase
+from twisted.internet.task import Clock
+
 from mimic.test.fixtures import APIMockHelper
-from mimic.test.helpers import request
+from mimic.test.helpers import request, json_request
 from mimic.rest.glance_api import GlanceApi
+from mimic.core import MimicCore
+from mimic.resource import MimicRoot
+from mimic.canned_responses.json.glance.glance_images_json import image_schema
+from mimic.model.glance_objects import random_image_list
 
 
 class GlanceAPITests(SynchronousTestCase):
     """
     Tests for the Glance plugin api
     """
+
     def get_responsebody(self, r):
         """
         util json response body
@@ -33,3 +41,52 @@ class GlanceAPITests(SynchronousTestCase):
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
         self.assertEquals(True, 'images' in json.dumps(data))
+
+
+class GlanceAdminAPITests(SynchronousTestCase):
+    """
+    Tests for the Glance Admin API
+    """
+
+    def setUp(self):
+        """
+        Initialize core and root
+        """
+        self.core = MimicCore(Clock(), [])
+        self.root = MimicRoot(self.core).app.resource()
+
+    def list_images(self):
+        """
+        List images and return response
+        """
+        uri = "/glance/v2/images"
+        (response, content) = self.successResultOf(json_request(
+            self, self.root, "GET", uri))
+        self.assertEqual(200, response.code)
+        return content
+
+    def test_list_image_schema(self):
+        """
+        Get the image schema returned from glance admin API
+        """
+        uri = "/glance/v2/schemas/image"
+        (response, content) = self.successResultOf(json_request(
+            self, self.root, "GET", uri))
+        self.assertEqual(200, response.code)
+        self.assertEqual(sorted(image_schema.keys()),
+                         sorted(content))
+
+    def test_list_images_for_admin(self):
+        """
+        List the images returned from the glance admin api
+        """
+        content = self.list_images()
+        self.assertEqual(len(random_image_list), len(content['images']))
+
+    def test_list_images_for_admin_consistently(self):
+        """
+        List the images returned from the glance admin api
+        """
+        content1 = self.list_images()
+        content2 = self.list_images()
+        self.assertEqual(content2, content1)

--- a/mimic/test/test_glance.py
+++ b/mimic/test/test_glance.py
@@ -82,6 +82,9 @@ class GlanceAdminAPITests(SynchronousTestCase):
         """
         content = self.list_images()
         self.assertEqual(len(random_image_list), len(content['images']))
+        actual_image_names = [image['name'] for image in content['images']]
+        expected_image_names = [each['name'] for each in random_image_list]
+        self.assertEqual(sorted(actual_image_names), sorted(expected_image_names))
 
     def test_list_images_for_admin_consistently(self):
         """

--- a/mimic/test/test_glance.py
+++ b/mimic/test/test_glance.py
@@ -63,6 +63,8 @@ class GlanceAdminAPITests(SynchronousTestCase):
         (response, content) = self.successResultOf(json_request(
             self, self.root, "GET", uri))
         self.assertEqual(200, response.code)
+        for each in content['images']:
+            self.assertEqual(each["status"], "active")
         return content
 
     def test_list_image_schema(self):

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -411,21 +411,6 @@ class NovaAPITests(SynchronousTestCase):
         delete_server_response = self.successResultOf(delete_server)
         self.assertEqual(delete_server_response.code, 404)
 
-    def test_get_server_image(self):
-        """
-        Test to verify :func:`get_image` on ``GET /v2.0/<tenant_id>/images/<image_id>``
-        """
-        get_server_image = request(
-            self, self.root, "GET", self.uri + '/images/test-image-id')
-        get_server_image_response = self.successResultOf(get_server_image)
-        get_server_image_response_body = self.successResultOf(
-            treq.json_content(get_server_image_response))
-        self.assertEqual(get_server_image_response.code, 200)
-        self.assertEqual(
-            get_server_image_response_body['image']['id'], 'test-image-id')
-        self.assertEqual(
-            get_server_image_response_body['image']['status'], 'ACTIVE')
-
     def test_get_server_flavor(self):
         """
         Test to verify :func:`get_image` on ``GET /v2.0/<tenant_id>/flavors/<flavor_id>``
@@ -1638,16 +1623,6 @@ class NovaAPINegativeTests(SynchronousTestCase):
             self, self.root, "GET", self.uri + '/servers/' + server_id)
         get_server_response = self.successResultOf(get_server)
         self.assertEquals(get_server_response.code, 404)
-
-    def test_get_invalid_image(self):
-        """
-        Test to verify :func:`get_image` when invalid image from the
-        :obj: `mimic_presets` is provided or if image id ends with Z.
-        """
-        get_server_image = request(self, self.root, "GET", self.uri +
-                                   '/images/test-image-idZ')
-        get_server_image_response = self.successResultOf(get_server_image)
-        self.assertEqual(get_server_image_response.code, 404)
 
     def test_get_server_flavor(self):
         """

--- a/mimic/test/test_server_images.py
+++ b/mimic/test/test_server_images.py
@@ -64,7 +64,7 @@ class NovaAPIImagesTests(SynchronousTestCase):
         self.assertEqual(
             get_server_image_response_body['image']['id'], 'test-image-id')
         self.assertEqual(
-            get_server_image_response_body['image']['status'], 'active')
+            get_server_image_response_body['image']['status'], 'ACTIVE')
 
     def test_get_image_list(self):
         """
@@ -87,11 +87,9 @@ class NovaAPIImagesTests(SynchronousTestCase):
         for each_image in image_list:
             self.assertEqual(
                 sorted(each_image.keys()),
-                sorted(['id', 'name', 'links', 'status', 'progress', 'min_ram',
+                sorted(['id', 'name', 'links', 'status', 'progress', 'minRam',
                         'OS-DCF:diskConfig', 'OS-EXT-IMG-SIZE:size', 'metadata',
-                        'flavor_classes', 'disk_format', 'ssh_user', 'min_disk',
-                        'auto_disk_config', 'virtual_size', 'created', 'updated',
-                        'schema', 'visibility']))
+                        'minDisk', 'created', 'updated']))
 
     def test_get_image_list_with_details_is_consistent(self):
         """

--- a/mimic/test/test_server_images.py
+++ b/mimic/test/test_server_images.py
@@ -63,6 +63,8 @@ class NovaAPIImagesTests(SynchronousTestCase):
             '/images/test-image-id')
         self.assertEqual(
             get_server_image_response_body['image']['id'], 'test-image-id')
+        self.assertEqual(
+            get_server_image_response_body['image']['status'], 'ACTIVE')
 
     def test_get_image_list(self):
         """

--- a/mimic/test/test_server_images.py
+++ b/mimic/test/test_server_images.py
@@ -64,7 +64,7 @@ class NovaAPIImagesTests(SynchronousTestCase):
         self.assertEqual(
             get_server_image_response_body['image']['id'], 'test-image-id')
         self.assertEqual(
-            get_server_image_response_body['image']['status'], 'ACTIVE')
+            get_server_image_response_body['image']['status'], 'active')
 
     def test_get_image_list(self):
         """

--- a/mimic/test/test_server_images.py
+++ b/mimic/test/test_server_images.py
@@ -1,0 +1,114 @@
+"""
+Tests for :mod:`nova_api` and :mod:`nova_objects` for images.
+"""
+
+from twisted.trial.unittest import SynchronousTestCase
+
+from mimic.test.helpers import json_request, request
+from mimic.rest.nova_api import NovaApi, NovaControlApi
+from mimic.test.fixtures import APIMockHelper
+
+
+class NovaAPIImagesTests(SynchronousTestCase):
+
+    """
+    Tests for Images using the Nova Api plugin.
+    """
+
+    def setUp(self):
+        """
+        Create a :obj:`MimicCore` with :obj:`NovaApi` as the only plugin.
+        """
+        nova_api = NovaApi(["ORD", "MIMIC"])
+        self.helper = self.helper = APIMockHelper(
+            self, [nova_api, NovaControlApi(nova_api=nova_api)]
+        )
+        self.root = self.helper.root
+        self.uri = self.helper.uri
+
+    def get_server_image(self, postfix):
+        """
+        Get images, assert response code is 200 and return response body.
+        """
+        (response, content) = self.successResultOf(json_request(
+            self, self.root, "GET", self.uri + postfix))
+        self.assertEqual(200, response.code)
+        return content
+
+    def test_get_server_image_negative(self):
+        """
+        Test to verify :func:`get_image` when invalid image from the
+        :obj: `mimic_presets` is provided.
+        """
+        get_server_image = request(self, self.root, "GET", self.uri +
+                                   '/images/1111')
+        get_server_image_response = self.successResultOf(get_server_image)
+        self.assertEqual(get_server_image_response.code, 404)
+
+    def test_get_server_image_negative2(self):
+        """
+        Test to verify :func:`get_image` when invalid image from the
+        :obj: `mimic_presets` is provided.
+        """
+        get_server_image = request(self, self.root, "GET", self.uri +
+                                   '/images/any-image-ending-with-Z')
+        get_server_image_response = self.successResultOf(get_server_image)
+        self.assertEqual(get_server_image_response.code, 404)
+
+    def test_get_server_image(self):
+        """
+        Test to verify :func:`get_image` on ``GET /v2.0/<tenant_id>/images/<image_id>``
+        """
+        get_server_image_response_body = self.get_server_image(
+            '/images/test-image-id')
+        self.assertEqual(
+            get_server_image_response_body['image']['id'], 'test-image-id')
+
+    def test_get_image_list(self):
+        """
+        Test to verify :func:`get_image_list` on ``GET /v2.0/<tenant_id>/images``
+        """
+        get_image_list_response_body = self.get_server_image('/images')
+        image_list = get_image_list_response_body['images']
+        self.assertTrue(len(image_list) > 1)
+        for each_image in image_list:
+            self.assertEqual(sorted(each_image.keys()), sorted(['id', 'name', 'links']))
+
+    def test_get_image_list_with_details(self):
+        """
+        Test to verify :func:`test_get_image_list_with_details` on
+        ``GET /v2.0/<tenant_id>/images/details``
+        """
+        get_image_list_response_body = self.get_server_image('/images/detail')
+        image_list = get_image_list_response_body['images']
+        self.assertTrue(len(image_list) > 1)
+        for each_image in image_list:
+            self.assertEqual(
+                sorted(each_image.keys()),
+                sorted(['id', 'name', 'links', 'status', 'progress', 'min_ram',
+                        'OS-DCF:diskConfig', 'OS-EXT-IMG-SIZE:size', 'metadata',
+                        'flavor_classes', 'disk_format', 'ssh_user', 'min_disk',
+                        'auto_disk_config', 'virtual_size', 'created', 'updated',
+                        'schema']))
+
+    def test_get_image_list_with_details_is_consistent(self):
+        """
+        Test to verify ``GET /v2.0/<tenant_id>/images/details`` returns
+        consistent data on mutiple list calls
+        """
+        get_image_list_response_body = self.get_server_image('/images/detail')
+        get_image_list2_response_body = self.get_server_image('/images/detail')
+        self.assertEqual(get_image_list_response_body, get_image_list2_response_body)
+
+    def test_get_image_list_after_list_images(self):
+        """
+        Test to verify :func:`get_image_list` on ``GET /v2.0/<tenant_id>/images``
+        """
+        image_list = self.get_server_image('/images')['images']
+        for each_image in image_list:
+            get_server_image_response_body = self.get_server_image(
+                '/images/' + each_image['id'])
+            self.assertEqual(each_image['id'],
+                             get_server_image_response_body['image']['id'])
+            self.assertEqual(each_image['name'],
+                             get_server_image_response_body['image']['name'])

--- a/mimic/test/test_server_images.py
+++ b/mimic/test/test_server_images.py
@@ -91,7 +91,7 @@ class NovaAPIImagesTests(SynchronousTestCase):
                         'OS-DCF:diskConfig', 'OS-EXT-IMG-SIZE:size', 'metadata',
                         'flavor_classes', 'disk_format', 'ssh_user', 'min_disk',
                         'auto_disk_config', 'virtual_size', 'created', 'updated',
-                        'schema']))
+                        'schema', 'visibility']))
 
     def test_get_image_list_with_details_is_consistent(self):
         """


### PR DESCRIPTION
…objects

Initially created this PR to add list images inside of the nova plugin, thinking [Arsenal] (https://github.com/rackerlabs/arsenal) uses this API call. But then realized that Arsenal uses the Glance Admin API and included that in commit b530313