### PR TITLE
feat(maas_plugin): add MaasControlApi

### DIFF
--- a/mimic/model/maas_objects.py
+++ b/mimic/model/maas_objects.py
@@ -3,46 +3,52 @@ MaaS API data model
 """
 
 import random
-import time
 
 
-def random_letters(len_min, len_max=None):
+def random_letters(len_min, len_max):
     """
     Makes a string with random letters (a-z).
     """
-    if len_max is None:
-        len_max = len_min
     return ''.join([chr(ord('a') + random.randint(0, 25))
                     for _ in xrange(random.randint(len_min, len_max))])
 
 
-class TestCheckMetric(object):
+class Metric(object):
     """
-    Models a metric from the test-check API
+    Models a MaaS metric type.
     """
-    def __init__(self, name, type, unit='other'):
+    def __init__(self, name, type, clock, unit='other'):
         """
-        Constructs a test check metric data source
+        Initializes the metric.
         """
         self.name = name
         self.type = type
         self._unit = unit
-        self._override = None
+        self._overrides = {}
+        self._clock = clock
 
-    def set_override(self, value):
+    def _override_key(self, **kwargs):
         """
-        Sets the override metric value.
+        Computes a key used for hashing overrides, as a tuple of strings.
+        """
+        return (kwargs['entity_id'],
+                kwargs['check_id'],
+                kwargs.get('monitoring_zone', '__AGENT__'))
 
-        We wrap the override value in a dict so that we can distinguish
-        between None (i.e., null) and no override.
+    def set_override(self, **kwargs):
         """
-        self._override = {'value': value}
+        Sets the override metric for a given tenant, entity and check.
 
-    def clear_override(self):
+        Override metrics are defined as a function which takes a timestamp
+        and returns the metric value.
         """
-        Clears the override metric value.
+        self._overrides[self._override_key(**kwargs)] = kwargs['override_fn']
+
+    def clear_overrides(self):
         """
-        self._override = None
+        Clears the override metric values.
+        """
+        self._overrides = {}
 
     def _get_default_data(self):
         """
@@ -60,33 +66,51 @@ class TestCheckMetric(object):
             return random_letters(12, 30)
         raise ValueError('No default data getter for type {0}!'.format(self.type))
 
-    def get_value(self):
+    def get_value_for_test_check(self, **kwargs):
         """
         Gets the metric data object as returned from the test-check API.
         """
-        data = (self._get_default_data() if self._override is None
-                else self._override['value'])
+        override_key = self._override_key(**kwargs)
+        timestamp = kwargs['timestamp']
+        data = self._get_default_data()
+
+        if override_key in self._overrides:
+            data_fn = self._overrides[override_key]
+            data = data_fn(timestamp)
+
         return {'type': self.type,
                 'unit': self._unit,
                 'data': data}
 
 
-class TestCheckData(object):
+class CheckType(object):
     """
-    Models test-check response data
+    Data model for a MaaS check type (e.g., remote.ping).
     """
-    def __init__(self, metrics):
+    def __init__(self, clock, metrics):
         """
-        Initializes the test-check responder
+        Constructs a check type with metrics.
         """
         self.metrics = metrics
-        self.available = True
-        self.status = "code=200,rt=0.4s,bytes=99"
-        self.response_code = 200
+        self.test_check_available = {}
+        self.test_check_status = {}
+        self.test_check_response_code = {}
+        self._clock = clock
+
+    def clear_overrides(self):
+        """
+        Clears the overrides for test-checks and metrics.
+        """
+        self.test_check_available = {}
+        self.test_check_status = {}
+        self.test_check_response_code = {}
+
+        for metric in self.metrics:
+            metric.clear_overrides()
 
     def get_metric_by_name(self, metric_name):
         """
-        Gets the metric on this test-check.
+        Gets the metric on this check type.
 
         This method is useful for setting and clearing overrides on the
         test metrics.
@@ -96,102 +120,110 @@ class TestCheckData(object):
                 return metric
         raise NameError('No metric named "{0}"!'.format(metric_name))
 
-    def get_response(self):
+    def get_test_check_response(self, **kwargs):
         """
-        Gets the test-check response.
+        Gets the response as would have been returned by the test-check API.
         """
-        monitoring_zone = random_letters(6)
-        return (self.response_code,
-                [{'timestamp': int(time.time() * 1000),
+        entity_id = kwargs['entity_id']
+        check_id = kwargs.get('check_id', '__test_check')
+        monitoring_zones = kwargs.get('monitoring_zones') or ['__AGENT__']
+
+        ench_key = (entity_id, check_id)
+        timestamp = int(1000 * self._clock.seconds())
+
+        return (self.test_check_response_code.get(ench_key, 200),
+                [{'timestamp': timestamp,
                   'monitoring_zone_id': monitoring_zone,
-                  'available': self.available,
-                  'status': self.status,
-                  'metrics': dict([(m.name, m.get_value()) for m in self.metrics])}])
+                  'available': self.test_check_available.get(ench_key, True),
+                  'status': self.test_check_status.get(
+                      ench_key, 'code=200,rt=0.4s,bytes=99'),
+                  'metrics': dict([(m.name,
+                                    m.get_value_for_test_check(
+                                        entity_id=entity_id,
+                                        check_id=check_id,
+                                        monitoring_zone=monitoring_zone,
+                                        timestamp=timestamp))
+                                   for m in self.metrics])}
+                 for monitoring_zone in monitoring_zones])
 
 
-test_check_responses = {}
-
-test_check_responses['agent.cpu'] = lambda: TestCheckData([
-    TestCheckMetric('user_percent_average', 'n', 'percent'),
-    TestCheckMetric('wait_percent_average', 'n', 'percent'),
-    TestCheckMetric('sys_percent_average', 'n', 'percent'),
-    TestCheckMetric('idle_percent_average', 'n', 'percent'),
-    TestCheckMetric('irq_percent_average', 'n', 'percent'),
-    TestCheckMetric('usage_average', 'n', 'percent'),
-    TestCheckMetric('min_cpu_usage', 'n', 'percent'),
-    TestCheckMetric('max_cpu_usage', 'n', 'percent'),
-    TestCheckMetric('stolen_percent_average', 'n', 'percent')])
-
-test_check_responses['agent.disk'] = lambda: TestCheckData([
-    TestCheckMetric('queue', 'i'),
-    TestCheckMetric('read_bytes', 'i', 'bytes'),
-    TestCheckMetric('reads', 'i', 'count'),
-    TestCheckMetric('rtime', 'i'),
-    TestCheckMetric('wtime', 'i'),
-    TestCheckMetric('write_bytes', 'i', 'bytes'),
-    TestCheckMetric('writes', 'i', 'count')])
-
-test_check_responses['agent.filesystem'] = lambda: TestCheckData([
-    TestCheckMetric('avail', 'i', 'kilobytes'),
-    TestCheckMetric('free', 'i', 'kilobytes'),
-    TestCheckMetric('options', 's', 'string'),
-    TestCheckMetric('total', 'i', 'kilobytes'),
-    TestCheckMetric('used', 'i', 'kilobytes'),
-    TestCheckMetric('files', 'i', 'count'),
-    TestCheckMetric('free_files', 'i', 'count')])
-
-test_check_responses['agent.load_average'] = lambda: TestCheckData([
-    TestCheckMetric('1m', 'n'),
-    TestCheckMetric('5m', 'n'),
-    TestCheckMetric('10m', 'n')])
-
-test_check_responses['agent.memory'] = lambda: TestCheckData([
-    TestCheckMetric('actual_free', 'i', 'bytes'),
-    TestCheckMetric('actual_used', 'i', 'bytes'),
-    TestCheckMetric('free', 'i', 'bytes'),
-    TestCheckMetric('ram', 'i', 'megabytes'),
-    TestCheckMetric('swap_free', 'i', 'bytes'),
-    TestCheckMetric('swap_page_in', 'i', 'bytes'),
-    TestCheckMetric('swap_page_out', 'i', 'bytes'),
-    TestCheckMetric('swap_total', 'i', 'bytes'),
-    TestCheckMetric('swap_used', 'i', 'bytes'),
-    TestCheckMetric('total', 'i', 'bytes'),
-    TestCheckMetric('used', 'i', 'bytes')])
-
-test_check_responses['agent.network'] = lambda: TestCheckData([
-    TestCheckMetric('rx_bytes', 'i', 'bytes'),
-    TestCheckMetric('rx_dropped', 'i', 'bytes'),
-    TestCheckMetric('rx_errors', 'i', 'bytes'),
-    TestCheckMetric('rx_packets', 'i', 'bytes'),
-    TestCheckMetric('tx_bytes', 'i', 'bytes'),
-    TestCheckMetric('tx_dropped', 'i', 'bytes'),
-    TestCheckMetric('tx_errors', 'i', 'bytes'),
-    TestCheckMetric('tx_packets', 'i', 'bytes')])
-
-test_check_responses['remote.http'] = lambda: TestCheckData([
-    TestCheckMetric('rx_bytes', 'i', 'bytes'),
-    TestCheckMetric('rx_dropped', 'i', 'bytes'),
-    TestCheckMetric('rx_errors', 'i', 'bytes'),
-    TestCheckMetric('rx_packets', 'i', 'bytes'),
-    TestCheckMetric('tx_bytes', 'i', 'bytes'),
-    TestCheckMetric('tx_dropped', 'i', 'bytes'),
-    TestCheckMetric('tx_errors', 'i', 'bytes'),
-    TestCheckMetric('tx_packets', 'i', 'bytes')])
-
-test_check_responses['remote.ping'] = lambda: TestCheckData([
-    TestCheckMetric('available', 'n', 'percent'),
-    TestCheckMetric('average', 'n'),
-    TestCheckMetric('count', 'i', 'count'),
-    TestCheckMetric('maximum', 'n'),
-    TestCheckMetric('minimum', 'n')])
-
-
-def get_test_check_response_by_type(check_type):
+class MaasStore(object):
     """
-    Looks up the correct test-check data response by check type.
-
-    This should not be used if a test-check responder exists for the
-    desired entity ID and check type. The responder should be cached
-    so that the metric values can be overridden.
+    A collection of MaaS configuration objects.
     """
-    return test_check_responses[check_type]()
+    def __init__(self, clock):
+        """
+        Initializes the Maas configuration using the provided clock.
+        """
+        self.check_types = {
+            'agent.cpu': CheckType(clock, [
+                Metric('user_percent_average', 'n', clock, unit='percent'),
+                Metric('wait_percent_average', 'n', clock, unit='percent'),
+                Metric('sys_percent_average', 'n', clock, unit='percent'),
+                Metric('idle_percent_average', 'n', clock, unit='percent'),
+                Metric('irq_percent_average', 'n', clock, unit='percent'),
+                Metric('usage_average', 'n', clock, unit='percent'),
+                Metric('min_cpu_usage', 'n', clock, unit='percent'),
+                Metric('max_cpu_usage', 'n', clock, unit='percent'),
+                Metric('stolen_percent_average', 'n', clock, unit='percent')]),
+            'agent.disk': CheckType(clock, [
+                Metric('queue', 'i', clock),
+                Metric('read_bytes', 'i', clock, unit='bytes'),
+                Metric('reads', 'i', clock, unit='count'),
+                Metric('rtime', 'i', clock),
+                Metric('wtime', 'i', clock),
+                Metric('write_bytes', 'i', clock, unit='bytes'),
+                Metric('writes', 'i', clock, unit='count')]),
+            'agent.filesystem': CheckType(clock, [
+                Metric('avail', 'i', clock, unit='kilobytes'),
+                Metric('free', 'i', clock, unit='kilobytes'),
+                Metric('options', 's', clock, unit='string'),
+                Metric('total', 'i', clock, unit='kilobytes'),
+                Metric('used', 'i', clock, unit='kilobytes'),
+                Metric('files', 'i', clock, unit='count'),
+                Metric('free_files', 'i', clock, unit='count')]),
+            'agent.load_average': CheckType(clock, [
+                Metric('1m', 'n', clock),
+                Metric('5m', 'n', clock),
+                Metric('10m', 'n', clock)]),
+            'agent.memory': CheckType(clock, [
+                Metric('actual_free', 'i', clock, unit='bytes'),
+                Metric('actual_used', 'i', clock, unit='bytes'),
+                Metric('free', 'i', clock, unit='bytes'),
+                Metric('ram', 'i', clock, unit='megabytes'),
+                Metric('swap_free', 'i', clock, unit='bytes'),
+                Metric('swap_page_in', 'i', clock, unit='bytes'),
+                Metric('swap_page_out', 'i', clock, unit='bytes'),
+                Metric('swap_total', 'i', clock, unit='bytes'),
+                Metric('swap_used', 'i', clock, unit='bytes'),
+                Metric('total', 'i', clock, unit='bytes'),
+                Metric('used', 'i', clock, unit='bytes')]),
+            'agent.network': CheckType(clock, [
+                Metric('rx_bytes', 'i', clock, unit='bytes'),
+                Metric('rx_dropped', 'i', clock, unit='bytes'),
+                Metric('rx_errors', 'i', clock, unit='bytes'),
+                Metric('rx_packets', 'i', clock, unit='bytes'),
+                Metric('tx_bytes', 'i', clock, unit='bytes'),
+                Metric('tx_dropped', 'i', clock, unit='bytes'),
+                Metric('tx_errors', 'i', clock, unit='bytes'),
+                Metric('tx_packets', 'i', clock, unit='bytes')]),
+            'remote.http': CheckType(clock, [
+                Metric('bytes', 'i', clock, unit='bytes'),
+                Metric('cert_end', 'i', clock),
+                Metric('cert_end_in', 'i', clock),
+                Metric('cert_error', 's', clock, unit='string'),
+                Metric('cert_issuer', 's', clock, unit='string'),
+                Metric('cert_start', 'i', clock),
+                Metric('cert_subject', 's', clock, unit='string'),
+                Metric('cert_subject_alternative_names', 's', clock, unit='string'),
+                Metric('code', 's', clock, unit='string'),
+                Metric('duration', 'i', clock),
+                Metric('truncated', 'i', clock, unit='bytes'),
+                Metric('tt_connect', 'i', clock),
+                Metric('tt_firstbyte', 'i', clock)]),
+            'remote.ping': CheckType(clock, [
+                Metric('available', 'n', clock, unit='percent'),
+                Metric('average', 'n', clock),
+                Metric('count', 'i', clock, unit='count'),
+                Metric('maximum', 'n', clock),
+                Metric('minimum', 'n', clock)])}

--- a/mimic/model/maas_objects.py
+++ b/mimic/model/maas_objects.py
@@ -1,0 +1,197 @@
+"""
+MaaS API data model
+"""
+
+import random
+import time
+
+
+def random_letters(len_min, len_max=None):
+    """
+    Makes a string with random letters (a-z).
+    """
+    if len_max is None:
+        len_max = len_min
+    return ''.join([chr(ord('a') + random.randint(0, 25))
+                    for _ in xrange(random.randint(len_min, len_max))])
+
+
+class TestCheckMetric(object):
+    """
+    Models a metric from the test-check API
+    """
+    def __init__(self, name, type, unit='other'):
+        """
+        Constructs a test check metric data source
+        """
+        self.name = name
+        self.type = type
+        self._unit = unit
+        self._override = None
+
+    def set_override(self, value):
+        """
+        Sets the override metric value.
+
+        We wrap the override value in a dict so that we can distinguish
+        between None (i.e., null) and no override.
+        """
+        self._override = {'value': value}
+
+    def clear_override(self):
+        """
+        Clears the override metric value.
+        """
+        self._override = None
+
+    def _get_default_data(self):
+        """
+        Gets the default data point. This data point may be overridden by
+        setting the override value.
+        """
+        if self.type == 'i':
+            return random.randint(0, 100000)
+        elif self.type == 'n':
+            if self._unit == 'percent':
+                return random.uniform(0, 100)
+            else:
+                return random.uniform(0, 100000)
+        elif self.type == 's':
+            return random_letters(12, 30)
+        raise ValueError('No default data getter for type {0}!'.format(self.type))
+
+    def get_value(self):
+        """
+        Gets the metric data object as returned from the test-check API.
+        """
+        data = (self._get_default_data() if self._override is None
+                else self._override['value'])
+        return {'type': self.type,
+                'unit': self._unit,
+                'data': data}
+
+
+class TestCheckData(object):
+    """
+    Models test-check response data
+    """
+    def __init__(self, metrics):
+        """
+        Initializes the test-check responder
+        """
+        self.metrics = metrics
+        self.available = True
+        self.status = "code=200,rt=0.4s,bytes=99"
+        self.response_code = 200
+
+    def get_metric_by_name(self, metric_name):
+        """
+        Gets the metric on this test-check.
+
+        This method is useful for setting and clearing overrides on the
+        test metrics.
+        """
+        for metric in self.metrics:
+            if metric.name == metric_name:
+                return metric
+        raise NameError('No metric named "{0}"!'.format(metric_name))
+
+    def get_response(self):
+        """
+        Gets the test-check response.
+        """
+        monitoring_zone = random_letters(6)
+        return (self.response_code,
+                [{'timestamp': int(time.time() * 1000),
+                  'monitoring_zone_id': monitoring_zone,
+                  'available': self.available,
+                  'status': self.status,
+                  'metrics': dict([(m.name, m.get_value()) for m in self.metrics])}])
+
+
+test_check_responses = {}
+
+test_check_responses['agent.cpu'] = lambda: TestCheckData([
+    TestCheckMetric('user_percent_average', 'n', 'percent'),
+    TestCheckMetric('wait_percent_average', 'n', 'percent'),
+    TestCheckMetric('sys_percent_average', 'n', 'percent'),
+    TestCheckMetric('idle_percent_average', 'n', 'percent'),
+    TestCheckMetric('irq_percent_average', 'n', 'percent'),
+    TestCheckMetric('usage_average', 'n', 'percent'),
+    TestCheckMetric('min_cpu_usage', 'n', 'percent'),
+    TestCheckMetric('max_cpu_usage', 'n', 'percent'),
+    TestCheckMetric('stolen_percent_average', 'n', 'percent')])
+
+test_check_responses['agent.disk'] = lambda: TestCheckData([
+    TestCheckMetric('queue', 'i'),
+    TestCheckMetric('read_bytes', 'i', 'bytes'),
+    TestCheckMetric('reads', 'i', 'count'),
+    TestCheckMetric('rtime', 'i'),
+    TestCheckMetric('wtime', 'i'),
+    TestCheckMetric('write_bytes', 'i', 'bytes'),
+    TestCheckMetric('writes', 'i', 'count')])
+
+test_check_responses['agent.filesystem'] = lambda: TestCheckData([
+    TestCheckMetric('avail', 'i', 'kilobytes'),
+    TestCheckMetric('free', 'i', 'kilobytes'),
+    TestCheckMetric('options', 's', 'string'),
+    TestCheckMetric('total', 'i', 'kilobytes'),
+    TestCheckMetric('used', 'i', 'kilobytes'),
+    TestCheckMetric('files', 'i', 'count'),
+    TestCheckMetric('free_files', 'i', 'count')])
+
+test_check_responses['agent.load_average'] = lambda: TestCheckData([
+    TestCheckMetric('1m', 'n'),
+    TestCheckMetric('5m', 'n'),
+    TestCheckMetric('10m', 'n')])
+
+test_check_responses['agent.memory'] = lambda: TestCheckData([
+    TestCheckMetric('actual_free', 'i', 'bytes'),
+    TestCheckMetric('actual_used', 'i', 'bytes'),
+    TestCheckMetric('free', 'i', 'bytes'),
+    TestCheckMetric('ram', 'i', 'megabytes'),
+    TestCheckMetric('swap_free', 'i', 'bytes'),
+    TestCheckMetric('swap_page_in', 'i', 'bytes'),
+    TestCheckMetric('swap_page_out', 'i', 'bytes'),
+    TestCheckMetric('swap_total', 'i', 'bytes'),
+    TestCheckMetric('swap_used', 'i', 'bytes'),
+    TestCheckMetric('total', 'i', 'bytes'),
+    TestCheckMetric('used', 'i', 'bytes')])
+
+test_check_responses['agent.network'] = lambda: TestCheckData([
+    TestCheckMetric('rx_bytes', 'i', 'bytes'),
+    TestCheckMetric('rx_dropped', 'i', 'bytes'),
+    TestCheckMetric('rx_errors', 'i', 'bytes'),
+    TestCheckMetric('rx_packets', 'i', 'bytes'),
+    TestCheckMetric('tx_bytes', 'i', 'bytes'),
+    TestCheckMetric('tx_dropped', 'i', 'bytes'),
+    TestCheckMetric('tx_errors', 'i', 'bytes'),
+    TestCheckMetric('tx_packets', 'i', 'bytes')])
+
+test_check_responses['remote.http'] = lambda: TestCheckData([
+    TestCheckMetric('rx_bytes', 'i', 'bytes'),
+    TestCheckMetric('rx_dropped', 'i', 'bytes'),
+    TestCheckMetric('rx_errors', 'i', 'bytes'),
+    TestCheckMetric('rx_packets', 'i', 'bytes'),
+    TestCheckMetric('tx_bytes', 'i', 'bytes'),
+    TestCheckMetric('tx_dropped', 'i', 'bytes'),
+    TestCheckMetric('tx_errors', 'i', 'bytes'),
+    TestCheckMetric('tx_packets', 'i', 'bytes')])
+
+test_check_responses['remote.ping'] = lambda: TestCheckData([
+    TestCheckMetric('available', 'n', 'percent'),
+    TestCheckMetric('average', 'n'),
+    TestCheckMetric('count', 'i', 'count'),
+    TestCheckMetric('maximum', 'n'),
+    TestCheckMetric('minimum', 'n')])
+
+
+def get_test_check_response_by_type(check_type):
+    """
+    Looks up the correct test-check data response by check type.
+
+    This should not be used if a test-check responder exists for the
+    desired entity ID and check type. The responder should be cached
+    so that the metric values can be overridden.
+    """
+    return test_check_responses[check_type]()

--- a/mimic/plugins/maas_plugin.py
+++ b/mimic/plugins/maas_plugin.py
@@ -1,6 +1,7 @@
 """
 Plugin for Rax Monitoring API (aka MaaS, aka ele) mock.
 """
-from mimic.rest.maas_api import MaasApi
+from mimic.rest.maas_api import MaasApi, MaasControlApi
 
 maas = MaasApi()
+maas_control = MaasControlApi(maas_api=maas)

--- a/mimic/rest/maas_api.py
+++ b/mimic/rest/maas_api.py
@@ -358,6 +358,13 @@ def parse_and_flatten_qs(url):
     return flat_qs
 
 
+def _mcache_factory():
+    """
+    Makes a defaultdict that makes MCache objects for each tenant.
+    """
+    return collections.defaultdict(MCache)
+
+
 class MaasMock(object):
 
     """
@@ -380,9 +387,7 @@ class MaasMock(object):
         Retrieve the M_cache object containing all objects created so far
         """
         return (self._session_store.session_for_tenant_id(tenant_id)
-                .data_for_api(self._api_mock,
-                              lambda: collections.defaultdict(
-                                  lambda: MCache(self._session_store.clock)))[self._name]
+                .data_for_api(self._api_mock, _mcache_factory)[self._name]
                 )
 
     def _audit(self, app, request, tenant_id, status, content=''):
@@ -1359,8 +1364,7 @@ class MaasController(object):
         Retrieve the M_cache object containing all objects created so far
         """
         return (self.session_store.session_for_tenant_id(tenant_id)
-                .data_for_api(self.api_mock.maas_api,
-                              lambda: collections.defaultdict(MCache))[self.region])
+                .data_for_api(self.api_mock.maas_api, _mcache_factory)[self.region])
 
     app = MimicApp()
 

--- a/mimic/rest/maas_api.py
+++ b/mimic/rest/maas_api.py
@@ -669,7 +669,7 @@ class MaasMock(object):
         response_code, response_body = maas_store.check_types[check_type].get_test_check_response(
             entity_id=entity_id,
             monitoring_zones=test_config.get('monitoring_zones_poll'),
-            timestamp=int(1000 * time.time()))
+            timestamp=int(1000 * self._session_store.clock.seconds()))
         request.setResponseCode(response_code)
         self._audit('checks', request, tenant_id, response_code, content)
         return json.dumps(response_body)
@@ -773,6 +773,7 @@ class MaasMock(object):
         content = request.content.read()
         payload = json.loads(content)
         n_tests = len(payload['check_data'])
+        current_time_milliseconds = int(1000 * self._session_store.clock.seconds())
         test_responses = self._entity_cache_for_tenant(tenant_id).test_alarm_responses
         response_payload = []
         if entity_id in test_responses:
@@ -782,12 +783,12 @@ class MaasMock(object):
                 response_payload.append({'state': test_response['state'],
                                          'status': test_response.get(
                                              'status', 'Matched default return statement'),
-                                         'timestamp': int(time.time() * 1000)})
+                                         'timestamp': current_time_milliseconds})
         else:
             for i in xrange(n_tests):
                 response_payload.append({'state': random.choice(['OK', 'WARNING', 'CRITICAL']),
                                          'status': _random_hipsum(),
-                                         'timestamp': int(time.time() * 1000)})
+                                         'timestamp': current_time_milliseconds})
 
         status = 200
         request.setResponseCode(status)

--- a/mimic/test/test_core.py
+++ b/mimic/test/test_core.py
@@ -34,6 +34,7 @@ class CoreBuildingTests(SynchronousTestCase):
             loadbalancer_plugin.loadbalancer,
             loadbalancer_plugin.loadbalancer_control,
             maas_plugin.maas,
+            maas_plugin.maas_control,
             nova_plugin.nova,
             nova_plugin.nova_control_api,
             queue_plugin.queue,

--- a/mimic/test/test_maas.py
+++ b/mimic/test/test_maas.py
@@ -17,7 +17,7 @@ class MaasObjectsTests(SynchronousTestCase):
         Known types for TestCheckMetric are 'i', 'n', and 's'. Other types
         raise ValueError.
         """
-        metric = Metric('whuut', 'z', Clock())
+        metric = Metric(name='whuut', type='z')
         with self.assertRaises(ValueError):
             metric.get_value_for_test_check(
                 timestamp=0,
@@ -30,7 +30,8 @@ class MaasObjectsTests(SynchronousTestCase):
         NameError.
         """
         clock = Clock()
-        check_type = CheckType(clock, [Metric('that_metric', 'i', clock, unit='count')])
+        check_type = CheckType(clock=clock, metrics=[
+            Metric(name='that_metric', type='i', unit='count')])
         with self.assertRaises(NameError):
             check_type.get_metric_by_name('not_that_metric')
 
@@ -522,7 +523,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         The test-check control API can clear metrics.
 
-        NB: Randomly generated string metrics are between 12 and 30
+        ..note: Randomly generated string metrics are between 12 and 30
         characters long.
         """
         options = {'data': 'really great forty-three character sentence'}
@@ -615,6 +616,9 @@ class MaasAPITests(SynchronousTestCase):
         self.assertIn('timestamp', data[0])
 
     def test_test_alarm_setting_status(self):
+        """
+        Users can set the status field on the response from the test-alarm API.
+        """
         req = request(self, self.root, "PUT",
                       '{0}/entities/{1}/alarms/test_response'.format(
                           self.ctl_uri, self.entity_id),
@@ -633,6 +637,10 @@ class MaasAPITests(SynchronousTestCase):
         self.assertEquals('test status message', data[0]['status'])
 
     def test_test_alarm_clearing_response(self):
+        """
+        Sending HTTP DELETE to the entity's test-alarm response
+        causes the response to be cleared and not returned later.
+        """
         req = request(self, self.root, "PUT",
                       '{0}/entities/{1}/alarms/test_response'.format(
                           self.ctl_uri, self.entity_id),
@@ -656,6 +664,9 @@ class MaasAPITests(SynchronousTestCase):
         self.assertNotEquals('test-alarm working OK', data[0]['status'])
 
     def test_test_alarm_setting_errors(self):
+        """
+        Users can use the control API to make the test-alarm API return errors.
+        """
         parse_error = {'code': 400,
                        'type': 'alarmParseError',
                        'message': 'Failed to parse alarm'}

--- a/mimic/util/helper.py
+++ b/mimic/util/helper.py
@@ -51,6 +51,27 @@ def random_string(length, selectable=None):
     return ''.join([choice(selectable) for _ in xrange(length)])
 
 
+def random_hipsum(length):
+    """
+    Generates a random sentence using Hipsum ( http://hipsum.co/ ).
+
+    :param length The number of words in the desired sentence.
+    :returns: A Unicode string containing `length` words.
+    """
+    hipsum = ''.join([
+        "Retro squid Portland raw denim Austin, normcore slow-carb Brooklyn. ",
+        "Deep v organic VHS drinking vinegar. Fingerstache locavore kogi Tumblr ",
+        "cred. Vice typewriter retro iPhone pour-over cred XOXO church-key, ",
+        "post-ironic kogi. Selvage polaroid retro, cold-pressed meh craft beer ",
+        "artisan pour-over taxidermy sartorial art party. Food truck church-key ",
+        "four loko wayfarers craft beer dreamcatcher normcore yr, jean shorts ",
+        "bespoke migas art party crucifix next level. Street art chia bitters, ",
+        "gastropub mixtape flexitarian Godard occupy lumbersexual."]).split(' ')
+    offset = randint(1, len(hipsum))
+    rotated = hipsum[offset:] + hipsum[:offset]
+    return ' '.join(rotated[:length])
+
+
 def random_ipv4(*numbers):
     """
     Return a random IPv4 address - parts of the IP address can be provided.


### PR DESCRIPTION
This change adds an empty control API for MaaS. Future plans for this
control API include

1. Refactoring some of the in-band control mechanisms already used by
   the `MaasApi` into the control API; and
2. Implementing some of the changes from the `toksPatches` branch that
   needed the control plane to be done the right way.

**Update:** This change also implements a `test-alarm` API for MaaS as a first example of what we can do with the MaaS control API.