### PR TITLE
Add get any permissions endpoint to Valkyrie API

### DIFF
--- a/mimic/model/valkyrie_objects.py
+++ b/mimic/model/valkyrie_objects.py
@@ -93,6 +93,7 @@ class ValkyrieStore(object):
     permissions.append(AccountContactPermission(123456, 56, 12, 256, 2))
 
     permissions.append(AccountContactPermission(654321, 78, 14, 262144, 2))
+    permissions.append(AccountContactPermission(654321, 90, 12, 1048576, 2))
     permissions.append(AccountContactPermission(654321, 90, 15, 654321, 1))
 
     def create_token(self, request):
@@ -110,7 +111,7 @@ class ValkyrieStore(object):
         """
         pm = [p for p in self.permissions if (p.account_number == account_number and
                                               p.contact_id == contact_id and
-                                              p.item_type_id == item_type)]
+                                              (item_type is None or p.item_type_id == item_type))]
 
         response_message = {"contact_permissions": []}
         for p in pm:

--- a/mimic/rest/valkyrie_api.py
+++ b/mimic/rest/valkyrie_api.py
@@ -36,6 +36,20 @@ class ValkyrieApi(object):
         """
         return self.core.valkyrie_store.create_token(request)
 
+    effective_any_permissions_route = ('/account/<int:account_number>'
+                                       '/permissions/contacts/any'
+                                       '/by_contact/<int:contact_id>/effective')
+
+    @app.route(effective_any_permissions_route, methods=['GET'])
+    def effective_any_permissions(self, request, account_number, contact_id):
+        """
+        Responds with response code 200 and returns a list of all permissions
+        for the given account and contact
+        See https://valkyrie.my.rackspace.com/#managed-accounts
+        """
+        return self.core.valkyrie_store.get_permissions(request,
+                                                        account_number, contact_id, None)
+
     effective_accounts_permissions_route = ('/account/<int:account_number>'
                                             '/permissions/contacts/accounts'
                                             '/by_contact/<int:contact_id>/effective')

--- a/mimic/test/test_valkyrie.py
+++ b/mimic/test/test_valkyrie.py
@@ -76,6 +76,7 @@ class ValkyrieAPITests(SynchronousTestCase):
         self.assertTrue(content["contact_permissions"])
         self.assertEqual(len(content["contact_permissions"]), 1)
         self.assertEqual(content["contact_permissions"][0]["permission_type"], 15)
+        self.assertEqual(content["contact_permissions"][0]["item_type_name"], "accounts")
 
     def test_get_empty_devices_effective_permissions(self):
         """
@@ -102,3 +103,24 @@ class ValkyrieAPITests(SynchronousTestCase):
         permission = content["contact_permissions"][0]
         self.assertEqual(permission["permission_type"], 14)
         self.assertEqual(permission["item_id"], 262144)
+        self.assertEqual(permission["item_type_name"], "devices")
+
+    def test_get_any_permissions(self):
+        """
+        Obtain list of all permissions for contact 90 on account 654321
+        """
+        (response, content) = self.successResultOf(
+            json_request(self, self.root, "GET",
+                         self.url +
+                         "/account/654321/permissions/contacts/any/by_contact/90/effective"))
+        self.assertEqual(200, response.code)
+        self.assertTrue(content["contact_permissions"])
+        self.assertEqual(len(content["contact_permissions"]), 2)
+        device_permission = content["contact_permissions"][0]
+        self.assertEqual(device_permission["permission_type"], 12)
+        self.assertEqual(device_permission["item_id"], 1048576)
+        self.assertEqual(device_permission["item_type_name"], "devices")
+        account_permission = content["contact_permissions"][1]
+        self.assertEqual(account_permission["permission_type"], 15)
+        self.assertEqual(account_permission["item_id"], 654321)
+        self.assertEqual(account_permission["item_type_name"], "accounts")


### PR DESCRIPTION
The Repose Valkyrie filter is being reworked to include a call to endpoint /account/{account_number}/permissions/contacts/any/by_contact/{contact_id}/effective, so this change simulates it.