### PR TITLE
refactor(lbaas): move store methods to store

### DIFF
--- a/mimic/canned_responses/loadbalancer.py
+++ b/mimic/canned_responses/loadbalancer.py
@@ -4,8 +4,6 @@ Canned response for add/get/list/delete load balancers and
 add/get/delete/list nodes
 """
 from random import randrange
-from mimic.util.helper import (set_resource_status, seconds_to_timestamp)
-from twisted.python import log
 
 
 def load_balancer_example(lb_info, lb_id, status,
@@ -41,17 +39,6 @@ def load_balancer_example(lb_info, lb_id, status,
     return lb_example
 
 
-def _delete_node(store, lb_id, node_id):
-    """Delete a node by ID."""
-    if store.lbs[lb_id].nodes:
-        for each in store.lbs[lb_id].nodes:
-            if each.id == node_id:
-                index = store.lbs[lb_id].nodes.index(each)
-                del store.lbs[lb_id].nodes[index]
-                return True
-    return False
-
-
 def _format_meta(metadata_list):
     """
     creates metadata with 'id' as a key
@@ -61,56 +48,3 @@ def _format_meta(metadata_list):
         each.update({"id": randrange(999)})
         meta.append(each)
     return meta
-
-
-def _verify_and_update_lb_state(store, lb_id, set_state=True,
-                                current_timestamp=None):
-    """
-    Based on the current state, the metadata on the lb and the time since the LB has
-    been in that state, set the appropriate state in store.lbs
-    Note: Reconsider if update metadata is implemented
-    """
-    current_timestring = seconds_to_timestamp(current_timestamp)
-    if store.lbs[lb_id]["status"] == "BUILD":
-        store.meta[lb_id]["lb_building"] = store.meta[lb_id]["lb_building"] or 10
-        store.lbs[lb_id]["status"] = set_resource_status(
-            store.lbs[lb_id]["updated"]["time"],
-            store.meta[lb_id]["lb_building"],
-            current_timestamp=current_timestamp
-        ) or "BUILD"
-
-    elif store.lbs[lb_id]["status"] == "ACTIVE" and set_state:
-        if "lb_pending_update" in store.meta[lb_id]:
-            store.lbs[lb_id]["status"] = "PENDING-UPDATE"
-            log.msg(store.lbs[lb_id]["status"])
-        if "lb_pending_delete" in store.meta[lb_id]:
-            store.lbs[lb_id]["status"] = "PENDING-DELETE"
-        if "lb_error_state" in store.meta[lb_id]:
-            store.lbs[lb_id]["status"] = "ERROR"
-        store.lbs[lb_id]["updated"]["time"] = current_timestring
-
-    elif store.lbs[lb_id]["status"] == "PENDING-UPDATE":
-        if "lb_pending_update" in store.meta[lb_id]:
-            store.lbs[lb_id]["status"] = set_resource_status(
-                store.lbs[lb_id]["updated"]["time"],
-                store.meta[lb_id]["lb_pending_update"],
-                current_timestamp=current_timestamp
-            ) or "PENDING-UPDATE"
-
-    elif store.lbs[lb_id]["status"] == "PENDING-DELETE":
-        store.meta[lb_id]["lb_pending_delete"] = store.meta[lb_id]["lb_pending_delete"] or 10
-        store.lbs[lb_id]["status"] = set_resource_status(
-            store.lbs[lb_id]["updated"]["time"],
-            store.meta[lb_id]["lb_pending_delete"], "DELETED",
-            current_timestamp=current_timestamp
-        ) or "PENDING-DELETE"
-        store.lbs[lb_id]["updated"]["time"] = current_timestring
-
-    elif store.lbs[lb_id]["status"] == "DELETED":
-        # see del_load_balancer above for an explanation of this state change.
-        store.lbs[lb_id]["status"] = set_resource_status(
-            store.lbs[lb_id]["updated"]["time"], 3600, "DELETING-NOW",
-            current_timestamp=current_timestamp
-        ) or "DELETED"
-        if store.lbs[lb_id]["status"] == "DELETING-NOW":
-            del store.lbs[lb_id]

--- a/mimic/model/clb_objects.py
+++ b/mimic/model/clb_objects.py
@@ -16,9 +16,7 @@ from six import string_types
 from twisted.internet.interfaces import IReactorTime
 from twisted.python import log
 
-from mimic.canned_responses.loadbalancer import (load_balancer_example,
-                                                 _verify_and_update_lb_state,
-                                                 _delete_node)
+from mimic.canned_responses.loadbalancer import load_balancer_example
 from mimic.model.clb_errors import (
     considered_immutable_error,
     invalid_json_schema,
@@ -26,9 +24,11 @@ from mimic.model.clb_errors import (
     node_not_found,
     updating_node_validation_error
 )
-from mimic.util.helper import (not_found_response, seconds_to_timestamp,
-                               EMPTY_RESPONSE,
-                               invalid_resource)
+from mimic.util.helper import (EMPTY_RESPONSE,
+                               invalid_resource,
+                               not_found_response,
+                               seconds_to_timestamp,
+                               set_resource_status)
 
 
 def _one_of_validator(*items):
@@ -227,6 +227,58 @@ class RegionalCLBCollection(object):
 
         return {'loadBalancer': self.lbs[lb_id].full_json()}, 202
 
+    def _verify_and_update_lb_state(self, lb_id, set_state=True,
+                                    current_timestamp=None):
+        """
+        Based on the current state, the metadata on the lb and the time since the LB has
+        been in that state, set the appropriate state in self.lbs
+        Note: Reconsider if update metadata is implemented
+        """
+        current_timestring = seconds_to_timestamp(current_timestamp)
+        if self.lbs[lb_id]["status"] == "BUILD":
+            self.meta[lb_id]["lb_building"] = self.meta[lb_id]["lb_building"] or 10
+            self.lbs[lb_id]["status"] = set_resource_status(
+                self.lbs[lb_id]["updated"]["time"],
+                self.meta[lb_id]["lb_building"],
+                current_timestamp=current_timestamp
+            ) or "BUILD"
+
+        elif self.lbs[lb_id]["status"] == "ACTIVE" and set_state:
+            if "lb_pending_update" in self.meta[lb_id]:
+                self.lbs[lb_id]["status"] = "PENDING-UPDATE"
+                log.msg(self.lbs[lb_id]["status"])
+            if "lb_pending_delete" in self.meta[lb_id]:
+                self.lbs[lb_id]["status"] = "PENDING-DELETE"
+            if "lb_error_state" in self.meta[lb_id]:
+                self.lbs[lb_id]["status"] = "ERROR"
+            self.lbs[lb_id]["updated"]["time"] = current_timestring
+
+        elif self.lbs[lb_id]["status"] == "PENDING-UPDATE":
+            if "lb_pending_update" in self.meta[lb_id]:
+                self.lbs[lb_id]["status"] = set_resource_status(
+                    self.lbs[lb_id]["updated"]["time"],
+                    self.meta[lb_id]["lb_pending_update"],
+                    current_timestamp=current_timestamp
+                ) or "PENDING-UPDATE"
+
+        elif self.lbs[lb_id]["status"] == "PENDING-DELETE":
+            self.meta[lb_id]["lb_pending_delete"] = self.meta[lb_id]["lb_pending_delete"] or 10
+            self.lbs[lb_id]["status"] = set_resource_status(
+                self.lbs[lb_id]["updated"]["time"],
+                self.meta[lb_id]["lb_pending_delete"], "DELETED",
+                current_timestamp=current_timestamp
+            ) or "PENDING-DELETE"
+            self.lbs[lb_id]["updated"]["time"] = current_timestring
+
+        elif self.lbs[lb_id]["status"] == "DELETED":
+            # see del_load_balancer above for an explanation of this state change.
+            self.lbs[lb_id]["status"] = set_resource_status(
+                self.lbs[lb_id]["updated"]["time"], 3600, "DELETING-NOW",
+                current_timestamp=current_timestamp
+            ) or "DELETED"
+            if self.lbs[lb_id]["status"] == "DELETING-NOW":
+                del self.lbs[lb_id]
+
     def set_attributes(self, lb_id, kvpairs):
         """
         Sets zero or more attributes on the load balancer object.
@@ -261,8 +313,7 @@ class RegionalCLBCollection(object):
         code 200. If no load balancers are found returns 404.
         """
         if lb_id in self.lbs:
-            _verify_and_update_lb_state(self, lb_id, False,
-                                        self.clock.seconds())
+            self._verify_and_update_lb_state(lb_id, False, self.clock.seconds())
             log.msg(self.lbs[lb_id]["status"])
             return {'loadBalancer': self.lbs[lb_id].full_json()}, 200
         return not_found_response("loadbalancer"), 404
@@ -272,8 +323,7 @@ class RegionalCLBCollection(object):
         Returns the node on the load balancer
         """
         if lb_id in self.lbs:
-            _verify_and_update_lb_state(self, lb_id, False,
-                                        self.clock.seconds())
+            self._verify_and_update_lb_state(lb_id, False, self.clock.seconds())
 
             if self.lbs[lb_id]["status"] == "DELETED":
                 return (
@@ -296,10 +346,9 @@ class RegionalCLBCollection(object):
 
         :return: A 2-tuple, containing the HTTP response and code, in that order.
         """
-        for each in self.lbs:
-            _verify_and_update_lb_state(self, each, False,
-                                        self.clock.seconds())
-            log.msg(self.lbs[each]["status"])
+        for lb_id in self.lbs:
+            self._verify_and_update_lb_state(lb_id, False, self.clock.seconds())
+            log.msg(self.lbs[lb_id]["status"])
         return (
             {'loadBalancers': [lb.short_json() for lb in self.lbs.values()]},
             200)
@@ -309,8 +358,7 @@ class RegionalCLBCollection(object):
         Returns the list of nodes remaining on the load balancer
         """
         if lb_id in self.lbs:
-            _verify_and_update_lb_state(self, lb_id, False,
-                                        self.clock.seconds())
+            self._verify_and_update_lb_state(lb_id, False, self.clock.seconds())
             if lb_id not in self.lbs:
                 return not_found_response("loadbalancer"), 404
 
@@ -324,6 +372,18 @@ class RegionalCLBCollection(object):
         else:
             return not_found_response("loadbalancer"), 404
 
+    def _delete_node(self, lb_id, node_id):
+        """
+        Deletes a node by ID.
+        """
+        if self.lbs[lb_id].nodes:
+            previous_size = len(self.lbs[lb_id].nodes)
+            self.lbs[lb_id].nodes[:] = [node
+                                        for node in self.lbs[lb_id].nodes
+                                        if node.id != node_id]
+            return len(self.lbs[lb_id].nodes) < previous_size
+        return False
+
     def delete_node(self, lb_id, node_id):
         """
         Determines whether the node to be deleted exists in the session store,
@@ -332,17 +392,17 @@ class RegionalCLBCollection(object):
         current_timestamp = self.clock.seconds()
         if lb_id in self.lbs:
 
-            _verify_and_update_lb_state(self, lb_id, False, current_timestamp)
+            self._verify_and_update_lb_state(lb_id, False, current_timestamp)
 
             if self.lbs[lb_id]["status"] != "ACTIVE":
                 # Error message verified as of 2015-04-22
                 return considered_immutable_error(
                     self.lbs[lb_id]["status"], lb_id)
 
-            _verify_and_update_lb_state(self, lb_id,
-                                        current_timestamp=current_timestamp)
+            self._verify_and_update_lb_state(
+                lb_id, current_timestamp=current_timestamp)
 
-            if _delete_node(self, lb_id, node_id):
+            if self._delete_node(lb_id, node_id):
                 return None, 202
             else:
                 return not_found_response("node"), 404
@@ -363,7 +423,7 @@ class RegionalCLBCollection(object):
             return not_found_response("loadbalancer"), 404
 
         current_timestamp = self.clock.seconds()
-        _verify_and_update_lb_state(self, lb_id, False, current_timestamp)
+        self._verify_and_update_lb_state(lb_id, False, current_timestamp)
 
         if self.lbs[lb_id]["status"] != "ACTIVE":
             # Error message verified as of 2015-04-22
@@ -391,10 +451,10 @@ class RegionalCLBCollection(object):
         for node_id in node_ids:
             # It should not be possible for this to fail, since we've already
             # checked that they all exist.
-            assert _delete_node(self, lb_id, node_id) is True
+            assert self._delete_node(lb_id, node_id) is True
 
-        _verify_and_update_lb_state(self, lb_id,
-                                    current_timestamp=current_timestamp)
+        self._verify_and_update_lb_state(
+            lb_id, current_timestamp=current_timestamp)
         return EMPTY_RESPONSE, 202
 
     def add_node(self, node_list, lb_id):
@@ -411,7 +471,7 @@ class RegionalCLBCollection(object):
         """
         if lb_id in self.lbs:
             current_timestamp = self.clock.seconds()
-            _verify_and_update_lb_state(self, lb_id, False, current_timestamp)
+            self._verify_and_update_lb_state(lb_id, False, current_timestamp)
 
             if self.lbs[lb_id]["status"] != "ACTIVE":
                 return considered_immutable_error(
@@ -437,8 +497,8 @@ class RegionalCLBCollection(object):
                     "per load balancer.".format(self.node_limit), 413)
                 return (resource, 413)
 
-            _verify_and_update_lb_state(self, lb_id,
-                                        current_timestamp=current_timestamp)
+            self._verify_and_update_lb_state(
+                lb_id, current_timestamp=current_timestamp)
             return {"nodes": [node.as_json() for node in nodes]}, 202
 
         return not_found_response("loadbalancer"), 404
@@ -479,8 +539,7 @@ class RegionalCLBCollection(object):
 
         # Now, finally, check if the LB exists and node exists
         if lb_id in self.lbs:
-            _verify_and_update_lb_state(self, lb_id, False,
-                                        self.clock.seconds())
+            self._verify_and_update_lb_state(lb_id, False, self.clock.seconds())
 
             if self.lbs[lb_id]["status"] != "ACTIVE":
                 return considered_immutable_error(
@@ -514,7 +573,7 @@ class RegionalCLBCollection(object):
                 # Dont doubt this to be 422, it is 400!
                 return invalid_resource(msg, 400), 400
 
-            _verify_and_update_lb_state(self, lb_id, True, current_timestamp)
+            self._verify_and_update_lb_state(lb_id, True, current_timestamp)
 
             if any([self.lbs[lb_id]["status"] == "ACTIVE",
                     self.lbs[lb_id]["status"] == "ERROR",
@@ -526,8 +585,8 @@ class RegionalCLBCollection(object):
                 return EMPTY_RESPONSE, 202
 
             if self.lbs[lb_id]["status"] == "DELETED":
-                _verify_and_update_lb_state(self, lb_id,
-                                            current_timestamp=current_timestamp)
+                self._verify_and_update_lb_state(
+                    lb_id, current_timestamp=current_timestamp)
                 msg = "Must provide valid load balancers: {0} could not be found.".format(lb_id)
                 # Dont doubt this to be 422, it is 400!
                 return invalid_resource(msg, 400), 400


### PR DESCRIPTION
The methods `_verify_and_update_lb_state` and `_delete_node` are
actually private methods of the
`mimic.model.clb_objects.RegionalCLBCollection` class. They were defined
in the `mimic.canned_responses.loadbalancer` module, which caused
confusion. This change moves them into the class where they belong.

Fixes #430.