### PR TITLE
feat(maas_api): square wave override metrics

### DIFF
--- a/mimic/rest/maas_api.py
+++ b/mimic/rest/maas_api.py
@@ -2,6 +2,8 @@
 MAAS Mock API
 """
 
+from __future__ import division
+
 import json
 import collections
 import urlparse
@@ -304,6 +306,18 @@ def _metric_list_for_entity(maas_store, entity, checks):
                        for check in checks if check.entity_id == entity.id]}
 
 
+def _multiplot_interval(from_date, to_date, points):
+    """
+    Computes the size of the interval between points in a multiplot.
+
+    :return: the multiplot interval size.
+    :rtype: ``float``
+    """
+    if points < 2:
+        return 0.0
+    return (to_date - from_date) / (points - 1)
+
+
 def _compute_multiplot(maas_store, entity_id, check, metric_name, from_date, to_date, points):
     """
     Computes multiplot data for a single (entity, check, metric) group.
@@ -318,7 +332,7 @@ def _compute_multiplot(maas_store, entity_id, check, metric_name, from_date, to_
     if check.type not in maas_store.check_types:
         return fallback
 
-    interval = (to_date - from_date) / points
+    interval = _multiplot_interval(from_date, to_date, points)
     metric = None
     base_metric_name = metric_name
     metric_value_kwargs = {'entity_id': entity_id,
@@ -1571,4 +1585,58 @@ class MaasController(object):
         request.setResponseCode(201)
         request.setHeader('x-object-id', new_state.id.encode('utf-8'))
         request.setHeader('content-type', 'text/plain')
+        return b''
+
+    @app.route('/v1.0/<string:tenant_id>/entities/<string:entity_id>/checks' +
+               '/<string:check_id>/metrics/<string:metric_name>', methods=['PUT'])
+    def set_metric_override(self, request, tenant_id, entity_id, check_id, metric_name):
+        """
+        Sets overrides on a metric.
+        """
+        checks = self._entity_cache_for_tenant(tenant_id).checks_list
+        check = None
+
+        for c in checks:
+            if c.id == check_id and c.entity_id == entity_id:
+                check = c
+                break
+        else:
+            request.setResponseCode(404)
+            return json.dumps({'type': 'notFoundError',
+                               'code': 404,
+                               'message': 'Object does not exist',
+                               'details': 'Object "Check" with key "{0}:{1}" does not exist'.format(
+                                   entity_id, check_id)})
+
+        maas_store = self._entity_cache_for_tenant(tenant_id).maas_store
+        metric = maas_store.check_types[check.type].get_metric_by_name(metric_name)
+        request_body = json.loads(request.content.read())
+        monitoring_zones = request_body.get('monitoring_zones', ['__AGENT__'])
+        override_type = request_body['type']
+        override_options = request_body.get('options', {})
+        override_fn = None
+
+        if override_type == 'squarewave':
+            fn_period = int(override_options.get('period', 10 * 60 * 1000))
+            half_period = fn_period / 2
+            fn_min = override_options.get('min', 20)
+            fn_max = override_options.get('max', 80)
+            fn_offset = int(override_options.get('offset', 0))
+            override_fn = (lambda t: (fn_min
+                                      if ((t + fn_offset) % fn_period) < half_period
+                                      else fn_max))
+        else:
+            request.setResponseCode(400)
+            return json.dumps({'type': 'badRequest',
+                               'code': 400,
+                               'message': 'Validation error for key \'type\'',
+                               'details': 'Unknown value for "type": "{0}"'.format(override_type)})
+
+        for monitoring_zone in monitoring_zones:
+            metric.set_override(
+                entity_id=entity_id,
+                check_id=check_id,
+                monitoring_zone=monitoring_zone,
+                override_fn=override_fn)
+        request.setResponseCode(204)
         return b''

--- a/mimic/test/test_maas.py
+++ b/mimic/test/test_maas.py
@@ -1085,6 +1085,19 @@ class MaasAPITests(SynchronousTestCase):
         self.assertEquals(data['metrics'][0]['type'], 'unknown')
         self.assertEquals(len(data['metrics'][0]['data']), 0)
 
+    def test_multiplot_single_point(self):
+        """
+        Plotting a single point should not cause a server error.
+        """
+        resp = self.successResultOf(
+            request(self, self.root, "POST",
+                    '{0}/__experiments/multiplot?from={1}&to={2}&points={3}'.format(
+                        self.uri, '1412902262560', '1412988662560', 1),
+                    json.dumps({'metrics': [{'entity_id': self.entity_id,
+                                             'check_id': self.check_id,
+                                             'metric': 'mzord.available'}]})))
+        self.assertEquals(resp.code, 200)
+
     def test_get_all_notification_plans(self):
         """
         get all notification plans
@@ -1500,3 +1513,56 @@ class MaasAPITests(SynchronousTestCase):
         self.assertEquals(resp.code, 400)
         self.assertEquals(data['type'], 'badRequest')
         self.assertEquals(data['details'], 'Missing required key (status)')
+
+    def test_set_overrides_missing_check(self):
+        """
+        Trying to set the overrides on a check that does not exist causes a 404.
+        """
+        (resp, data) = self.successResultOf(
+            json_request(self, self.root, "PUT",
+                         '{0}/entities/{1}/checks/chWhut/metrics/available'.format(
+                             self.ctl_uri, self.entity_id),
+                         json.dumps({'type': 'squarewave'})))
+        self.assertEquals(resp.code, 404)
+        self.assertEquals(data['type'], 'notFoundError')
+        self.assertEquals(data['details'], ('Object "Check" with key ' +
+                                            '"{0}:chWhut" does not exist'.format(self.entity_id)))
+
+    def test_set_overrides_unknown_type(self):
+        """
+        Trying to set the overrides using an unknown metric type
+        causes a 400 Bad Request response.
+        """
+        (resp, data) = self.successResultOf(
+            json_request(self, self.root, "PUT",
+                         '{0}/entities/{1}/checks/{2}/metrics/available'.format(
+                             self.ctl_uri, self.entity_id, self.check_id),
+                         json.dumps({'type': 'lolwut'})))
+        self.assertEquals(resp.code, 400)
+        self.assertEquals(data['type'], 'badRequest')
+        self.assertEquals(data['details'], 'Unknown value for "type": "lolwut"')
+
+    def test_set_overrides_squarewave(self):
+        """
+        Users can override metrics using a square wave function.
+        """
+        resp = self.successResultOf(
+            request(self, self.root, "PUT",
+                    '{0}/entities/{1}/checks/{2}/metrics/available'.format(
+                        self.ctl_uri, self.entity_id, self.check_id),
+                    json.dumps({'type': 'squarewave',
+                                'options': {'min': 11,
+                                            'max': 22,
+                                            'offset': 0,
+                                            'period': 100},
+                                'monitoring_zones': ['mzord']})))
+        self.assertEquals(resp.code, 204)
+        (resp, data) = self.successResultOf(
+            json_request(self, self.root, "POST",
+                         '{0}/__experiments/multiplot?from=1&to=99&points=2'.format(self.uri),
+                         json.dumps({'metrics': [{'entity_id': self.entity_id,
+                                                  'check_id': self.check_id,
+                                                  'metric': 'mzord.available'}]})))
+        self.assertEquals(resp.code, 200)
+        self.assertEquals(data['metrics'][0]['data'][0]['average'], 11)
+        self.assertEquals(data['metrics'][0]['data'][1]['average'], 22)


### PR DESCRIPTION
This change adds back the square wave functionality that used to be in
the MaaS plugin. Users can specify that square wave metrics will be
returned for any entity, check and metric. They can also specify the
period, offset, and upper and lower values.