### PR TITLE
Added canned responses to Auth API

### DIFF
--- a/mimic/canned_responses/mimic_presets.py
+++ b/mimic/canned_responses/mimic_presets.py
@@ -40,6 +40,13 @@ get_presets = {"loadbalancers": {"lb_building": "On create load balancer, keeps 
                    # Tenants with user admin role
                    "admin_role": ["9999"],
                    # Tenants with this token result in a 401 when validating the token
-                   "token_fail_to_auth": ["never-cache-this-and-fail-to-auth"]
-}
-}
+                   "token_fail_to_auth": ["never-cache-this-and-fail-to-auth"],
+                   # Users presenting these tokens have contact IDs that correspond
+                   # to presets in the Valkyrie plugin...
+                   "non_dedicated_observer": ["OneTwo"],
+                   "non_dedicated_admin": ["ThreeFour"],
+                   "dedicated_full_device_permission_holder": ["HybridOneTwo"],
+                   "dedicated_account_permission_holder": ["HybridThreeFour"],
+                   "dedicated_limited_device_permission_holder": ["HybridFiveSix"],
+                   "dedicated_other_account_observer": ["HybridSevenEight"],
+                   "dedicated_other_account_admin": ["HybridNineZero"]}}

--- a/mimic/rest/auth_api.py
+++ b/mimic/rest/auth_api.py
@@ -345,6 +345,120 @@ class AuthApi(object):
                 {"id": "observer",
                  "description": "Global Observer Role.",
                  "name": "observer"}]
+
+        if token_id in get_presets["identity"]["non_dedicated_observer"]:
+                response["access"]["token"]["tenant"] = {
+                    "id": "135790",
+                    "name": "135790",
+                }
+                response["access"]["user"] = {
+                    "name": "OneTwo",
+                    "roles": [{"id": "1",
+                               "name": "monitoring:observer",
+                               "description": "Monitoring Observer"}]
+                }
+
+        if token_id in get_presets["identity"]["non_dedicated_admin"]:
+                response["access"]["token"]["tenant"] = {
+                    "id": "135790",
+                    "name": "135790",
+                }
+                response["access"]["user"] = {
+                    "name": "ThreeFour",
+                    "roles": [{"id": "1",
+                               "name": "monitoring:admin",
+                               "description": "Monitoring Admin"},
+                              {"id": "2",
+                               "name": "admin",
+                               "description": "Admin"}]
+                }
+
+        if token_id in get_presets["identity"]["dedicated_full_device_permission_holder"]:
+                response["access"]["token"]["tenant"] = {
+                    "id": "hybrid:123456",
+                    "name": "hybrid:123456",
+                }
+                response["access"]["user"] = {
+                    "id": "12",
+                    "name": "HybridOneTwo",
+                    "roles": [{"id": "1",
+                               "name": "monitoring:observer",
+                               "description": "Monitoring Observer"},
+                              {"id": "3",
+                               "name": "hybridRole",
+                               "description": "Hybrid Admin",
+                               "tenantId": "hybrid:123456"}],
+                    "RAX-AUTH:contactId": "12"
+                }
+
+        if token_id in get_presets["identity"]["dedicated_account_permission_holder"]:
+                response["access"]["token"]["tenant"] = {
+                    "id": "hybrid:123456",
+                    "name": "hybrid:123456",
+                }
+                response["access"]["user"] = {
+                    "id": "34",
+                    "name": "HybridThreeFour",
+                    "roles": [{"id": "1",
+                               "name": "monitoring:creator",
+                               "description": "Monitoring Creator"},
+                              {"id": "2",
+                               "name": "creator",
+                               "description": "Creator"}],
+                    "RAX-AUTH:contactId": "34"
+                }
+
+        if token_id in get_presets["identity"]["dedicated_limited_device_permission_holder"]:
+                response["access"]["token"]["tenant"] = {
+                    "id": "hybrid:123456",
+                    "name": "hybrid:123456",
+                }
+                response["access"]["user"] = {
+                    "id": "56",
+                    "name": "HybridFiveSix",
+                    "roles": [{"id": "1",
+                               "name": "monitoring:observer",
+                               "description": "Monitoring Observer"},
+                              {"id": "2",
+                               "name": "observer",
+                               "description": "Observer"}],
+                    "RAX-AUTH:contactId": "56"
+                }
+
+        if token_id in get_presets["identity"]["dedicated_other_account_observer"]:
+                response["access"]["token"]["tenant"] = {
+                    "id": "hybrid:654321",
+                    "name": "hybrid:654321",
+                }
+                response["access"]["user"] = {
+                    "id": "78",
+                    "name": "HybridSevenEight",
+                    "roles": [{"id": "1",
+                               "name": "monitoring:observer",
+                               "description": "Observer"},
+                              {"id": "2",
+                               "name": "observer",
+                               "description": "Observer"}],
+                    "RAX-AUTH:contactId": "78"
+                }
+
+        if token_id in get_presets["identity"]["dedicated_other_account_admin"]:
+                response["access"]["token"]["tenant"] = {
+                    "id": "hybrid:654321",
+                    "name": "hybrid:654321",
+                }
+                response["access"]["user"] = {
+                    "id": "90",
+                    "name": "HybridNineZero",
+                    "roles": [{"id": "1",
+                               "name": "monitoring:admin",
+                               "description": "Admin"},
+                              {"id": "2",
+                               "name": "admin",
+                               "description": "Admin"}],
+                    "RAX-AUTH:contactId": "90"
+                }
+
         return json.dumps(response)
 
     @app.route('/v2.0/tokens/<string:token_id>/endpoints', methods=['GET'])

--- a/mimic/test/test_auth.py
+++ b/mimic/test/test_auth.py
@@ -1286,3 +1286,60 @@ class IdentityBehaviorInjectionTests(SynchronousTestCase):
             self, root, username="failme", request_func=request_with_content)
         self.assertEqual(response.code, 500)
         self.assertEqual(body, "Failure of JSON")
+
+
+class IdentityNondedicatedFixtureTests(SynchronousTestCase):
+
+    def test_non_dedicated_tokens(self):
+        """
+        Obtain Identity entries when presented tokens issued to non-dedicated users
+        """
+        url = "/identity/v2.0/tokens"
+        core, root = core_and_root([])
+        (response, content) = self.successResultOf(
+            json_request(self, root, "GET", url + "/OneTwo"))
+        self.assertEqual(200, response.code)
+        self.assertEqual(content["access"]["token"]["tenant"]["id"], "135790")
+
+        (response, content) = self.successResultOf(
+            json_request(self, root, "GET", url + "/ThreeFour"))
+        self.assertEqual(200, response.code)
+
+
+class IdentityDedicatedFixtureTests(SynchronousTestCase):
+
+    def test_dedicated_tokens(self):
+        """
+        Obtain Identity entries when presented tokens issued to dedicated users
+        """
+        url = "/identity/v2.0/tokens"
+        core, root = core_and_root([])
+        (response, content) = self.successResultOf(
+            json_request(self, root, "GET", url + "/HybridOneTwo"))
+        self.assertEqual(200, response.code)
+        self.assertEqual(content["access"]["token"]["tenant"]["id"], "hybrid:123456")
+        self.assertEqual(content["access"]["user"]["RAX-AUTH:contactId"], "12")
+
+        (response, content) = self.successResultOf(
+            json_request(self, root, "GET", url + "/HybridThreeFour"))
+        self.assertEqual(200, response.code)
+        self.assertEqual(content["access"]["token"]["tenant"]["id"], "hybrid:123456")
+        self.assertEqual(content["access"]["user"]["RAX-AUTH:contactId"], "34")
+
+        (response, content) = self.successResultOf(
+            json_request(self, root, "GET", url + "/HybridFiveSix"))
+        self.assertEqual(200, response.code)
+        self.assertEqual(content["access"]["token"]["tenant"]["id"], "hybrid:123456")
+        self.assertEqual(content["access"]["user"]["RAX-AUTH:contactId"], "56")
+
+        (response, content) = self.successResultOf(
+            json_request(self, root, "GET", url + "/HybridSevenEight"))
+        self.assertEqual(200, response.code)
+        self.assertEqual(content["access"]["token"]["tenant"]["id"], "hybrid:654321")
+        self.assertEqual(content["access"]["user"]["RAX-AUTH:contactId"], "78")
+
+        (response, content) = self.successResultOf(
+            json_request(self, root, "GET", url + "/HybridNineZero"))
+        self.assertEqual(200, response.code)
+        self.assertEqual(content["access"]["token"]["tenant"]["id"], "hybrid:654321")
+        self.assertEqual(content["access"]["user"]["RAX-AUTH:contactId"], "90")


### PR DESCRIPTION
Need to add a few canned responses to the Identity API that provide user data containing contact IDs that match those in the fixed permissions in the Valkyrie API plugin.