### PR TITLE
ensure uniqueness of private IPs within a tenant

### DIFF
--- a/mimic/model/nova_objects.py
+++ b/mimic/model/nova_objects.py
@@ -306,6 +306,14 @@ class Server(object):
         metadata = server_json.get("metadata") or {}
         cls.validate_metadata(metadata, max_metadata_items)
 
+        while True:
+            private_ip = IPv4Address(
+                address="10.180.{0}.{1}".format(ipsegment(), ipsegment()))
+            if private_ip not in [addr
+                              for server in collection.servers
+                              for addr in server.private_ips]:
+                break
+
         self = cls(
             collection=collection,
             server_name=server_json['name'],
@@ -314,10 +322,7 @@ class Server(object):
             metadata=metadata,
             creation_time=now,
             update_time=now,
-            private_ips=[
-                IPv4Address(address="10.180.{0}.{1}"
-                            .format(ipsegment(), ipsegment())),
-            ],
+            private_ips=[private_ip],
             public_ips=[
                 IPv4Address(address="198.101.241.{0}".format(ipsegment())),
                 IPv6Address(address="2001:4800:780e:0510:d87b:9cbc:ff04:513a")

--- a/mimic/model/nova_objects.py
+++ b/mimic/model/nova_objects.py
@@ -309,9 +309,8 @@ class Server(object):
         while True:
             private_ip = IPv4Address(
                 address="10.180.{0}.{1}".format(ipsegment(), ipsegment()))
-            if private_ip not in [addr
-                              for server in collection.servers
-                              for addr in server.private_ips]:
+            if private_ip not in [addr for server in collection.servers
+                                  for addr in server.private_ips]:
                 break
 
         self = cls(

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -2294,6 +2294,10 @@ class NovaAPIMetadataTests(SynchronousTestCase):
 
 class NovaServerTests(SynchronousTestCase):
     def test_unique_ips(self):
+        """
+        The private IP address of generated servers will be unique even if
+        the given ``ipsegment`` factory generates non-unique pairs.
+        """
         nova_api = NovaApi(["ORD", "MIMIC"])
         self.helper = self.helper = APIMockHelper(
             self, [nova_api, NovaControlApi(nova_api=nova_api)]


### PR DESCRIPTION
quick fix to make sure private IPs are unique within a tenant, with test.

Fixes #383.