### PR TITLE
fix(maas_api): drop unrecognized keys when creating

### DIFF
--- a/mimic/model/maas_objects.py
+++ b/mimic/model/maas_objects.py
@@ -130,6 +130,7 @@ class Alarm(object):
                 'label': self.label,
                 'criteria': self.criteria,
                 'check_id': self.check_id,
+                'entity_id': self.entity_id,
                 'notification_plan_id': self.notification_plan_id,
                 'created_at': self.created_at,
                 'updated_at': self.updated_at,

--- a/mimic/rest/maas_api.py
+++ b/mimic/rest/maas_api.py
@@ -143,6 +143,13 @@ class MCache(object):
         self.test_alarm_errors = {}
 
 
+def _only_keys(dict_ins, keys):
+    """
+    Filters out unwanted keys of a dict.
+    """
+    return dict([(k, dict_ins[k]) for k in dict_ins if k in keys])
+
+
 def create_entity(clock, params):
     """
     Returns a dictionary representing an entity
@@ -154,7 +161,12 @@ def create_entity(clock, params):
         ``bool``, ``dict`` or ``NoneType``.
     """
     current_time_milliseconds = int(1000 * clock.seconds())
-    params_copy = dict(params)
+    params_copy = _only_keys(params, ['agent_id',
+                                      'ip_addresses',
+                                      'label',
+                                      'managed',
+                                      'metadata',
+                                      'uri'])
     params_copy['created_at'] = params_copy['updated_at'] = current_time_milliseconds
     return Entity(**params_copy)
 
@@ -170,7 +182,17 @@ def create_check(clock, entity_id, params):
         ``int``, ``bool``, ``dict`` or ``NoneType``.
     """
     current_time_milliseconds = int(1000 * clock.seconds())
-    params_copy = dict(params)
+    params_copy = _only_keys(params, ['details',
+                                      'disabled',
+                                      'label',
+                                      'metadata',
+                                      'monitoring_zones_poll',
+                                      'period',
+                                      'target_alias',
+                                      'target_hostname',
+                                      'target_resolver',
+                                      'timeout',
+                                      'type'])
     params_copy['entity_id'] = entity_id
     params_copy['created_at'] = params_copy['updated_at'] = current_time_milliseconds
     return Check(**params_copy)
@@ -187,7 +209,12 @@ def create_alarm(clock, entity_id, params):
         ``bool``, ``dict``, or ``NoneType``.
     """
     current_time_milliseconds = int(1000 * clock.seconds())
-    params_copy = dict(params)
+    params_copy = _only_keys(params, ['check_id',
+                                      'criteria',
+                                      'disabled',
+                                      'label',
+                                      'metadata',
+                                      'notification_plan_id'])
     params_copy['entity_id'] = entity_id
     params_copy['created_at'] = params_copy['updated_at'] = current_time_milliseconds
     return Alarm(**params_copy)
@@ -204,7 +231,11 @@ def create_notification_plan(clock, params):
         ``dict`` or ``NoneType``.
     """
     current_time_milliseconds = int(1000 * clock.seconds())
-    params_copy = dict(params)
+    params_copy = _only_keys(params, ['critical_state',
+                                      'label',
+                                      'metadata',
+                                      'ok_state',
+                                      'warning_state'])
     params_copy['created_at'] = params_copy['updated_at'] = current_time_milliseconds
     return NotificationPlan(**params_copy)
 
@@ -220,7 +251,10 @@ def create_notification(clock, params):
         ``dict`` or ``NoneType``.
     """
     current_time_milliseconds = int(1000 * clock.seconds())
-    params_copy = dict(params)
+    params_copy = _only_keys(params, ['details',
+                                      'label',
+                                      'metadata',
+                                      'type'])
     params_copy['created_at'] = params_copy['updated_at'] = current_time_milliseconds
     return Notification(**params_copy)
 
@@ -234,7 +268,13 @@ def create_suppression(clock, params):
         <http://docs.rackspace.com/cm/api/v1.0/cm-devguide/content/service-suppressions.html>`_
     :rtype: ``dict`` mapping ``unicode`` to ``unicode`` or ``list``.
     """
-    params_copy = dict(params)
+    params_copy = _only_keys(params, ['alarms',
+                                      'checks',
+                                      'end_time',
+                                      'entities',
+                                      'label',
+                                      'notification_plans',
+                                      'start_time'])
     params_copy['created_at'] = params_copy['updated_at'] = int(1000 * clock.seconds())
     return Suppression(**params_copy)
 
@@ -997,7 +1037,7 @@ class MaasMock(object):
         """
         content = request.content.read()
         postdata = json.loads(content)
-        newnp = create_notification_plan(self._session_store.clock, {'label': postdata['label']})
+        newnp = create_notification_plan(self._session_store.clock, postdata)
         self._entity_cache_for_tenant(tenant_id).notificationplans_list.append(newnp)
         status = 201
         request.setResponseCode(status)

--- a/mimic/test/test_maas.py
+++ b/mimic/test/test_maas.py
@@ -312,6 +312,17 @@ class MaasAPITests(SynchronousTestCase):
         self.assertEquals(data['type'], 'badRequest')
         self.assertEquals(data['message'], 'Validation error for key \'type\'')
 
+    def test_create_entity_with_unrecognized_keys(self):
+        """
+        When creating an entity with properties that are not
+        recognized by MaaS, MaaS creates the entity and stores keys
+        that it knows how to use.
+        """
+        resp = self.successResultOf(
+            request(self, self.root, "POST", '{0}/entities'.format(self.uri),
+                    json.dumps({'label': 'foo', 'whut': 'WAT'})))
+        self.assertEquals(resp.code, 201)
+
     def test_update_entity(self):
         """
         update entity
@@ -436,6 +447,20 @@ class MaasAPITests(SynchronousTestCase):
         self.assertEquals('internet7_v4', data['target_alias'])
         self.assertEquals('ItsAcheck', data['label'])
 
+    def test_create_check_with_unrecognized_keys(self):
+        """
+        When creating a check with properties that are not
+        recognized by MaaS, MaaS creates the entity and stores keys
+        that it knows how to use.
+        """
+        resp = self.successResultOf(
+            request(self, self.root, "POST",
+                    '{0}/entities/{1}/checks'.format(self.uri, self.entity_id),
+                    json.dumps({'label': 'check-foo',
+                                'type': 'remote.ping',
+                                'whut': 'WAT'})))
+        self.assertEquals(resp.code, 201)
+
     def test_update_alarm(self):
         """
         update alarm
@@ -476,6 +501,22 @@ class MaasAPITests(SynchronousTestCase):
         data = self.get_responsebody(resp)
         self.assertEquals('np123456', data['notification_plan_id'])
         self.assertEquals('ItsAnAlarm', data['label'])
+
+    def test_create_alarm_with_unrecognized_keys(self):
+        """
+        When creating an alarm with properties that are not
+        recognized by MaaS, MaaS creates the entity and stores keys
+        that it knows how to use.
+        """
+        resp = self.successResultOf(
+            request(self, self.root, "POST",
+                    '{0}/entities/{1}/alarms'.format(self.uri, self.entity_id),
+                    json.dumps({'label': 'alarm-foo',
+                                'check_id': self.check_id,
+                                'criteria': 'return new AlarmStatus(OK);',
+                                'notification_plan_id': 'npL01Wu7',
+                                'whut': 'WAT'})))
+        self.assertEquals(resp.code, 201)
 
     def test_delete_alarm(self):
         """
@@ -815,6 +856,47 @@ class MaasAPITests(SynchronousTestCase):
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
         self.assertEquals(True, 'npTechnicalContactsEmail' in json.dumps(data))
+
+    def test_create_notification_plan_with_unrecognized_keys(self):
+        """
+        When creating a notification plan with properties that are not
+        recognized by MaaS, MaaS creates the entity and stores keys
+        that it knows how to use.
+        """
+        resp = self.successResultOf(
+            request(self, self.root, "POST",
+                    '{0}/notification_plans'.format(self.uri),
+                    json.dumps({'label': 'np-foo',
+                                'whut': 'WAT'})))
+        self.assertEquals(resp.code, 201)
+
+    def test_create_notification_with_unrecognized_keys(self):
+        """
+        When creating a notification with properties that are not
+        recognized by MaaS, MaaS creates the entity and stores keys
+        that it knows how to use.
+        """
+        resp = self.successResultOf(
+            request(self, self.root, "POST",
+                    '{0}/notifications'.format(self.uri),
+                    json.dumps({'label': 'nt-foo',
+                                'details': {'address': 'bob@company.com'},
+                                'type': 'email',
+                                'whut': 'WAT'})))
+        self.assertEquals(resp.code, 201)
+
+    def test_create_suppression_with_unrecognized_keys(self):
+        """
+        When creating a suppression with properties that are not
+        recognized by MaaS, MaaS creates the entity and stores keys
+        that it knows how to use.
+        """
+        resp = self.successResultOf(
+            request(self, self.root, "POST",
+                    '{0}/suppressions'.format(self.uri),
+                    json.dumps({'label': 'sp-foo',
+                                'whut': 'WAT'})))
+        self.assertEquals(resp.code, 201)
 
     def test_agenthostinfo(self):
         """


### PR DESCRIPTION
If keys that are not part of the MaaS business domain are POSTed to the
MaaS endpoints, a 500 would have been caused. This change fixes the bug.
In real MaaS, the extra properties would be dropped, so Mimic does the
same thing now.