### PR TITLE
Add canned responses to Identity plugin

### DIFF
--- a/mimic/canned_responses/mimic_presets.py
+++ b/mimic/canned_responses/mimic_presets.py
@@ -45,8 +45,12 @@ get_presets = {"loadbalancers": {"lb_building": "On create load balancer, keeps 
                    # to presets in the Valkyrie plugin...
                    "non_dedicated_observer": ["OneTwo"],
                    "non_dedicated_admin": ["ThreeFour"],
+                   "non_dedicated_impersonator": ["ThreeFourImpersonator"],
+                   "non_dedicated_racker": ["ThreeFourRacker"],
                    "dedicated_full_device_permission_holder": ["HybridOneTwo"],
                    "dedicated_account_permission_holder": ["HybridThreeFour"],
+                   "dedicated_impersonator": ["HybridThreeFourImpersonator"],
+                   "dedicated_racker": ["HybridOneTwoRacker"],
                    "dedicated_limited_device_permission_holder": ["HybridFiveSix"],
-                   "dedicated_other_account_observer": ["HybridSevenEight"],
+                   "dedicated_non_permission_holder": ["HybridSevenEight"],
                    "dedicated_other_account_admin": ["HybridNineZero"]}}

--- a/mimic/rest/auth_api.py
+++ b/mimic/rest/auth_api.py
@@ -346,12 +346,15 @@ class AuthApi(object):
                  "description": "Global Observer Role.",
                  "name": "observer"}]
 
+        # Canned responses to be removed ...
+
         if token_id in get_presets["identity"]["non_dedicated_observer"]:
                 response["access"]["token"]["tenant"] = {
                     "id": "135790",
                     "name": "135790",
                 }
                 response["access"]["user"] = {
+                    "id": "12",
                     "name": "OneTwo",
                     "roles": [{"id": "1",
                                "name": "monitoring:observer",
@@ -364,6 +367,7 @@ class AuthApi(object):
                     "name": "135790",
                 }
                 response["access"]["user"] = {
+                    "id": "34",
                     "name": "ThreeFour",
                     "roles": [{"id": "1",
                                "name": "monitoring:admin",
@@ -371,6 +375,46 @@ class AuthApi(object):
                               {"id": "2",
                                "name": "admin",
                                "description": "Admin"}]
+                }
+
+        if token_id in get_presets["identity"]["non_dedicated_impersonator"]:
+                response["access"]["token"]["tenant"] = {
+                    "id": "135790",
+                    "name": "135790",
+                }
+                response["access"]["user"] = {
+                    "id": "34",
+                    "name": "ThreeFour",
+                    "roles": [{"id": "1",
+                               "name": "identity:nobody",
+                               "description": "Nobody"}]
+                }
+                response["access"]["RAX-AUTH:impersonator"] = {
+                    "id": response["access"]["user"]["id"],
+                    "name": response["access"]["user"]["name"],
+                    "roles": [{"id": "1",
+                               "name": "monitoring:service-admin"},
+                              {"id": "2",
+                               "name": "object-store:admin"}]
+                }
+
+        if token_id in get_presets["identity"]["non_dedicated_racker"]:
+                response["access"]["token"]["tenant"] = {
+                    "id": "135790",
+                    "name": "135790",
+                }
+                response["access"]["user"] = {
+                    "id": "34",
+                    "name": "ThreeFour",
+                    "roles": [{"id": "1",
+                               "name": "identity:nobody",
+                               "description": "Nobody"}]
+                }
+                response["access"]["RAX-AUTH:impersonator"] = {
+                    "id": response["access"]["user"]["id"],
+                    "name": response["access"]["user"]["name"],
+                    "roles": [{"id": "1",
+                               "name": "Racker"}]
                 }
 
         if token_id in get_presets["identity"]["dedicated_full_device_permission_holder"]:
@@ -425,20 +469,57 @@ class AuthApi(object):
                     "RAX-AUTH:contactId": "56"
                 }
 
-        if token_id in get_presets["identity"]["dedicated_other_account_observer"]:
+        if token_id in get_presets["identity"]["dedicated_racker"]:
                 response["access"]["token"]["tenant"] = {
-                    "id": "hybrid:654321",
-                    "name": "hybrid:654321",
+                    "id": "hybrid:123456",
+                    "name": "hybrid:123456",
+                }
+                response["access"]["user"] = {
+                    "id": "12",
+                    "name": "HybridOneTwo",
+                    "roles": [{"id": "1",
+                               "name": "identity:nobody",
+                               "description": "Nobody"}],
+                    "RAX-AUTH:contactId": "12"
+                }
+                response["access"]["RAX-AUTH:impersonator"] = {
+                    "id": response["access"]["user"]["id"],
+                    "name": response["access"]["user"]["name"],
+                    "roles": [{"id": "1",
+                               "name": "Racker"}]
+                }
+
+        if token_id in get_presets["identity"]["dedicated_impersonator"]:
+                response["access"]["token"]["tenant"] = {
+                    "id": "hybrid:123456",
+                    "name": "hybrid:123456",
+                }
+                response["access"]["user"] = {
+                    "id": "34",
+                    "name": "HybridThreeFour",
+                    "roles": [{"id": "1",
+                               "name": "identity:nobody",
+                               "description": "Nobody"}],
+                    "RAX-AUTH:contactId": "34"
+                }
+                response["access"]["RAX-AUTH:impersonator"] = {
+                    "id": response["access"]["user"]["id"],
+                    "name": response["access"]["user"]["name"],
+                    "roles": [{"id": "1",
+                               "name": "monitoring:service-admin"}]
+                }
+
+        if token_id in get_presets["identity"]["dedicated_non_permission_holder"]:
+                response["access"]["token"]["tenant"] = {
+                    "id": "hybrid:123456",
+                    "name": "hybrid:123456",
                 }
                 response["access"]["user"] = {
                     "id": "78",
                     "name": "HybridSevenEight",
                     "roles": [{"id": "1",
-                               "name": "monitoring:observer",
-                               "description": "Observer"},
-                              {"id": "2",
-                               "name": "observer",
-                               "description": "Observer"}],
+                               "name": "identity:user-admin",
+                               "description": "User admin"}],
                     "RAX-AUTH:contactId": "78"
                 }
 

--- a/mimic/test/test_auth.py
+++ b/mimic/test/test_auth.py
@@ -1305,6 +1305,14 @@ class IdentityNondedicatedFixtureTests(SynchronousTestCase):
             json_request(self, root, "GET", url + "/ThreeFour"))
         self.assertEqual(200, response.code)
 
+        (response, content) = self.successResultOf(
+            json_request(self, root, "GET", url + "/ThreeFourImpersonator"))
+        self.assertEqual(200, response.code)
+
+        (response, content) = self.successResultOf(
+            json_request(self, root, "GET", url + "/ThreeFourRacker"))
+        self.assertEqual(200, response.code)
+
 
 class IdentityDedicatedFixtureTests(SynchronousTestCase):
 
@@ -1321,7 +1329,19 @@ class IdentityDedicatedFixtureTests(SynchronousTestCase):
         self.assertEqual(content["access"]["user"]["RAX-AUTH:contactId"], "12")
 
         (response, content) = self.successResultOf(
+            json_request(self, root, "GET", url + "/HybridOneTwoRacker"))
+        self.assertEqual(200, response.code)
+        self.assertEqual(content["access"]["token"]["tenant"]["id"], "hybrid:123456")
+        self.assertEqual(content["access"]["user"]["RAX-AUTH:contactId"], "12")
+
+        (response, content) = self.successResultOf(
             json_request(self, root, "GET", url + "/HybridThreeFour"))
+        self.assertEqual(200, response.code)
+        self.assertEqual(content["access"]["token"]["tenant"]["id"], "hybrid:123456")
+        self.assertEqual(content["access"]["user"]["RAX-AUTH:contactId"], "34")
+
+        (response, content) = self.successResultOf(
+            json_request(self, root, "GET", url + "/HybridThreeFourImpersonator"))
         self.assertEqual(200, response.code)
         self.assertEqual(content["access"]["token"]["tenant"]["id"], "hybrid:123456")
         self.assertEqual(content["access"]["user"]["RAX-AUTH:contactId"], "34")
@@ -1335,7 +1355,7 @@ class IdentityDedicatedFixtureTests(SynchronousTestCase):
         (response, content) = self.successResultOf(
             json_request(self, root, "GET", url + "/HybridSevenEight"))
         self.assertEqual(200, response.code)
-        self.assertEqual(content["access"]["token"]["tenant"]["id"], "hybrid:654321")
+        self.assertEqual(content["access"]["token"]["tenant"]["id"], "hybrid:123456")
         self.assertEqual(content["access"]["user"]["RAX-AUTH:contactId"], "78")
 
         (response, content) = self.successResultOf(


### PR DESCRIPTION
Integration testing has revealed the need for a few more and different types of canned entries in the Identity plugin.  

I'm aware that larding up Mimic with canned responses is not the proper approach (see discussion in #444).  Again I repeat the pledge to add a control endpoint or other mechanism for loading test fixtures to this (and the Valkyrie) plugin as soon as time permits.

 