### PR TITLE
feat(MaasApi): filter overview results by entity ID

### DIFF
--- a/mimic/rest/maas_api.py
+++ b/mimic/rest/maas_api.py
@@ -766,6 +766,17 @@ class MaasMock(object):
         serves the overview api call,returns all entities,checks and alarms
         """
         all_entities = self._entity_cache_for_tenant(tenant_id).entities_list
+        if 'entityId' in request.args:
+            all_entities = [entity for entity in all_entities
+                            if entity.id in request.args['entityId']]
+            if len(all_entities) == 0:
+                request.setResponseCode(404)
+                return json.dumps({'type': 'notFoundError',
+                                   'code': 404,
+                                   'message': 'Object does not exist',
+                                   'details': 'Object "Entity" with key "{0}" does not exist'.format(
+                                       request.args['entityId'])})
+
         checks = self._entity_cache_for_tenant(tenant_id).checks_list
         alarms = self._entity_cache_for_tenant(tenant_id).alarms_list
         page_limit = min(int(request.args.get('limit', [100])[0]), 1000)

--- a/mimic/test/test_maas.py
+++ b/mimic/test/test_maas.py
@@ -1176,3 +1176,27 @@ class MaasAPITests(SynchronousTestCase):
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
         self.assertEquals(data['values'][0]['entity']['label'], 'ItsAnEntity')
+
+    def test_overview_filters_by_entity(self):
+        """
+        The overview call restricts results to the desired entity,
+        regardless if other entities exist.
+        """
+        (resp, data) = self.successResultOf(
+            json_request(self, self.root, "GET",
+                         '{0}/views/overview?entityId={1}'.format(
+                             self.uri, self.entity_id)))
+        self.assertEquals(resp.code, 200)
+        self.assertEquals(len(data['values']), 1)
+        self.assertEquals(data['values'][0]['entity']['label'], 'ItsAnEntity')
+
+    def test_overview_missing_entity_404s(self):
+        """
+        If the user passes in a non-existing entity ID, a 404 is returned.
+        """
+        (resp, data) = self.successResultOf(
+            json_request(self, self.root, "GET",
+                         '{0}/views/overview?entityId={1}'.format(
+                             self.uri, 'enDoesNotExist')))
+        self.assertEquals(resp.code, 404)
+        self.assertEquals(data['type'], 'notFoundError')


### PR DESCRIPTION
This change fixes an integration bug that has been worked around
upstream in Intelligence. In this case, Intelligence sometimes requests
a single entity's overview as a performance optimization, and the
backend is assumed to return overview data for exactly one entity. Mimic
did not do anything with the `entityId` query string parameter, and
incorrect results were returned. This change adds support for the
parameter in Mimic.

Usage of the overview call, including the `entityId` query string
parameter, is described in [section 5.18.1](http://goo.gl/c6dsYu)
of the Rackspace Cloud Monitoring Developer Guide.