### PR TITLE
SSH Keypair Routes

### DIFF
--- a/mimic/model/keypair_objects.py
+++ b/mimic/model/keypair_objects.py
@@ -74,6 +74,9 @@ class RegionalKeyPairCollection(object):
         Remove a :obj:`KeyPair` from the list of keypairs
         """
         kp_to_remove = self.keypair_by_name(name)
+        if kp_to_remove is None:
+            raise ValueError("Keypair Not Found")
+
         self.keypairs.remove(kp_to_remove)
 
 

--- a/mimic/model/keypair_objects.py
+++ b/mimic/model/keypair_objects.py
@@ -34,19 +34,19 @@ class KeyPair(object):
 class RegionalKeyPairCollection(object):
     """
     A :obj:`ReionalKeyPairCollection` is a collection of
-    :obj:`KeyPair` objects owned by a given tenant for a region.
+    :obj:`KeyPair` objects owned by a given tenant for a  region.
     """
 
     def create_keypair(self, keypair):
         """
-        Add a :obj:`KeyPair` to the list of keypairs
+        Add a :obj:`KeyPair` to the list of  keypairs
         """
         self.keypairs.append(keypair)
         return self.keypair_by_name(keypair.name).key_json()
 
     def keypair_by_name(self, name):
         """
-        Return a :obj:`KeyPair` by name from the current keypairs list
+        Return a :obj:`KeyPair` by name from the current keypairs  list
         """
         for keypair in self.keypairs:
             if keypair.name == name:
@@ -54,7 +54,7 @@ class RegionalKeyPairCollection(object):
 
     def json_list(self):
         """
-        JSON List of all :obj:`KeyPair` for a region
+        JSON List of all :obj:`KeyPair` for a  region
         """
         result = {"keypairs": []}
         if len(self.keypairs) > 0:
@@ -71,7 +71,7 @@ class RegionalKeyPairCollection(object):
 
     def remove_keypair(self, name):
         """
-        Remove a :obj:`KeyPair` from the list of keypairs
+        Remove a :obj:`KeyPair` from the list of  keypairs
         """
         kp_to_remove = self.keypair_by_name(name)
         self.keypairs.remove(kp_to_remove)

--- a/mimic/model/keypair_objects.py
+++ b/mimic/model/keypair_objects.py
@@ -1,0 +1,100 @@
+"""
+Keypair objects for mimic
+"""
+
+import json
+
+from characteristic import attributes, Attribute
+
+
+@attributes(['name', 'public_key'])
+class KeyPair(object):
+    """
+    A KeyPair object
+    """
+    fingerprint = "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"
+
+    def key_json(self):
+        """
+        Serialize a :obj:`Keypair` into JSON
+        """
+        return {
+            "keypair": {
+                "name": self.name,
+                "public_key": self.public_key,
+                "fingerprint": self.fingerprint
+            }
+        }
+
+
+@attributes(
+    ["tenant_id", "region_name", "clock",
+     Attribute("keypairs", default_factory=list)]
+)
+class RegionalKeyPairCollection(object):
+    """
+    A :obj:`ReionalKeyPairCollection` is a collection of
+    :obj:`KeyPair` objects owned by a given tenant for a region.
+    """
+
+    def create_keypair(self, keypair):
+        """
+        Add a :obj:`KeyPair` to the list of keypairs
+        """
+        self.keypairs.append(keypair)
+        return self.keypair_by_name(keypair.name).key_json()
+
+    def keypair_by_name(self, name):
+        """
+        Return a :obj:`KeyPair` by name from the current keypairs list
+        """
+        for keypair in self.keypairs:
+            if keypair.name == name:
+                return keypair
+
+    def json_list(self):
+        """
+        JSON List of all :obj:`KeyPair` for a region
+        """
+        result = {"keypairs": []}
+        if len(self.keypairs) > 0:
+            keypairs_json = {}
+            for keypair in self.keypairs:
+                keypairs_json.update(keypair.key_json())
+            result = {
+                "keypairs": [
+                    keypairs_json
+                ]
+            }
+
+        return json.dumps(result)
+
+    def remove_keypair(self, name):
+        """
+        Remove a :obj:`KeyPair` from the list of keypairs
+        """
+        kp_to_remove = self.keypair_by_name(name)
+        self.keypairs.remove(kp_to_remove)
+
+
+@attributes(["tenant_id", "clock",
+             Attribute("regional_collections", default_factory=dict)])
+class GlobalKeyPairCollections(object):
+    """
+    A :obj:`GlobalKeyPairCollections` is a set of all the
+    :obj:`RegionalKeyPairCollection` objects owned by a given tenant.  In other
+    words, all the objects that a single tenant owns globally.
+    """
+
+    def collection_for_region(self, region_name):
+        """
+        Get a :obj:`RegionalServerCollection` for the region identified by the
+        given name.
+        """
+        if region_name not in self.regional_collections:
+            self.regional_collections[region_name] = (
+                RegionalKeyPairCollection(tenant_id=self.tenant_id,
+                                          region_name=region_name,
+                                          clock=self.clock)
+            )
+        return self.regional_collections[region_name]

--- a/mimic/model/keypair_objects.py
+++ b/mimic/model/keypair_objects.py
@@ -13,6 +13,7 @@ class KeyPair(object):
     A KeyPair object
     """
     fingerprint = "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa"
+    user_id = "fake"
 
     def key_json(self):
         """
@@ -22,7 +23,8 @@ class KeyPair(object):
             "keypair": {
                 "name": self.name,
                 "public_key": self.public_key,
-                "fingerprint": self.fingerprint
+                "fingerprint": self.fingerprint,
+                "user_id": self.user_id
             }
         }
 

--- a/mimic/model/keypair_objects.py
+++ b/mimic/model/keypair_objects.py
@@ -34,19 +34,19 @@ class KeyPair(object):
 class RegionalKeyPairCollection(object):
     """
     A :obj:`ReionalKeyPairCollection` is a collection of
-    :obj:`KeyPair` objects owned by a given tenant for a  region.
+    :obj:`KeyPair` objects owned by a given tenant for a region.
     """
 
     def create_keypair(self, keypair):
         """
-        Add a :obj:`KeyPair` to the list of  keypairs
+        Add a :obj:`KeyPair` to the list of keypairs
         """
         self.keypairs.append(keypair)
         return self.keypair_by_name(keypair.name).key_json()
 
     def keypair_by_name(self, name):
         """
-        Return a :obj:`KeyPair` by name from the current keypairs  list
+        Return a :obj:`KeyPair` by name from the current keypairs list
         """
         for keypair in self.keypairs:
             if keypair.name == name:
@@ -54,7 +54,7 @@ class RegionalKeyPairCollection(object):
 
     def json_list(self):
         """
-        JSON List of all :obj:`KeyPair` for a  region
+        JSON List of all :obj:`KeyPair` for a region
         """
         result = {"keypairs": []}
         if len(self.keypairs) > 0:
@@ -71,7 +71,7 @@ class RegionalKeyPairCollection(object):
 
     def remove_keypair(self, name):
         """
-        Remove a :obj:`KeyPair` from the list of  keypairs
+        Remove a :obj:`KeyPair` from the list of keypairs
         """
         kp_to_remove = self.keypair_by_name(name)
         self.keypairs.remove(kp_to_remove)

--- a/mimic/rest/nova_api.py
+++ b/mimic/rest/nova_api.py
@@ -227,7 +227,7 @@ class NovaRegion(object):
         image_region_collection = image_global_collection.collection_for_region(
             self._name)
         return image_region_collection
-        
+
     def _keypair_collection_for_tenant(self, tenant_id):
         """
         Returns the keypairs for a region
@@ -435,7 +435,8 @@ class NovaRegion(object):
         try:
             content = json.loads(request.content.read())
             keypair = content["keypair"]
-            keypair_from_request = KeyPair(name=keypair["name"], public_key=keypair["public_key"])
+            keypair_from_request = KeyPair(
+                name=keypair["name"], public_key=keypair["public_key"])
         except (ValueError or KeyError):
             request.setResponseCode(400)
             return json.dumps(bad_request("Malformed request body", request))

--- a/mimic/rest/nova_api.py
+++ b/mimic/rest/nova_api.py
@@ -17,6 +17,7 @@ from twisted.plugin import IPlugin
 from twisted.web.http import CREATED, BAD_REQUEST
 
 from mimic.canned_responses.nova import get_limit
+from mimic.model.keypair_objects import GlobalKeyPairCollections, KeyPair
 from mimic.rest.mimicapp import MimicApp
 from mimic.catalog import Entry
 from mimic.catalog import Endpoint
@@ -226,6 +227,16 @@ class NovaRegion(object):
         image_region_collection = image_global_collection.collection_for_region(
             self._name)
         return image_region_collection
+        
+    def _keypair_collection_for_tenant(self, tenant_id):
+        tenant_session = self._session_store.session_for_tenant_id(tenant_id)
+        kp_global_collection = tenant_session.data_for_api(
+            "keypair_collection",
+            lambda: GlobalKeyPairCollections(tenant_id=tenant_id,
+                                             clock=self._session_store.clock))
+        kp_region_collection = kp_global_collection.collection_for_region(
+            self._name)
+        return kp_region_collection
 
     app = MimicApp()
 
@@ -403,6 +414,40 @@ class NovaRegion(object):
         Perform the requested action on the server
         """
         return self._region_collection_for_tenant(tenant_id).request_action(request, server_id, self.url)
+
+    @app.route("/v2/<string:tenant_id>/os-keypairs", methods=['GET'])
+    def get_key_pairs(self, request, tenant_id):
+        """
+        Returns current key pairs
+        """
+        return self._keypair_collection_for_tenant(tenant_id).json_list()
+
+    @app.route("/v2/<string:tenant_id>/os-keypairs", methods=['POST'])
+    def create_key_pair(self, request, tenant_id):
+        """
+        Returns a newly created key pair with the specified name.
+        """
+        try:
+            content = json.loads(request.content.read())
+        except ValueError:
+            request.setResponseCode(400)
+            return json.dumps(bad_request("Malformed request body", request))
+
+        keypair = content["keypair"]
+        keypair_from_request = KeyPair(
+            name=keypair["name"], public_key=keypair["public_key"])
+        keypair_response = self._keypair_collection_for_tenant(
+            tenant_id).create_keypair(keypair=keypair_from_request)
+        return json.dumps(keypair_response)
+
+    @app.route("/v2/<string:tenant_id>/os-keypairs/<string:keypairname>", methods=['DELETE'])
+    def delete_key_pair(self, request, tenant_id, keypairname):
+        """
+        Removes a key by its name
+        """
+        self._keypair_collection_for_tenant(
+            tenant_id).remove_keypair(keypairname)
+        request.setResponseCode(202)
 
 
 class ServerMetadata(object):

--- a/mimic/rest/nova_api.py
+++ b/mimic/rest/nova_api.py
@@ -421,7 +421,8 @@ class NovaRegion(object):
     @app.route("/v2/<string:tenant_id>/os-keypairs", methods=['GET'])
     def get_key_pairs(self, request, tenant_id):
         """
-        Returns current key pairs
+        Returns current key pairs.
+        http://docs.rackspace.com/servers/api/v2/cs-devguide/content/ListKeyPairs.html
         """
         return self._keypair_collection_for_tenant(tenant_id).json_list()
 
@@ -429,6 +430,7 @@ class NovaRegion(object):
     def create_key_pair(self, request, tenant_id):
         """
         Returns a newly created key pair with the specified name.
+        http://docs.rackspace.com/servers/api/v2/cs-devguide/content/UploadKeyPair.html
         """
         try:
             content = json.loads(request.content.read())
@@ -445,7 +447,8 @@ class NovaRegion(object):
     @app.route("/v2/<string:tenant_id>/os-keypairs/<string:keypairname>", methods=['DELETE'])
     def delete_key_pair(self, request, tenant_id, keypairname):
         """
-        Removes a key by its name
+        Removes a key by its name.
+        http://docs.rackspace.com/servers/api/v2/cs-devguide/content/DeleteKeyPair.html
         """
         try:
             self._keypair_collection_for_tenant(

--- a/mimic/test/test_keypairs.py
+++ b/mimic/test/test_keypairs.py
@@ -1,0 +1,87 @@
+"""
+Tests for :mod:`nova_api` and :mod:`nova_objects`.
+"""
+
+from twisted.trial.unittest import SynchronousTestCase
+
+from mimic.test.helpers import json_request, request
+from mimic.rest.nova_api import NovaApi, NovaControlApi
+from mimic.test.fixtures import APIMockHelper
+
+
+class KeyPairTests(SynchronousTestCase):
+    """
+    Tests for keypairs
+    """
+
+    def setUp(self):
+        """
+        Create a :obj:`MimicCore` with :obj:`NovaApi` as the only plugin
+        """
+        nova_api = NovaApi(["ORD", "MIMIC"])
+        self.helper = APIMockHelper(
+            self, [nova_api, NovaControlApi(nova_api=nova_api)]
+        )
+        self.root = self.helper.root
+        self.clock = self.helper.clock
+        self.uri = self.helper.uri
+        self.create_keypair_response, self.create_keypair_response_body = (
+            self.create_keypair())
+        self.keypair_name = self.create_keypair_response_body[
+            'keypair']['name']
+
+    def create_keypair(self, kp_body=None):
+        if kp_body is None:
+            kp_body = {
+                "keypair": {
+                    "name": "setUP_test_lp",
+                    "public_key": "ssh-rsa testkey/"
+                }
+            }
+
+        resp, body = self.successResultOf(json_request(
+            self, self.helper.root, "POST", self.helper.uri + '/os-keypairs',
+            kp_body
+        ))
+        return resp, body
+
+    def get_keypairs_list(self):
+        resp, body = self.successResultOf(json_request(
+            self, self.helper.root, "GET", self.helper.uri + '/os-keypairs'
+        ))
+        return resp, body
+
+    def test_create_keypair(self):
+        kp_test_body = {
+            "keypair": {
+                "name": "test_lp",
+                "public_key": "ssh-rsa testkey/"
+            }
+        }
+        resp, body = self.create_keypair(kp_test_body)
+
+        self.assertEqual(resp.code, 200)
+        self.assertEqual(body['keypair']['name'],
+                         kp_test_body['keypair']['name'])
+
+    def test_error_create_keypair(self):
+        test_error_body = "{{a]"
+        resp, body = self.create_keypair(test_error_body)
+        self.assertEqual(resp.code, 400)
+        self.assertSubstring("Malformed", str(body))
+
+    def test_list_keypair(self):
+        resp, body = self.get_keypairs_list()
+        self.assertEqual(resp.code, 200)
+        self.assertEqual(body['keypairs'][0]['keypair']
+                         ['name'], self.keypair_name)
+
+    def test_delete_keypair(self):
+        resp = self.successResultOf(request(
+            self, self.helper.root, "DELETE", self.helper.uri +
+            '/os-keypairs/' + self.keypair_name
+        ))
+
+        self.assertEqual(resp.code, 202)
+        resp, body = self.get_keypairs_list()
+        self.assertTrue(len(body['keypairs']) < 2)

--- a/mimic/test/test_keypairs.py
+++ b/mimic/test/test_keypairs.py
@@ -84,4 +84,12 @@ class KeyPairTests(SynchronousTestCase):
 
         self.assertEqual(resp.code, 202)
         resp, body = self.get_keypairs_list()
-        self.assertTrue(len(body['keypairs']) < 2)
+        self.assertNotIn(self.keypair_name, str(body['keypairs']))
+
+    def test_error_delete_keypair(self):
+        resp = self.successResultOf(request(
+            self, self.helper.root, "DELETE", self.helper.uri +
+            '/os-keypairs/keydoesntexist'
+        ))
+
+        self.assertEqual(resp.code, 404)

--- a/mimic/test/test_keypairs.py
+++ b/mimic/test/test_keypairs.py
@@ -63,6 +63,8 @@ class KeyPairTests(SynchronousTestCase):
         self.assertEqual(resp.code, 200)
         self.assertEqual(body['keypair']['name'],
                          kp_test_body['keypair']['name'])
+        self.assertTrue(len(body['keypair']['fingerprint']) > 1)
+        self.assertTrue(len(body['keypair']['user_id']) > 1)
 
     def test_error_create_keypair(self):
         test_error_body = "{{a]"


### PR DESCRIPTION
Now able to create, read and delete SSH Keys for the NovaApi:
http://docs.rackspace.com/servers/api/v2/cs-devguide/content/ServersKeyPairs-d1e2545.html

Verified it works in reach here:
![reach](http://19aa15d9760e52e9d7a6-6bf9c89be6f9d48237983c051ac7f055.r89.cf1.rackcdn.com/ssh_keys_working.gif)