### PR TITLE
feat(maas_api): use mimic metrics in multiplot

### DIFF
--- a/mimic/model/maas_objects.py
+++ b/mimic/model/maas_objects.py
@@ -388,21 +388,25 @@ class Metric(object):
             return random_string(random.randint(12, 30), selectable=(string.letters + string.digits))
         raise ValueError('No default data getter for type {0}!'.format(self.type))
 
+    def get_value(self, **kwargs):
+        """
+        Gets the value of the metric at the specified timestamp.
+
+        Overrides will be applied as necessary.
+        """
+        override_key = self._override_key(**kwargs)
+        timestamp = kwargs['timestamp']
+        if override_key in self._overrides:
+            return self._overrides[override_key](timestamp)
+        return self._get_default_data()
+
     def get_value_for_test_check(self, **kwargs):
         """
         Gets the metric data object as returned from the test-check API.
         """
-        override_key = self._override_key(**kwargs)
-        timestamp = kwargs['timestamp']
-        data = self._get_default_data()
-
-        if override_key in self._overrides:
-            data_fn = self._overrides[override_key]
-            data = data_fn(timestamp)
-
         return {'type': self.type,
                 'unit': self.unit,
-                'data': data}
+                'data': self.get_value(**kwargs)}
 
 
 @attributes(["metrics",


### PR DESCRIPTION
This PR ditches the old way of doing multiplot, which was to look for a ping check and spit out random metrics unless the name of the check was "squarewave", in which case it did other things.

With this change, multiplot consults the collection of MaaS metrics in the `maas_store` to see if anyone has specified an override for the requested metric. If so, the override (specified as a function taking a timestamp) generates metrics over the interval; otherwise, random values are generated appropriately for the metric type. The net of this is that anyone who uses MaaS and doesn't use `squarewave`* will get the same metrics they're used to, but now with additional types. Additionally, it will make it easy to rebuild `squarewave` using metric overrides and the control API.

*I believe nobody actually uses this. Toks wrote it, but Intelligence doesn't use it.