### PR TITLE
chore(py3): future import unicode_literals everywhere

### DIFF
--- a/mimic/canned_responses/auth.py
+++ b/mimic/canned_responses/auth.py
@@ -2,6 +2,9 @@
 """
 Canned response for get auth token
 """
+
+from __future__ import unicode_literals
+
 from datetime import datetime, timedelta
 
 

--- a/mimic/canned_responses/fastly.py
+++ b/mimic/canned_responses/fastly.py
@@ -1,6 +1,9 @@
 """
 Canned response for fastly
 """
+
+from __future__ import unicode_literals
+
 import random
 import string
 import uuid

--- a/mimic/canned_responses/glance.py
+++ b/mimic/canned_responses/glance.py
@@ -1,6 +1,9 @@
 """
 Cannned responses for glance images
 """
+
+from __future__ import unicode_literals
+
 from mimic.canned_responses.json.glance.glance_images_json import (images,
                                                                    image_schema)
 

--- a/mimic/canned_responses/json/glance/glance_images_json.py
+++ b/mimic/canned_responses/json/glance/glance_images_json.py
@@ -2,6 +2,8 @@
 Glance images
 """
 
+from __future__ import unicode_literals
+
 images = {
     "images":
         [{

--- a/mimic/canned_responses/loadbalancer.py
+++ b/mimic/canned_responses/loadbalancer.py
@@ -3,6 +3,9 @@
 Canned response for add/get/list/delete load balancers and
 add/get/delete/list nodes
 """
+
+from __future__ import unicode_literals
+
 from random import randrange
 
 

--- a/mimic/canned_responses/maas_alarm_examples.py
+++ b/mimic/canned_responses/maas_alarm_examples.py
@@ -2,6 +2,8 @@
 Canned responses for MAAS alarm examples.
 """
 
+from __future__ import unicode_literals
+
 
 def alarm_examples():
     """

--- a/mimic/canned_responses/maas_json_home.py
+++ b/mimic/canned_responses/maas_json_home.py
@@ -2,6 +2,8 @@
 Canned response for monitoring json home
 """
 
+from __future__ import unicode_literals
+
 
 def json_home(url):
     """

--- a/mimic/canned_responses/maas_monitoring_zones.py
+++ b/mimic/canned_responses/maas_monitoring_zones.py
@@ -2,6 +2,8 @@
 Canned responses for MAAS monitoring zones.
 """
 
+from __future__ import unicode_literals
+
 
 def monitoring_zones():
     """

--- a/mimic/canned_responses/mimic_presets.py
+++ b/mimic/canned_responses/mimic_presets.py
@@ -2,6 +2,9 @@
 Defines the preset values in the mimic api.
 """
 
+from __future__ import unicode_literals
+
+
 get_presets = {"loadbalancers": {"lb_building": "On create load balancer, keeps the load balancer in "
                                                 "building state for given seconds",
                                  "lb_error_state": "Puts the LB in error state, and such an LB can only"

--- a/mimic/canned_responses/noit.py
+++ b/mimic/canned_responses/noit.py
@@ -1,6 +1,9 @@
 """
 Canned response for Noit
 """
+
+from __future__ import unicode_literals
+
 import time
 from mimic.canned_responses.noit_metrics_fixture import (metrics_common_template,
                                                          metrics)

--- a/mimic/canned_responses/noit_metrics_fixture.py
+++ b/mimic/canned_responses/noit_metrics_fixture.py
@@ -2,6 +2,8 @@
 Fixtures for metrics
 """
 
+from __future__ import unicode_literals
+
 # Remove this when changing over to object model
 # as this is repeated within the check_template
 

--- a/mimic/canned_responses/nova.py
+++ b/mimic/canned_responses/nova.py
@@ -3,6 +3,8 @@
 Canned responses for nova's GET limits API
 """
 
+from __future__ import unicode_literals
+
 
 def get_limit():
     """

--- a/mimic/canned_responses/queue.py
+++ b/mimic/canned_responses/queue.py
@@ -2,6 +2,8 @@
 Canned response for Queue
 """
 
+from __future__ import unicode_literals
+
 
 def queues_example(queue_name):
     """

--- a/mimic/catalog.py
+++ b/mimic/catalog.py
@@ -2,6 +2,8 @@
 Classes which represent the objects within the service catalog.
 """
 
+from __future__ import unicode_literals
+
 __all__ = ("Endpoint", "Entry")
 
 

--- a/mimic/imimic.py
+++ b/mimic/imimic.py
@@ -2,6 +2,8 @@
 Interfaces for Mimic.
 """
 
+from __future__ import unicode_literals
+
 from zope.interface import Attribute, Interface
 
 

--- a/mimic/model/behaviors.py
+++ b/mimic/model/behaviors.py
@@ -1,6 +1,9 @@
 """
 General-purpose utilities for customizing response behavior.
 """
+
+from __future__ import unicode_literals
+
 import json
 import re
 from itertools import cycle

--- a/mimic/model/clb_errors.py
+++ b/mimic/model/clb_errors.py
@@ -6,6 +6,8 @@ so the API will probably change.  But this seems better than sprinkling them
 all over the request code right now.
 """
 
+from __future__ import unicode_literals
+
 
 def considered_immutable_error(clb_state, lb_id):
     """

--- a/mimic/model/clb_objects.py
+++ b/mimic/model/clb_objects.py
@@ -4,6 +4,9 @@ Balancer API docs
 <http://docs.rackspace.com/loadbalancers/api/v1.0/clb-devguide/content/API_Operations.html>`
  for more information.
 """
+
+from __future__ import unicode_literals
+
 from copy import deepcopy
 from random import randrange
 
@@ -77,7 +80,7 @@ class Node(object):
     id = attr.ib(validator=attr.validators.instance_of(int),
                  default=attr.Factory(lambda: randrange(999999)))
     status = attr.ib(validator=attr.validators.instance_of(str),
-                     default="ONLINE")
+                     default=b"ONLINE")
     feed_events = attr.ib(default=[])
 
     @classmethod

--- a/mimic/model/cloudfeeds.py
+++ b/mimic/model/cloudfeeds.py
@@ -5,6 +5,8 @@ http://docs.rackspace.com/cloud-feeds/api/v1.0/feeds-devguide/content/overview.h
 for more details.
 """
 
+from __future__ import unicode_literals
+
 import attr
 from six import string_types
 

--- a/mimic/model/customer_objects.py
+++ b/mimic/model/customer_objects.py
@@ -1,6 +1,9 @@
 """
 Customer Contacts storage object
 """
+
+from __future__ import unicode_literals
+
 from characteristic import attributes, Attribute
 
 

--- a/mimic/model/flavor_collections.py
+++ b/mimic/model/flavor_collections.py
@@ -2,6 +2,8 @@
 Model objects for the flavors.
 """
 
+from __future__ import unicode_literals
+
 from characteristic import attributes, Attribute
 from json import dumps
 from mimic.model.flavors import (

--- a/mimic/model/flavors.py
+++ b/mimic/model/flavors.py
@@ -2,6 +2,8 @@
 Model objects for mimic flavors.
 """
 
+from __future__ import unicode_literals
+
 from characteristic import attributes
 
 

--- a/mimic/model/glance_objects.py
+++ b/mimic/model/glance_objects.py
@@ -1,6 +1,9 @@
 """
 Model objects for the Glance mimic.
 """
+
+from __future__ import unicode_literals
+
 from json import dumps, loads
 from characteristic import attributes, Attribute
 from uuid import uuid4

--- a/mimic/model/identity.py
+++ b/mimic/model/identity.py
@@ -1,6 +1,9 @@
 """
 Models relating to identity.
 """
+
+from __future__ import unicode_literals
+
 from uuid import uuid4
 
 from attr import Factory, attributes, attr, validators

--- a/mimic/model/image_collections.py
+++ b/mimic/model/image_collections.py
@@ -2,6 +2,8 @@
 Model objects for images.
 """
 
+from __future__ import unicode_literals
+
 from characteristic import attributes, Attribute
 from json import dumps
 from mimic.model.rackspace_images import (ImageStore, OnMetalImage)

--- a/mimic/model/ironic_objects.py
+++ b/mimic/model/ironic_objects.py
@@ -1,6 +1,9 @@
 """
 Model objects for the Nova mimic.
 """
+
+from __future__ import unicode_literals
+
 from characteristic import attributes, Attribute
 from uuid import uuid4
 from json import loads, dumps

--- a/mimic/model/keypair_objects.py
+++ b/mimic/model/keypair_objects.py
@@ -2,6 +2,8 @@
 Keypair objects for mimic
 """
 
+from __future__ import unicode_literals
+
 import json
 
 from characteristic import attributes, Attribute

--- a/mimic/model/maas_objects.py
+++ b/mimic/model/maas_objects.py
@@ -2,6 +2,8 @@
 MaaS API data model
 """
 
+from __future__ import unicode_literals
+
 import random
 import string
 from uuid import uuid4

--- a/mimic/model/mailgun_objects.py
+++ b/mimic/model/mailgun_objects.py
@@ -1,6 +1,9 @@
 """
 Mailgun object storage
 """
+
+from __future__ import unicode_literals
+
 import time
 from characteristic import attributes, Attribute
 

--- a/mimic/model/nova_objects.py
+++ b/mimic/model/nova_objects.py
@@ -2,6 +2,8 @@
 Model objects for the Nova mimic.
 """
 
+from __future__ import unicode_literals
+
 import re
 
 from characteristic import attributes, Attribute

--- a/mimic/model/rackspace_images.py
+++ b/mimic/model/rackspace_images.py
@@ -2,6 +2,8 @@
 Model objects for mimic images.
 """
 
+from __future__ import unicode_literals
+
 from characteristic import attributes
 import uuid
 import random

--- a/mimic/model/valkyrie_objects.py
+++ b/mimic/model/valkyrie_objects.py
@@ -1,6 +1,9 @@
 """
 Model objects for the Valkyrie mimic.
 """
+
+from __future__ import unicode_literals
+
 from characteristic import attributes, Attribute
 from json import dumps
 

--- a/mimic/resource.py
+++ b/mimic/resource.py
@@ -1,6 +1,9 @@
 """
 Resources for Mimic's core application.
 """
+
+from __future__ import unicode_literals
+
 import json
 
 from io import StringIO
@@ -50,9 +53,9 @@ class MimicRoot(object):
         """
         A helpful greeting message.
         """
-        request.responseHeaders.setRawHeaders("content-type", ["text/plain"])
+        request.responseHeaders.setRawHeaders(b"content-type", [b"text/plain"])
         return ("To get started with Mimic, POST an authentication request to:"
-                "\n\n/identity/v2.0/tokens\n")
+                "\n\n/identity/v2.0/tokens\n").encode('utf-8')
 
     @app.route("/identity", branch=True)
     def get_auth_api(self, request):
@@ -172,7 +175,7 @@ class MimicRequest(Request, object):
     """
     Mimic requests by default are of content type application/json.
     """
-    defaultContentType = "application/json"
+    defaultContentType = b"application/json"
 
 
 class MimicLoggingRequest(MimicRequest, object):

--- a/mimic/rest/auth_api.py
+++ b/mimic/rest/auth_api.py
@@ -2,6 +2,9 @@
 """
 Defines get token, impersonation
 """
+
+from __future__ import unicode_literals
+
 import json
 import time
 

--- a/mimic/rest/cloudfeeds.py
+++ b/mimic/rest/cloudfeeds.py
@@ -2,6 +2,9 @@
 """
 Defines the control plane API endpoints for the Cloudfeeds Plugin.
 """
+
+from __future__ import unicode_literals
+
 from uuid import uuid4
 from six import text_type
 from zope.interface import implementer

--- a/mimic/rest/customer_api.py
+++ b/mimic/rest/customer_api.py
@@ -3,6 +3,8 @@
 API Mock for the Customer API.
 """
 
+from __future__ import unicode_literals
+
 import json
 
 from mimic.rest.mimicapp import MimicApp

--- a/mimic/rest/fastly_api.py
+++ b/mimic/rest/fastly_api.py
@@ -3,6 +3,8 @@
 Defines get current customer
 """
 
+from __future__ import unicode_literals
+
 import json
 
 from mimic.rest.mimicapp import MimicApp

--- a/mimic/rest/glance_api.py
+++ b/mimic/rest/glance_api.py
@@ -3,6 +3,8 @@
 Defines a list of images from glance
 """
 
+from __future__ import unicode_literals
+
 import json
 from uuid import uuid4
 from six import text_type

--- a/mimic/rest/ironic_api.py
+++ b/mimic/rest/ironic_api.py
@@ -4,6 +4,8 @@ API Mock for Ironic.
 http://docs.openstack.org/developer/ironic/webapi/v1.html
 """
 
+from __future__ import unicode_literals
+
 from mimic.rest.mimicapp import MimicApp
 
 

--- a/mimic/rest/loadbalancer_api.py
+++ b/mimic/rest/loadbalancer_api.py
@@ -2,6 +2,9 @@
 """
 Defines add node and delete node from load balancers
 """
+
+from __future__ import unicode_literals
+
 import json
 from uuid import uuid4
 from six import string_types, text_type
@@ -276,7 +279,7 @@ class LoadBalancerRegion(object):
         """
         body, code = self.session(tenant_id).get_node_feed(lb_id, node_id)
         request.setResponseCode(code)
-        request.setHeader("Content-Type", "application/atom+xml")
+        request.setHeader(b"Content-Type", b"application/atom+xml")
         return body
 
     @app.route(

--- a/mimic/rest/maas_api.py
+++ b/mimic/rest/maas_api.py
@@ -2,7 +2,7 @@
 MAAS Mock API
 """
 
-from __future__ import division
+from __future__ import division, unicode_literals
 
 import json
 import collections
@@ -462,10 +462,10 @@ class MaasMock(object):
         self._entity_cache_for_tenant(tenant_id).entities_list.append(newentity)
         status = 201
         request.setResponseCode(status)
-        request.setHeader('location', base_uri_from_request(request).rstrip('/') +
-                          request.path + '/' + newentity.id.encode('utf-8'))
-        request.setHeader('x-object-id', newentity.id.encode('utf-8'))
-        request.setHeader('content-type', 'text/plain')
+        request.setHeader(b'location', base_uri_from_request(request).rstrip('/').encode('utf-8') +
+                          request.path + b'/' + newentity.id.encode('utf-8'))
+        request.setHeader(b'x-object-id', newentity.id.encode('utf-8'))
+        request.setHeader(b'content-type', b'text/plain')
         self._audit('entities', request, tenant_id, status, content)
         return b''
 
@@ -512,9 +512,10 @@ class MaasMock(object):
 
         status = 204
         request.setResponseCode(status)
-        request.setHeader('location', base_uri_from_request(request).rstrip('/') + request.path)
-        request.setHeader('x-object-id', entity_id.encode('utf-8'))
-        request.setHeader('content-type', 'text/plain')
+        request.setHeader(b'location', base_uri_from_request(request).rstrip('/').encode('utf-8') +
+                          request.path)
+        request.setHeader(b'x-object-id', entity_id.encode('utf-8'))
+        request.setHeader(b'content-type', b'text/plain')
         self._audit('entities', request, tenant_id, status, content)
         return b''
 
@@ -548,7 +549,7 @@ class MaasMock(object):
 
         status = 204
         request.setResponseCode(status)
-        request.setHeader('content-type', 'text/plain')
+        request.setHeader(b'content-type', b'text/plain')
         self._audit('entities', request, tenant_id, status)
         return b''
 
@@ -578,10 +579,10 @@ class MaasMock(object):
         self._entity_cache_for_tenant(tenant_id).checks_list.append(newcheck)
         status = 201
         request.setResponseCode(status)
-        request.setHeader('location', base_uri_from_request(request).rstrip('/') +
-                          request.path + '/' + newcheck.id.encode('utf-8'))
-        request.setHeader('x-object-id', newcheck.id.encode('utf-8'))
-        request.setHeader('content-type', 'text/plain')
+        request.setHeader(b'location', base_uri_from_request(request).rstrip('/').encode('utf-8') +
+                          request.path + b'/' + newcheck.id.encode('utf-8'))
+        request.setHeader(b'x-object-id', newcheck.id.encode('utf-8'))
+        request.setHeader(b'content-type', b'text/plain')
         self._audit('checks', request, tenant_id, status, content)
         return b''
 
@@ -613,9 +614,10 @@ class MaasMock(object):
                 break
         status = 204
         request.setResponseCode(status)
-        request.setHeader('location', base_uri_from_request(request).rstrip('/') + request.path)
-        request.setHeader('x-object-id', check_id.encode('utf-8'))
-        request.setHeader('content-type', 'text/plain')
+        request.setHeader(b'location', base_uri_from_request(request).rstrip('/').encode('utf-8') +
+                          request.path)
+        request.setHeader(b'x-object-id', check_id.encode('utf-8'))
+        request.setHeader(b'content-type', b'text/plain')
         self._audit('checks', request, tenant_id, status, content)
         return b''
 
@@ -646,7 +648,7 @@ class MaasMock(object):
                      if not (alarm.check_id == check_id and alarm.entity_id == entity_id)]
         status = 204
         request.setResponseCode(status)
-        request.setHeader('content-type', 'text/plain')
+        request.setHeader(b'content-type', b'text/plain')
         self._audit('checks', request, tenant_id, status)
         return b''
 
@@ -698,10 +700,10 @@ class MaasMock(object):
         self._entity_cache_for_tenant(tenant_id).alarms_list.append(newalarm)
         status = 201
         request.setResponseCode(status)
-        request.setHeader('location', base_uri_from_request(request).rstrip('/') +
-                          request.path + '/' + newalarm.id.encode('utf-8'))
-        request.setHeader('x-object-id', newalarm.id.encode('utf-8'))
-        request.setHeader('content-type', 'text/plain')
+        request.setHeader(b'location', base_uri_from_request(request).rstrip('/').encode('utf-8') +
+                          request.path + b'/' + newalarm.id.encode('utf-8'))
+        request.setHeader(b'x-object-id', newalarm.id.encode('utf-8'))
+        request.setHeader(b'content-type', b'text/plain')
         self._audit('alarms', request, tenant_id, status, content)
         return b''
 
@@ -741,9 +743,10 @@ class MaasMock(object):
 
         status = 204
         request.setResponseCode(status)
-        request.setHeader('location', base_uri_from_request(request).rstrip('/') + request.path)
-        request.setHeader('x-object-id', alarm_id.encode('utf-8'))
-        request.setHeader('content-type', 'text/plain')
+        request.setHeader(b'location', base_uri_from_request(request).rstrip('/').encode('utf-8') +
+                          request.path)
+        request.setHeader(b'x-object-id', alarm_id.encode('utf-8'))
+        request.setHeader(b'content-type', b'text/plain')
         self._audit('alarms', request, tenant_id, status, content)
         return b''
 
@@ -772,7 +775,7 @@ class MaasMock(object):
         status = 204
         request.setResponseCode(status)
         self._audit('alarms', request, tenant_id, status)
-        request.setHeader('content-type', 'text/plain')
+        request.setHeader(b'content-type', b'text/plain')
         return b''
 
     @app.route('/v1.0/<string:tenant_id>/entities/<string:entity_id>/test-alarm', methods=['POST'])
@@ -984,11 +987,11 @@ class MaasMock(object):
         """
         URL of agent install script
         """
-        xsil = "https://monitoring.api.rackspacecloud.com/"
-        xsil += "v1.0/00000/agent_installers/c69b2ceafc0444506fb32255af3d9be3.sh"
+        xsil = (b'https://monitoring.api.rackspacecloud.com'
+                b'/v1.0/00000/agent_installers/c69b2ceafc0444506fb32255af3d9be3.sh')
         status = 201
         request.setResponseCode(status)
-        request.setHeader('x-shell-installer-location', xsil)
+        request.setHeader(b'x-shell-installer-location', xsil)
         self._audit('agent_installers', request, tenant_id, status, request.content.read())
         return b''
 
@@ -1002,10 +1005,10 @@ class MaasMock(object):
         self._entity_cache_for_tenant(tenant_id).notifications_list.append(new_n)
         status = 201
         request.setResponseCode(status)
-        request.setHeader('content-type', 'text/plain')
-        request.setHeader('location', base_uri_from_request(request).rstrip('/') +
-                          request.path + '/' + new_n.id.encode('utf-8'))
-        request.setHeader('x-object-id', new_n.id.encode('utf-8'))
+        request.setHeader(b'content-type', b'text/plain')
+        request.setHeader(b'location', base_uri_from_request(request).rstrip('/').encode('utf-8') +
+                          request.path + b'/' + new_n.id.encode('utf-8'))
+        request.setHeader(b'x-object-id', new_n.id.encode('utf-8'))
         self._audit('notifications', request, tenant_id, status, content)
         return b''
 
@@ -1040,7 +1043,7 @@ class MaasMock(object):
 
         status = 204
         request.setResponseCode(status)
-        request.setHeader('content-type', 'text/plain')
+        request.setHeader(b'content-type', b'text/plain')
         self._audit('notifications', request, tenant_id, status, content)
         return b''
 
@@ -1067,7 +1070,7 @@ class MaasMock(object):
         status = 204
         request.setResponseCode(status)
         self._audit('notifications', request, tenant_id, status)
-        request.setHeader('content-type', 'text/plain')
+        request.setHeader(b'content-type', b'text/plain')
         return b''
 
     @app.route('/v1.0/<string:tenant_id>/notification_plans', methods=['POST'])
@@ -1081,10 +1084,10 @@ class MaasMock(object):
         self._entity_cache_for_tenant(tenant_id).notificationplans_list.append(newnp)
         status = 201
         request.setResponseCode(status)
-        request.setHeader('content-type', 'text/plain')
-        request.setHeader('location', base_uri_from_request(request).rstrip('/') +
-                          request.path + '/' + newnp.id.encode('utf-8'))
-        request.setHeader('x-object-id', newnp.id.encode('utf-8'))
+        request.setHeader(b'content-type', b'text/plain')
+        request.setHeader(b'location', base_uri_from_request(request).rstrip('/').encode('utf-8') +
+                          request.path + b'/' + newnp.id.encode('utf-8'))
+        request.setHeader(b'x-object-id', newnp.id.encode('utf-8'))
         self._audit('notification_plans', request, tenant_id, status, content)
         return b''
 
@@ -1129,7 +1132,7 @@ class MaasMock(object):
                 break
         status = 204
         request.setResponseCode(status)
-        request.setHeader('content-type', 'text/plain')
+        request.setHeader(b'content-type', b'text/plain')
         self._audit('notification_plans', request, tenant_id, status, content)
         return b''
 
@@ -1171,7 +1174,7 @@ class MaasMock(object):
         status = 204
         request.setResponseCode(status)
         self._audit('notification_plans', request, tenant_id, status)
-        request.setHeader('content-type', 'text/plain')
+        request.setHeader(b'content-type', b'text/plain')
         return b''
 
     @app.route('/v1.0/<string:tenant_id>/suppressions', methods=['GET'])
@@ -1212,10 +1215,10 @@ class MaasMock(object):
         self._entity_cache_for_tenant(tenant_id).suppressions_list.append(newsp)
         status = 201
         request.setResponseCode(status)
-        request.setHeader('location', base_uri_from_request(request).rstrip('/') +
-                          request.path + '/' + newsp.id.encode('utf-8'))
-        request.setHeader('x-object-id', newsp.id.encode('utf-8'))
-        request.setHeader('content-type', 'text/plain')
+        request.setHeader(b'location', base_uri_from_request(request).rstrip('/').encode('utf-8') +
+                          request.path + b'/' + newsp.id.encode('utf-8'))
+        request.setHeader(b'x-object-id', newsp.id.encode('utf-8'))
+        request.setHeader(b'content-type', b'text/plain')
         self._audit('suppressions', request, tenant_id, status, content)
         return b''
 
@@ -1235,7 +1238,7 @@ class MaasMock(object):
                 break
         status = 204
         request.setResponseCode(status)
-        request.setHeader('content-type', 'text/plain')
+        request.setHeader(b'content-type', b'text/plain')
         self._audit('suppressions', request, tenant_id, status, content)
         return b''
 
@@ -1262,7 +1265,7 @@ class MaasMock(object):
         status = 204
         request.setResponseCode(status)
         self._audit('suppressions', request, tenant_id, status)
-        request.setHeader('content-type', 'text/plain')
+        request.setHeader(b'content-type', b'text/plain')
         return b''
 
     @app.route('/v1.0/<string:tenant_id>/monitoring_zones', methods=['GET'])
@@ -1519,7 +1522,7 @@ class MaasController(object):
                      'response': request_body['response']}
         test_alarm_errors[entity_id].append(error_obj)
         request.setResponseCode(201)
-        request.setHeader('x-object-id', error_obj['id'])
+        request.setHeader(b'x-object-id', error_obj['id'].encode('utf-8'))
         return b''
 
     @app.route('/v1.0/<string:tenant_id>/entities/<string:entity_id>/alarms/test_response',
@@ -1633,8 +1636,8 @@ class MaasController(object):
 
         maas_store.alarm_states.append(new_state)
         request.setResponseCode(201)
-        request.setHeader('x-object-id', new_state.id.encode('utf-8'))
-        request.setHeader('content-type', 'text/plain')
+        request.setHeader(b'x-object-id', new_state.id.encode('utf-8'))
+        request.setHeader(b'content-type', b'text/plain')
         return b''
 
     @app.route('/v1.0/<string:tenant_id>/entities/<string:entity_id>/checks' +

--- a/mimic/rest/mailgun_api.py
+++ b/mimic/rest/mailgun_api.py
@@ -4,6 +4,8 @@ API Mock for Mail Gun.
 https://documentation.mailgun.com/api-sending.html
 """
 
+from __future__ import unicode_literals
+
 import json
 import time
 from six.moves.urllib.parse import parse_qs

--- a/mimic/rest/mimicapp.py
+++ b/mimic/rest/mimicapp.py
@@ -2,6 +2,8 @@
 Contains the base Klein app for Mimic.
 """
 
+from __future__ import unicode_literals
+
 from klein import Klein
 
 

--- a/mimic/rest/noit_api.py
+++ b/mimic/rest/noit_api.py
@@ -2,6 +2,9 @@
 """
 Defines get token, impersonation
 """
+
+from __future__ import unicode_literals
+
 import xmltodict
 from uuid import UUID
 from mimic.rest.mimicapp import MimicApp
@@ -53,7 +56,7 @@ class NoitApi(object):
         """
         response = self.validate_check_payload(request)
         if (response[0] == 200):
-            request.setHeader("content-type", "application/xml")
+            request.setHeader(b"content-type", b"application/xml")
             response_body = test_check(response[1]["module"])
             return xmltodict.unparse(response_body)
         request.setResponseCode(response[0])
@@ -72,7 +75,7 @@ class NoitApi(object):
         except (ValueError, AttributeError):
             request.setResponseCode(500)
             return
-        request.setHeader("content-type", "application/xml")
+        request.setHeader(b"content-type", b"application/xml")
         response = self.validate_check_payload(request)
         request.setResponseCode(response[0])
         if (response[0] == 200):
@@ -85,7 +88,7 @@ class NoitApi(object):
         """
         Return the current configuration and state of the specified check.
         """
-        request.setHeader("content-type", "application/xml")
+        request.setHeader(b"content-type", b"application/xml")
         return xmltodict.unparse(get_check(check_id))
 
     @app.route('/config/checks', methods=['GET'])
@@ -93,7 +96,7 @@ class NoitApi(object):
         """
         Return the current configuration and state of all checks.
         """
-        request.setHeader("content-type", "application/xml")
+        request.setHeader(b"content-type", b"application/xml")
         return xmltodict.unparse(get_all_checks())
 
     @app.route('/checks/delete/<check_id>', methods=['DELETE'])
@@ -103,5 +106,5 @@ class NoitApi(object):
         """
         response_code = delete_check(check_id) or 200
         request.setResponseCode(response_code)
-        request.setHeader("content-type", "application/xml")
+        request.setHeader(b"content-type", b"application/xml")
         return

--- a/mimic/rest/nova_api.py
+++ b/mimic/rest/nova_api.py
@@ -3,6 +3,8 @@
 Defines create, delete, get, list servers and get images and flavors.
 """
 
+from __future__ import unicode_literals
+
 from uuid import uuid4
 import json
 

--- a/mimic/rest/queue_api.py
+++ b/mimic/rest/queue_api.py
@@ -1,6 +1,9 @@
 """
 API mock for Rackspace Queues.
 """
+
+from __future__ import unicode_literals
+
 import json
 import collections
 from uuid import uuid4

--- a/mimic/rest/rackconnect_v3_api.py
+++ b/mimic/rest/rackconnect_v3_api.py
@@ -4,6 +4,9 @@
 API mock for the Rackspace RackConnect v3 API, which is documented at:
 http://docs.rcv3.apiary.io/
 """
+
+from __future__ import unicode_literals
+
 from collections import defaultdict
 import json
 from uuid import uuid4, UUID

--- a/mimic/rest/swift_api.py
+++ b/mimic/rest/swift_api.py
@@ -4,6 +4,8 @@
 API mock for OpenStack Swift / Rackspace Cloud Files.
 """
 
+from __future__ import unicode_literals
+
 from uuid import uuid4, uuid5, NAMESPACE_URL
 from six import text_type
 
@@ -155,12 +157,12 @@ class SwiftTenantInRegion(object):
         status code of 200 when such a container exists, 404 if not.
         """
         if container_name in self.containers:
-            request.responseHeaders.setRawHeaders("content-type",
-                                                  ["application/json"])
-            request.responseHeaders.setRawHeaders("x-container-object-count",
-                                                  ["0"])
-            request.responseHeaders.setRawHeaders("x-container-bytes-used",
-                                                  ["0"])
+            request.responseHeaders.setRawHeaders(b"content-type",
+                                                  [b"application/json"])
+            request.responseHeaders.setRawHeaders(b"x-container-object-count",
+                                                  [b"0"])
+            request.responseHeaders.setRawHeaders(b"x-container-bytes-used",
+                                                  [b"0"])
             request.setResponseCode(OK)
             return dumps([
                 obj.as_json() for obj in

--- a/mimic/rest/valkyrie_api.py
+++ b/mimic/rest/valkyrie_api.py
@@ -3,6 +3,8 @@
 API Mock for Valkyrie.
 """
 
+from __future__ import unicode_literals
+
 from mimic.rest.mimicapp import MimicApp
 
 

--- a/mimic/session.py
+++ b/mimic/session.py
@@ -4,6 +4,8 @@
 Implementation of simple in-memory session storage and generation for Mimic.
 """
 
+from __future__ import unicode_literals
+
 from six import text_type
 from uuid import uuid4
 from datetime import datetime, timedelta

--- a/mimic/tap.py
+++ b/mimic/tap.py
@@ -1,6 +1,9 @@
 """
 Twisted Application plugin for Mimic
 """
+
+from __future__ import unicode_literals
+
 from twisted.application.strports import service
 from twisted.application.service import MultiService
 from twisted.python import usage

--- a/mimic/test/behavior_tests.py
+++ b/mimic/test/behavior_tests.py
@@ -5,6 +5,9 @@ Automatically generate tests for behavior registration/deletion APIs.
 Also contains helper functions for specific behavior testing.
 (:see: :func:`register_behavior`)
 """
+
+from __future__ import unicode_literals
+
 import json
 
 from uuid import UUID, uuid4
@@ -151,7 +154,7 @@ def make_behavior_tests(behavior_helper_factory):
             Given a behavior ID, attempts to delete it.
             """
             response, body = self.successResultOf(request_with_content(
-                self, self.bhelper.root, "DELETE",
+                self, self.bhelper.root, b"DELETE",
                 "{0}/{1}".format(self.bhelper.behavior_api_endpoint,
                                  behavior_id)))
             self.assertEqual(response.code, status)
@@ -172,9 +175,9 @@ def make_behavior_tests(behavior_helper_factory):
             """
             name, params = self.bhelper.names_and_params[0]
             almost_correct = json.dumps({'name': name, 'parameters': params})
-            for invalid in ('', '{}', almost_correct):
+            for invalid in (b'', b'{}', almost_correct):
                 response, body = self.successResultOf(request_with_content(
-                    self, self.bhelper.root, "POST",
+                    self, self.bhelper.root, b"POST",
                     self.bhelper.behavior_api_endpoint,
                     invalid))
                 self.assertEqual(response.code, 400)
@@ -241,7 +244,7 @@ def make_behavior_tests(behavior_helper_factory):
                 self.bhelper.validate_default_behavior(
                     *self.bhelper.trigger_event())
 
-    Tester.__name__ = "TestsFor{0}".format(behavior_helper_factory.name)
+    Tester.__name__ = b"TestsFor{0}".format(behavior_helper_factory.name)
     Tester.__module__ = behavior_helper_factory.module
     return Tester
 
@@ -389,7 +392,7 @@ def register_behavior(test_case, root, uri, behavior_name, parameters,
                      "parameters": parameters,
                      "criteria": criteria}
     response, body = test_case.successResultOf(json_request(
-        test_case, root, "POST", uri, json.dumps(behavior_json)))
+        test_case, root, b"POST", uri, json.dumps(behavior_json)))
 
     test_case.assertEqual(response.code, 201)
     behavior_id = body.get("id")

--- a/mimic/test/dummy.py
+++ b/mimic/test/dummy.py
@@ -2,6 +2,8 @@
 Dummy classes that can be shared across test cases
 """
 
+from __future__ import unicode_literals
+
 from zope.interface import implementer
 
 from twisted.plugin import IPlugin

--- a/mimic/test/fixtures.py
+++ b/mimic/test/fixtures.py
@@ -1,6 +1,9 @@
 """
 Define fixtures to provide common functionality for Mimic testing
 """
+
+from __future__ import unicode_literals
+
 from mimic.test.helpers import json_request
 from mimic.core import MimicCore
 from mimic.resource import MimicRoot
@@ -23,7 +26,7 @@ class TenantAuthentication(object):
         :param password: the password with which to use to authenticate
         """
         _, self.service_catalog_json = test_case.successResultOf(json_request(
-            test_case, root, "POST", "/identity/v2.0/tokens",
+            test_case, root, b"POST", "/identity/v2.0/tokens",
             {
                 "auth": {
                     "passwordCredentials": {

--- a/mimic/test/helpers.py
+++ b/mimic/test/helpers.py
@@ -2,7 +2,7 @@
 Helper objects for tests, mostly to allow testing HTTP routes.
 """
 
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 import json
 

--- a/mimic/test/test_auth.py
+++ b/mimic/test/test_auth.py
@@ -2,6 +2,9 @@
 Tests for mimic identity (:mod:`mimic.model.identity` and
 :mod:`mimic.rest.auth_api`)
 """
+
+from __future__ import unicode_literals
+
 import json
 
 from twisted.trial.unittest import SynchronousTestCase
@@ -279,7 +282,7 @@ def authenticate_with_username_password(test_case, root,
         creds["auth"]["tenantId"] = tenant_id
     if tenant_name is not None:
         creds["auth"]["tenantName"] = tenant_name
-    return test_case.successResultOf(request_func(test_case, root, "POST",
+    return test_case.successResultOf(request_func(test_case, root, b"POST",
                                                   uri, json.dumps(creds)))
 
 
@@ -303,7 +306,7 @@ def authenticate_with_api_key(test_case, root, uri='/identity/v2.0/tokens',
         creds["auth"]["tenantId"] = tenant_id
     if tenant_name is not None:
         creds["auth"]["tenantName"] = tenant_name
-    return test_case.successResultOf(json_request(test_case, root, "POST",
+    return test_case.successResultOf(json_request(test_case, root, b"POST",
                                                   uri, creds))
 
 
@@ -321,7 +324,7 @@ def authenticate_with_token(test_case, root, uri='/identity/v2.0/tokens',
             }
         }
     }
-    return test_case.successResultOf(json_request(test_case, root, "POST",
+    return test_case.successResultOf(json_request(test_case, root, b"POST",
                                                   uri, creds))
 
 
@@ -333,9 +336,9 @@ def impersonate_user(test_case, root,
     using token and tenant ids.
     """
     headers = {
-        'X-Auth-Token': [str(impersonator_token)]} if impersonator_token else None
+        b'X-Auth-Token': [str(impersonator_token)]} if impersonator_token else None
     return test_case.successResultOf(json_request(
-        test_case, root, "POST", uri,
+        test_case, root, b"POST", uri,
         {"RAX-AUTH:impersonation": {"expire-in-seconds": 30,
                                     "user": {"username": username or "test1"}}},
         headers=headers
@@ -402,7 +405,7 @@ class GetAuthTokenAPITests(SynchronousTestCase):
         core, root = core_and_root([])
 
         (response, json_body) = self.successResultOf(json_request(
-            self, root, "POST", "/identity/v2.0/tokens", ""))
+            self, root, b"POST", "/identity/v2.0/tokens", b""))
 
         self.assertEqual(400, response.code)
 
@@ -413,7 +416,7 @@ class GetAuthTokenAPITests(SynchronousTestCase):
         core, root = core_and_root([])
 
         response = self.successResultOf(request(
-            self, root, "POST", "/identity/v2.0/tokens", "{ bad request: }"))
+            self, root, b"POST", "/identity/v2.0/tokens", b"{ bad request: }"))
 
         self.assertEqual(400, response.code)
 
@@ -493,7 +496,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         token = '1234567890'
 
         request(
-            self, root, "GET",
+            self, root, b"GET",
             "/identity/v2.0/tokens/{0}/endpoints".format(token)
         )
 
@@ -508,7 +511,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         core, root = core_and_root([ExampleAPI()])
 
         (response, json_body) = self.successResultOf(json_request(
-            self, root, "GET",
+            self, root, b"GET",
             "http://mybase/identity/v2.0/tokens/1234567890/endpoints"
         ))
 
@@ -614,7 +617,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         """
         core, root = core_and_root([ExampleAPI()])
         (response, json_body) = self.successResultOf(json_request(
-            self, root, "GET",
+            self, root, b"GET",
             "/identity/v2.0/users/1/OS-KSADM/credentials/RAX-KSKEY:apiKeyCredentials"
         ))
         self.assertEqual(response.code, 404)
@@ -630,12 +633,12 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
             }
         }
         (response, json_body) = self.successResultOf(json_request(
-            self, root, "POST", "/identity/v2.0/tokens", creds))
+            self, root, b"POST", "/identity/v2.0/tokens", creds))
         self.assertEqual(response.code, 200)
         user_id = json_body['access']['user']['id']
         username = json_body['access']['user']['name']
         (response, json_body) = self.successResultOf(json_request(
-            self, root, "GET",
+            self, root, b"GET",
             "/identity/v2.0/users/" + user_id +
             "/OS-KSADM/credentials/RAX-KSKEY:apiKeyCredentials"
         ))
@@ -700,7 +703,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         core, root = core_and_root([ExampleAPI()])
 
         (response, json_body) = self.successResultOf(json_request(
-            self, root, "POST", "/identity/v2.0/tokens",
+            self, root, b"POST", "/identity/v2.0/tokens",
             {
                 "auth": {
                     "token": {
@@ -719,7 +722,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         core, root = core_and_root([ExampleAPI()])
 
         (response, json_body) = self.successResultOf(json_request(
-            self, root, "GET",
+            self, root, b"GET",
             "http://mybase/identity/v1.1/mosso/123456"
         ))
         self.assertEqual(301, response.code)
@@ -743,7 +746,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         core, root = core_and_root([ExampleAPI()])
 
         (response, json_body) = self.successResultOf(json_request(
-            self, root, "POST", "http://mybase/identity/v2.0/RAX-AUTH/impersonation-tokens",
+            self, root, b"POST", "http://mybase/identity/v2.0/RAX-AUTH/impersonation-tokens",
             {"RAX-AUTH:impersonation": {"user": {"username": "user-test"}}}))
         self.assertEqual(200, response.code)
         self.assertTrue(json_body['access']['token']['id'])
@@ -755,7 +758,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         core, root = core_and_root([])
 
         (response, json_body) = self.successResultOf(json_request(
-            self, root, "POST", "http://mybase/identity/v2.0/RAX-AUTH/impersonation-tokens", ""))
+            self, root, b"POST", "http://mybase/identity/v2.0/RAX-AUTH/impersonation-tokens", b""))
 
         self.assertEqual(400, response.code)
 
@@ -766,8 +769,8 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         core, root = core_and_root([])
 
         response = self.successResultOf(request(
-            self, root, "POST", "http://mybase/identity/v2.0/RAX-AUTH/impersonation-tokens",
-                                "{ bad request: }"))
+            self, root, b"POST", "http://mybase/identity/v2.0/RAX-AUTH/impersonation-tokens",
+                                 b"{ bad request: }"))
 
         self.assertEqual(400, response.code)
 
@@ -778,7 +781,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         core, root = core_and_root([ExampleAPI()])
 
         (response, json_body) = self.successResultOf(json_request(
-            self, root, "GET",
+            self, root, b"GET",
             "http://mybase/identity/v2.0/tokens/123456a?belongsTo=111111"
         ))
         self.assertEqual(200, response.code)
@@ -795,7 +798,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         core, root = core_and_root([ExampleAPI()])
 
         (response, json_body) = self.successResultOf(json_request(
-            self, root, "GET",
+            self, root, b"GET",
             "http://mybase/identity/v2.0/tokens/123456a"
         ))
         self.assertEqual(200, response.code)
@@ -809,7 +812,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         core, root = core_and_root([ExampleAPI()])
 
         (response1, json_body1) = self.successResultOf(json_request(
-            self, root, "GET",
+            self, root, b"GET",
             "http://mybase/identity/v2.0/tokens/123456a?belongsTo=111111"
         ))
         self.assertEqual(200, response1.code)
@@ -855,7 +858,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
 
         # validate the impersonated_token
         (response3, json_body3) = self.successResultOf(json_request(
-            self, root, "GET",
+            self, root, b"GET",
             "http://mybase/identity/v2.0/tokens/{0}?belongsTo=12345".format(
                 impersonated_token)
         ))
@@ -911,7 +914,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
 
         # validate the impersonated_token1
         (response5, json_body5) = self.successResultOf(json_request(
-            self, root, "GET",
+            self, root, b"GET",
             "http://mybase/identity/v2.0/tokens/{0}?belongsTo=12345".format(
                 impersonated_token1)
         ))
@@ -922,7 +925,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
 
         # validate the impersonated_token2
         (response6, json_body6) = self.successResultOf(json_request(
-            self, root, "GET",
+            self, root, b"GET",
             "http://mybase/identity/v2.0/tokens/{0}?belongsTo=12345".format(
                 impersonated_token2)
         ))
@@ -939,7 +942,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         core, root = core_and_root([ExampleAPI()])
 
         (response, json_body) = self.successResultOf(json_request(
-            self, root, "GET",
+            self, root, b"GET",
             "http://mybase/identity/v2.0/tokens/this_is_an_impersonator_token"
         ))
         self.assertEqual(200, response.code)
@@ -954,7 +957,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         core, root = core_and_root([ExampleAPI()])
 
         (response, json_body) = self.successResultOf(json_request(
-            self, root, "GET",
+            self, root, b"GET",
             "http://mybase/identity/v2.0/tokens/this_is_a_racker_token"
         ))
         self.assertEqual(200, response.code)
@@ -970,7 +973,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         token = get_presets["identity"]["token_fail_to_auth"][0]
 
         (response, json_body) = self.successResultOf(json_request(
-            self, root, "GET",
+            self, root, b"GET",
             "http://mybase/identity/v2.0/tokens/{0}".format(token)
         ))
         self.assertEqual(401, response.code)
@@ -984,7 +987,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         token = get_presets["identity"]["observer_role"][0]
 
         (response, json_body) = self.successResultOf(json_request(
-            self, root, "GET",
+            self, root, b"GET",
             "http://mybase/identity/v2.0/tokens/any_token?belongsTo={0}".format(token)
         ))
         self.assertEqual(200, response.code)
@@ -1002,7 +1005,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         token = get_presets["identity"]["creator_role"][0]
 
         (response, json_body) = self.successResultOf(json_request(
-            self, root, "GET",
+            self, root, b"GET",
             "http://mybase/identity/v2.0/tokens/any_token?belongsTo={0}".format(token)
         ))
         self.assertEqual(200, response.code)
@@ -1020,7 +1023,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         token = get_presets["identity"]["admin_role"][0]
 
         (response, json_body) = self.successResultOf(json_request(
-            self, root, "GET",
+            self, root, b"GET",
             "http://mybase/identity/v2.0/tokens/any_token?belongsTo={0}".format(token)
         ))
         self.assertEqual(200, response.code)
@@ -1040,7 +1043,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         core, root = core_and_root([ExampleAPI()])
 
         (response, json_body) = self.successResultOf(json_request(
-            self, root, "GET",
+            self, root, b"GET",
             "http://mybase/identity/v2.0/users?name=random_user"
         ))
         self.assertEqual(200, response.code)
@@ -1058,7 +1061,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         user_id = json_body["access"]["user"]["id"]
 
         (response, json_body) = self.successResultOf(json_request(
-            self, root, "GET",
+            self, root, b"GET",
             "http://mybase/identity/v2.0/users?name={0}".format(username)
         ))
         self.assertEqual(200, response.code)
@@ -1094,7 +1097,7 @@ class AuthIntegrationTests(SynchronousTestCase):
 
         # get user for tenant
         response, json_body = self.successResultOf(json_request(
-            self, root, "GET", "/identity/v1.1/mosso/111111"))
+            self, root, b"GET", "/identity/v1.1/mosso/111111"))
         self.assertEqual(301, response.code)
         user = json_body['user']['id']
         self.assertEqual("my_user", user)
@@ -1106,7 +1109,7 @@ class AuthIntegrationTests(SynchronousTestCase):
 
         # get endpoints for this token, see what the tenant is
         response, json_body = self.successResultOf(json_request(
-            self, root, "GET",
+            self, root, b"GET",
             "/identity/v2.0/tokens/{0}/endpoints".format(token)))
         self.assertEqual(200, response.code)
         self.assertEqual(tenant_id,
@@ -1297,20 +1300,20 @@ class IdentityNondedicatedFixtureTests(SynchronousTestCase):
         url = "/identity/v2.0/tokens"
         core, root = core_and_root([])
         (response, content) = self.successResultOf(
-            json_request(self, root, "GET", url + "/OneTwo"))
+            json_request(self, root, b"GET", url + "/OneTwo"))
         self.assertEqual(200, response.code)
         self.assertEqual(content["access"]["token"]["tenant"]["id"], "135790")
 
         (response, content) = self.successResultOf(
-            json_request(self, root, "GET", url + "/ThreeFour"))
+            json_request(self, root, b"GET", url + "/ThreeFour"))
         self.assertEqual(200, response.code)
 
         (response, content) = self.successResultOf(
-            json_request(self, root, "GET", url + "/ThreeFourImpersonator"))
+            json_request(self, root, b"GET", url + "/ThreeFourImpersonator"))
         self.assertEqual(200, response.code)
 
         (response, content) = self.successResultOf(
-            json_request(self, root, "GET", url + "/ThreeFourRacker"))
+            json_request(self, root, b"GET", url + "/ThreeFourRacker"))
         self.assertEqual(200, response.code)
 
 
@@ -1323,43 +1326,43 @@ class IdentityDedicatedFixtureTests(SynchronousTestCase):
         url = "/identity/v2.0/tokens"
         core, root = core_and_root([])
         (response, content) = self.successResultOf(
-            json_request(self, root, "GET", url + "/HybridOneTwo"))
+            json_request(self, root, b"GET", url + "/HybridOneTwo"))
         self.assertEqual(200, response.code)
         self.assertEqual(content["access"]["token"]["tenant"]["id"], "hybrid:123456")
         self.assertEqual(content["access"]["user"]["RAX-AUTH:contactId"], "12")
 
         (response, content) = self.successResultOf(
-            json_request(self, root, "GET", url + "/HybridOneTwoRacker"))
+            json_request(self, root, b"GET", url + "/HybridOneTwoRacker"))
         self.assertEqual(200, response.code)
         self.assertEqual(content["access"]["token"]["tenant"]["id"], "hybrid:123456")
         self.assertEqual(content["access"]["user"]["RAX-AUTH:contactId"], "12")
 
         (response, content) = self.successResultOf(
-            json_request(self, root, "GET", url + "/HybridThreeFour"))
+            json_request(self, root, b"GET", url + "/HybridThreeFour"))
         self.assertEqual(200, response.code)
         self.assertEqual(content["access"]["token"]["tenant"]["id"], "hybrid:123456")
         self.assertEqual(content["access"]["user"]["RAX-AUTH:contactId"], "34")
 
         (response, content) = self.successResultOf(
-            json_request(self, root, "GET", url + "/HybridThreeFourImpersonator"))
+            json_request(self, root, b"GET", url + "/HybridThreeFourImpersonator"))
         self.assertEqual(200, response.code)
         self.assertEqual(content["access"]["token"]["tenant"]["id"], "hybrid:123456")
         self.assertEqual(content["access"]["user"]["RAX-AUTH:contactId"], "34")
 
         (response, content) = self.successResultOf(
-            json_request(self, root, "GET", url + "/HybridFiveSix"))
+            json_request(self, root, b"GET", url + "/HybridFiveSix"))
         self.assertEqual(200, response.code)
         self.assertEqual(content["access"]["token"]["tenant"]["id"], "hybrid:123456")
         self.assertEqual(content["access"]["user"]["RAX-AUTH:contactId"], "56")
 
         (response, content) = self.successResultOf(
-            json_request(self, root, "GET", url + "/HybridSevenEight"))
+            json_request(self, root, b"GET", url + "/HybridSevenEight"))
         self.assertEqual(200, response.code)
         self.assertEqual(content["access"]["token"]["tenant"]["id"], "hybrid:123456")
         self.assertEqual(content["access"]["user"]["RAX-AUTH:contactId"], "78")
 
         (response, content) = self.successResultOf(
-            json_request(self, root, "GET", url + "/HybridNineZero"))
+            json_request(self, root, b"GET", url + "/HybridNineZero"))
         self.assertEqual(200, response.code)
         self.assertEqual(content["access"]["token"]["tenant"]["id"], "hybrid:654321")
         self.assertEqual(content["access"]["user"]["RAX-AUTH:contactId"], "90")

--- a/mimic/test/test_cloudfeeds_int.py
+++ b/mimic/test/test_cloudfeeds_int.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from mimic.rest.cloudfeeds import (CloudFeedsApi, CloudFeedsControlApi)
 from mimic.test.fixtures import APIMockHelper
 from mimic.test.helpers import request
@@ -23,7 +25,7 @@ class TestCloudFeedsAPI(SynchronousTestCase):
         This is because the boilerplate is written but no endpoints.
         """
         r = request(
-            self, self.root, "GET", self.uri,
+            self, self.root, b"GET", self.uri,
         )
         resp = self.successResultOf(r)
         self.assertEquals(resp.code, 404)
@@ -35,7 +37,7 @@ class TestCloudFeedsAPI(SynchronousTestCase):
         endpoints.
         """
         r = request(
-            self, self.root, "GET", self.ctrl_uri,
+            self, self.root, b"GET", self.ctrl_uri,
         )
         resp = self.successResultOf(r)
         self.assertEquals(resp.code, 404)

--- a/mimic/test/test_cloudfeeds_unit.py
+++ b/mimic/test/test_cloudfeeds_unit.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from mimic.model import cloudfeeds
 from twisted.trial.unittest import SynchronousTestCase
 from testtools.matchers import (MatchesSetwise, MatchesDict, Equals)

--- a/mimic/test/test_customer.py
+++ b/mimic/test/test_customer.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import json
 
 from twisted.trial.unittest import SynchronousTestCase
@@ -32,7 +34,7 @@ class CustomerAPITests(SynchronousTestCase):
         Returns the contacts list
         """
         (response, content) = self.successResultOf(json_request(
-            self, root, "GET",
+            self, root, b"GET",
             "/v1/customer_accounts/CLOUD/{0}/contacts".format(tenant)))
         self.assertEqual(200, response.code)
         return content
@@ -77,7 +79,7 @@ class CustomerAPITests(SynchronousTestCase):
         expected_contacts = [{"email": "test@email.com", "role": "PRIMARY"},
                              {"email": "new@email.com", "role": "TECHNICAL"}]
         response = self.successResultOf(request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             "/v1/customer_accounts/CLOUD/555555/contacts",
             json.dumps(expected_contacts)))
         self.assertEqual(200, response.code)
@@ -94,7 +96,7 @@ class CustomerAPITests(SynchronousTestCase):
         expected_contacts = [{"email": "test1@email.com", "role": "PRIMARY"},
                              {"email": "new1@email.com", "role": "TECHNICAL"}]
         response = self.successResultOf(request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             "/v1/customer_accounts/CLOUD/555555/contacts",
             json.dumps(expected_contacts)))
         self.assertEqual(200, response.code)
@@ -108,7 +110,7 @@ class CustomerAPITests(SynchronousTestCase):
         """
         expected_contacts = []
         response = self.successResultOf(request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             "/v1/customer_accounts/CLOUD/77777/contacts",
             json.dumps(expected_contacts)))
         self.assertEqual(200, response.code)

--- a/mimic/test/test_fastly.py
+++ b/mimic/test/test_fastly.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from twisted.trial.unittest import SynchronousTestCase
 from twisted.internet.task import Clock
 
@@ -27,7 +29,7 @@ class FastlyAPITests(SynchronousTestCase):
         self.service_name = 'yumyum'
 
         (self.response, self.service_json) = self.successResultOf(json_request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             self.uri + '/service?customer_id={0}&name={1}'.format(
                 self.customer_id, self.service_name)))
 
@@ -40,7 +42,7 @@ class FastlyAPITests(SynchronousTestCase):
         JSON-serialized customer details.
         """
         (response, customer_json) = self.successResultOf(json_request(
-            self, self.root, "GET", self.uri + '/current_customer'))
+            self, self.root, b"GET", self.uri + '/current_customer'))
         customer_details = self.fastly_response.get_current_customer()
 
         self.assertEqual(200, response.code)
@@ -59,12 +61,12 @@ class FastlyAPITests(SynchronousTestCase):
         self.assertEqual(sorted(self.service_json), sorted(service_details))
 
         (response, json_by_service_name) = self.successResultOf(json_request(
-            self, self.root, "GET",
+            self, self.root, b"GET",
             self.uri + '/service/search?name={0}'.format(self.service_name)))
         self.assertEqual(200, self.response.code)
 
         (response, json_by_service_id) = self.successResultOf(json_request(
-            self, self.root, "GET",
+            self, self.root, b"GET",
             self.uri + '/service/{0}/details'.format(self.service_id)))
         self.assertEqual(200, self.response.code)
         self.assertEqual(sorted(json_by_service_name['service_details']),
@@ -77,7 +79,7 @@ class FastlyAPITests(SynchronousTestCase):
         version.
         """
         (response, version_json) = self.successResultOf(json_request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             self.uri + '/service/<{0}/version'.format(self.service_id)))
 
         version_details = self.fastly_response.create_version(
@@ -92,7 +94,7 @@ class FastlyAPITests(SynchronousTestCase):
         and returns JSON-serialized service details.
         """
         (response, json_body) = self.successResultOf(json_request(
-            self, self.root, "GET",
+            self, self.root, b"GET",
             self.uri + '/service/search?name={0}'.format(self.service_name)))
         service_details = self.fastly_response.get_service_by_name(
             service_name=self.service_name)
@@ -111,7 +113,7 @@ class FastlyAPITests(SynchronousTestCase):
                 self.service_id, self.version_id)
 
         (response, json_body) = self.successResultOf(json_request(
-            self, self.root, "POST", uri))
+            self, self.root, b"POST", uri))
         domain_details = self.fastly_response.create_domain(
             url_data=[('comment', ['comment']),
                       ('name', [self.service_name])],
@@ -132,14 +134,14 @@ class FastlyAPITests(SynchronousTestCase):
                 self.service_id, self.version_id)
 
         (response, json_body) = self.successResultOf(json_request(
-            self, self.root, "POST", uri))
+            self, self.root, b"POST", uri))
 
         uri = self.uri + '/service/{0}/version/{1}/domain/check_all' \
             '?name=llamallama&comment=redpajama'.format(
                 self.service_id, self.version_id)
 
         (response, json_body) = self.successResultOf(json_request(
-            self, self.root, "GET", uri))
+            self, self.root, b"GET", uri))
         domain_details = self.fastly_response.check_domains(
             service_id=self.service_id,
             service_version=self.version_id)
@@ -158,7 +160,7 @@ class FastlyAPITests(SynchronousTestCase):
                 self.service_id, self.version_id)
 
         (response, json_body) = self.successResultOf(json_request(
-            self, self.root, "POST", uri))
+            self, self.root, b"POST", uri))
 
         url_data = [('name', ['winniepoo']), ('address', ['honeytree']),
                     ('use_ssl', [False]), ('port', [80])]
@@ -181,7 +183,7 @@ class FastlyAPITests(SynchronousTestCase):
                 self.service_id, self.version_id)
 
         (response, json_body) = self.successResultOf(json_request(
-            self, self.root, "POST", uri))
+            self, self.root, b"POST", uri))
 
         url_data = [
             ('name', ['testcondition']),
@@ -207,7 +209,7 @@ class FastlyAPITests(SynchronousTestCase):
                 self.service_id, self.version_id)
 
         (response, json_body) = self.successResultOf(json_request(
-            self, self.root, "POST", uri))
+            self, self.root, b"POST", uri))
 
         url_data = [
             ('name', ['testcache']),
@@ -234,7 +236,7 @@ class FastlyAPITests(SynchronousTestCase):
                 self.service_id, self.version_id)
 
         (response, json_body) = self.successResultOf(json_request(
-            self, self.root, "POST", uri))
+            self, self.root, b"POST", uri))
 
         url_data = [
             ('status', ['200']),
@@ -266,7 +268,7 @@ class FastlyAPITests(SynchronousTestCase):
                 self.service_id, self.version_id)
 
         (response, json_body) = self.successResultOf(json_request(
-            self, self.root, "PUT", uri))
+            self, self.root, b"PUT", uri))
 
         url_data = [
             ('general.default_ttl', ['4242']),
@@ -287,7 +289,7 @@ class FastlyAPITests(SynchronousTestCase):
         response.
         """
         (response, version_json) = self.successResultOf(json_request(
-            self, self.root, "GET",
+            self, self.root, b"GET",
             self.uri + '/service/{0}/version'.format(self.service_id)))
 
         version_details = self.fastly_response.list_versions(
@@ -302,7 +304,7 @@ class FastlyAPITests(SynchronousTestCase):
         a JSON-serialized response.
         """
         (response, version_json) = self.successResultOf(json_request(
-            self, self.root, "PUT",
+            self, self.root, b"PUT",
             self.uri + '/service/{0}/version/{1}/activate'.format
                        (self.service_id, self.version_id)))
 
@@ -318,7 +320,7 @@ class FastlyAPITests(SynchronousTestCase):
         and returns a JSON-serialized response.
         """
         (response, version_json) = self.successResultOf(json_request(
-            self, self.root, "PUT",
+            self, self.root, b"PUT",
             self.uri + '/service/{0}/version/{1}/deactivate'.format
                        (self.service_id, self.version_id)))
 
@@ -334,7 +336,7 @@ class FastlyAPITests(SynchronousTestCase):
         response.
         """
         (response, service_json) = self.successResultOf(json_request(
-            self, self.root, "GET",
+            self, self.root, b"GET",
             self.uri + '/service/{0}/details'.format(self.service_id)))
 
         service_details = self.fastly_response.get_service_details(
@@ -348,7 +350,7 @@ class FastlyAPITests(SynchronousTestCase):
         specified service and returns a JSON-serialized response.
         """
         (response, delete_json) = self.successResultOf(json_request(
-            self, self.root, "DELETE",
+            self, self.root, b"DELETE",
             self.uri + '/service/{0}'.format(self.service_id)))
 
         self.assertEqual(200, response.code)
@@ -360,7 +362,7 @@ class FastlyAPITests(SynchronousTestCase):
         and returns a JSON-serialized response.
         """
         (response, delete_json) = self.successResultOf(json_request(
-            self, self.root, "GET", self.uri))
+            self, self.root, b"GET", self.uri))
 
         self.assertEqual(200, response.code)
         self.assertEqual(delete_json, {'status': 'ok'})

--- a/mimic/test/test_flavors.py
+++ b/mimic/test/test_flavors.py
@@ -2,6 +2,8 @@
 Tests for :mod:`nova_api` and :mod:`nova_objects` for flavors.
 """
 
+from __future__ import unicode_literals
+
 from twisted.trial.unittest import SynchronousTestCase
 
 from mimic.test.helpers import json_request, request
@@ -29,7 +31,7 @@ class NovaAPIFlavorsTests(SynchronousTestCase):
         Get flavors, assert response code is 200 and return response body.
         """
         (response, content) = self.successResultOf(json_request(
-            self, self.root, "GET", self.uri + postfix))
+            self, self.root, b"GET", self.uri + postfix))
         self.assertEqual(200, response.code)
         return content
 
@@ -45,7 +47,7 @@ class NovaAPIFlavorsTests(SynchronousTestCase):
         Test to verify :func:`get_flavor` when invalid flavor from the
         :obj: `mimic_presets` is provided.
         """
-        get_server_flavor = request(self, self.root, "GET", self.uri +
+        get_server_flavor = request(self, self.root, b"GET", self.uri +
                                     '/flavors/negative-test-1')
         get_server_flavor_response = self.successResultOf(get_server_flavor)
         self.assertEqual(get_server_flavor_response.code, 404)

--- a/mimic/test/test_glance.py
+++ b/mimic/test/test_glance.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import treq
 import json
 
@@ -36,7 +38,7 @@ class GlanceAPITests(SynchronousTestCase):
         """
         List the images returned from glance
         """
-        req = request(self, self.root, "GET", self.uri + '/images', '')
+        req = request(self, self.root, b"GET", self.uri + '/images', b'')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -64,7 +66,7 @@ class GlanceAdminAPITests(SynchronousTestCase):
         """
         request_json = request_json or self.create_request
         (response, content) = self.successResultOf(json_request(
-            self, self.root, "POST", self.uri,
+            self, self.root, b"POST", self.uri,
             body=request_json))
         self.assertEqual(response.code, 201)
         return content
@@ -74,7 +76,7 @@ class GlanceAdminAPITests(SynchronousTestCase):
         List images and return response
         """
         (response, content) = self.successResultOf(json_request(
-            self, self.root, "GET", self.uri))
+            self, self.root, b"GET", self.uri))
         self.assertEqual(200, response.code)
         for each in content['images']:
             self.assertEqual(each["status"], "active")
@@ -86,7 +88,7 @@ class GlanceAdminAPITests(SynchronousTestCase):
         """
         uri = "/glance/v2/schemas/image"
         (response, content) = self.successResultOf(json_request(
-            self, self.root, "GET", uri))
+            self, self.root, b"GET", uri))
         self.assertEqual(200, response.code)
         self.assertEqual(sorted(image_schema.keys()),
                          sorted(content))
@@ -123,7 +125,7 @@ class GlanceAdminAPITests(SynchronousTestCase):
         request_jsons = [{}, {"name": None}, {"hello": "world"}]
         for each in request_jsons:
             (response, content) = self.successResultOf(json_request(
-                self, self.root, "POST", self.uri,
+                self, self.root, b"POST", self.uri,
                 body=json.dumps(each)))
             self.assertEqual(response.code, 400)
 
@@ -134,7 +136,7 @@ class GlanceAdminAPITests(SynchronousTestCase):
         new_image = self.create_image()
 
         (response, content) = self.successResultOf(json_request(
-            self, self.root, "GET", self.uri + '/' + new_image['id']))
+            self, self.root, b"GET", self.uri + '/' + new_image['id']))
         self.assertEqual(200, response.code)
         self.assertEqual(new_image, content)
 
@@ -143,7 +145,7 @@ class GlanceAdminAPITests(SynchronousTestCase):
         Return 404 when trying to GET a non existant image.
         """
         response = self.successResultOf(request(
-            self, self.root, "GET", self.uri + '/' + '1111'))
+            self, self.root, b"GET", self.uri + '/' + '1111'))
         self.assertEqual(404, response.code)
 
     def test_delete_non_existant_image(self):
@@ -151,7 +153,7 @@ class GlanceAdminAPITests(SynchronousTestCase):
         Return 404 when trying to DELETE a non existant image.
         """
         response = self.successResultOf(request(
-            self, self.root, "DELETE", self.uri + '/' + '1111'))
+            self, self.root, b"DELETE", self.uri + '/' + '1111'))
         self.assertEqual(404, response.code)
 
     def test_delete_image(self):
@@ -161,11 +163,11 @@ class GlanceAdminAPITests(SynchronousTestCase):
         new_image = self.create_image()
 
         response = self.successResultOf(request(
-            self, self.root, "DELETE", self.uri + '/' + new_image['id']))
+            self, self.root, b"DELETE", self.uri + '/' + new_image['id']))
         self.assertEqual(204, response.code)
 
         response = self.successResultOf(request(
-            self, self.root, "GET", self.uri + '/' + new_image['id']))
+            self, self.root, b"GET", self.uri + '/' + new_image['id']))
         self.assertEqual(404, response.code)
 
     def test_get_then_delete_image(self):
@@ -176,11 +178,11 @@ class GlanceAdminAPITests(SynchronousTestCase):
 
         for each in images[:2]:
             response = self.successResultOf(request(
-                self, self.root, "DELETE", self.uri + '/' + each['id']))
+                self, self.root, b"DELETE", self.uri + '/' + each['id']))
             self.assertEqual(204, response.code)
 
             response = self.successResultOf(request(
-                self, self.root, "GET", self.uri + '/' + each['id']))
+                self, self.root, b"GET", self.uri + '/' + each['id']))
             self.assertEqual(404, response.code)
 
         images_after_delete = self.list_images()['images']

--- a/mimic/test/test_identity.py
+++ b/mimic/test/test_identity.py
@@ -1,6 +1,9 @@
 """
 Tests for identity model objects.
 """
+
+from __future__ import unicode_literals
+
 from twisted.internet.task import Clock
 from twisted.trial.unittest import SynchronousTestCase
 

--- a/mimic/test/test_ironic.py
+++ b/mimic/test/test_ironic.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import json
 from uuid import uuid4
 
@@ -66,7 +68,7 @@ class IronicAPITests(SynchronousTestCase):
         """
         request = create_request or self.create_request
         (response, content) = self.successResultOf(json_request(
-            self, self.root, "POST", self.url, body=json.dumps(request)))
+            self, self.root, b"POST", self.url, body=json.dumps(request)))
         self.assertEqual(response.code, 201)
         return content
 
@@ -78,7 +80,7 @@ class IronicAPITests(SynchronousTestCase):
         if postfix:
             url = self.url + postfix
         (response, content) = self.successResultOf(json_request(
-            self, self.root, "GET", url))
+            self, self.root, b"GET", url))
         self.assertEqual(200, response.code)
         return content
 
@@ -96,7 +98,7 @@ class IronicAPITests(SynchronousTestCase):
         as expected.
         """
         response = self.successResultOf(request(
-            self, self.root, "POST", self.url, body=json.dumps("")))
+            self, self.root, b"POST", self.url, body=json.dumps("")))
         self.assertEqual(response.code, 400)
 
     def test_delete_node_when_node_does_not_exist(self):
@@ -105,7 +107,7 @@ class IronicAPITests(SynchronousTestCase):
         does not exist.
         """
         response = self.successResultOf(request(
-            self, self.root, "DELETE", self.url + "/1234"))
+            self, self.root, b"DELETE", self.url + "/1234"))
         self.assertEqual(response.code, 404)
 
     def test_delete_node(self):
@@ -117,12 +119,12 @@ class IronicAPITests(SynchronousTestCase):
 
         # delete node
         response = self.successResultOf(request(
-            self, self.root, "DELETE", self.url + '/' + node_id))
+            self, self.root, b"DELETE", self.url + '/' + node_id))
         self.assertEqual(response.code, 204)
 
         # get node
         response = self.successResultOf(request(
-            self, self.root, "GET", self.url + '/' + node_id))
+            self, self.root, b"GET", self.url + '/' + node_id))
         self.assertEqual(404, response.code)
 
     def test_create_then_get_node(self):
@@ -137,7 +139,7 @@ class IronicAPITests(SynchronousTestCase):
 
         # get node
         (response, get_content) = self.successResultOf(json_request(
-            self, self.root, "GET", self.url + '/' + node_id))
+            self, self.root, b"GET", self.url + '/' + node_id))
         self.assertEqual(200, response.code)
         self.assertEqual(content, get_content)
 
@@ -150,7 +152,7 @@ class IronicAPITests(SynchronousTestCase):
 
         # get node
         (response, get_content) = self.successResultOf(json_request(
-            self, self.root, "GET", self.url + '/' + node_id))
+            self, self.root, b"GET", self.url + '/' + node_id))
         self.assertEqual(200, response.code)
         self.assertEqual(content, get_content)
 
@@ -159,14 +161,14 @@ class IronicAPITests(SynchronousTestCase):
         Test create node then get the node and verify attributes
         """
         (response, content) = self.successResultOf(json_request(
-            self, self.root, "POST", self.url, body=json.dumps({})))
+            self, self.root, b"POST", self.url, body=json.dumps({})))
         self.assertEqual(response.code, 201)
         node_id = str(content['uuid'])
         self.assertFalse(content['properties']['memory_mb'])
 
         # get node
         (response, get_content) = self.successResultOf(json_request(
-            self, self.root, "GET", self.url + '/' + node_id))
+            self, self.root, b"GET", self.url + '/' + node_id))
         self.assertEqual(200, response.code)
         self.assertEqual(content, get_content)
 
@@ -263,7 +265,7 @@ class IronicAPITests(SynchronousTestCase):
         # Change the provision_state
         url = self.url + "/{0}/states/provision".format(node_id)
         response = self.successResultOf(request(
-            self, self.root, "PUT", url, body=json.dumps(
+            self, self.root, b"PUT", url, body=json.dumps(
                 {'target': new_provision_state})))
         self.assertEqual(response.code, 202)
 
@@ -308,7 +310,7 @@ class IronicAPITests(SynchronousTestCase):
         """
         url = self.url + "/111/states/provision"
         (response, content) = self.successResultOf(json_request(
-            self, self.root, "PUT", url, body=json.dumps({'target': 'active'})))
+            self, self.root, b"PUT", url, body=json.dumps({'target': 'active'})))
         self.assertEqual(response.code, 404)
         self.assertTrue('111' in content['error_message']['faultstring'])
 
@@ -319,7 +321,7 @@ class IronicAPITests(SynchronousTestCase):
         """
         url = self.url + "/222/vendor_passthru/cache_image"
         (response, content) = self.successResultOf(json_request(
-            self, self.root, "POST", url, body=json.dumps({})))
+            self, self.root, b"POST", url, body=json.dumps({})))
         self.assertEqual(response.code, 404)
         self.assertTrue('222' in content['error_message']['faultstring'])
 
@@ -333,7 +335,7 @@ class IronicAPITests(SynchronousTestCase):
 
         url = self.url + "/{0}/vendor_passthru/not_cache_image".format(node_id)
         response = self.successResultOf(request(
-            self, self.root, "POST", url, body=json.dumps({})))
+            self, self.root, b"POST", url, body=json.dumps({})))
         self.assertEqual(response.code, 400)
 
     def test_vendor_passthru_cache_image_fails_when_args_invalid(self):
@@ -349,7 +351,7 @@ class IronicAPITests(SynchronousTestCase):
         for each in body_list:
             url = "/ironic/v1/nodes/{0}/vendor_passthru/cache_image".format(node_id)
             response = self.successResultOf(request(
-                self, self.root, "POST", url, body=json.dumps(each)))
+                self, self.root, b"POST", url, body=json.dumps(each)))
             self.assertEqual(response.code, 400)
 
     def test_vendor_passthru_cache_image(self):
@@ -367,7 +369,7 @@ class IronicAPITests(SynchronousTestCase):
         body = {"image_info": {"id": image_id}}
         url = self.url + "/{0}/vendor_passthru/cache_image".format(node_id)
         response = self.successResultOf(request(
-            self, self.root, "POST", url, body=json.dumps(body)))
+            self, self.root, b"POST", url, body=json.dumps(body)))
         self.assertEqual(response.code, 202)
 
         # GET node and verify the cache attributes on `driver_info`
@@ -387,7 +389,7 @@ class IronicAPITests(SynchronousTestCase):
         body = {"image_info": {"id": image_id}}
         url = self.url + "/{0}/vendor_passthru/cache_image".format(node_id)
         response = self.successResultOf(request(
-            self, self.root, "POST", url, body=json.dumps(body)))
+            self, self.root, b"POST", url, body=json.dumps(body)))
         self.assertEqual(response.code, 202)
 
         # GET node and verify the cache attributes on `driver_info`

--- a/mimic/test/test_keypairs.py
+++ b/mimic/test/test_keypairs.py
@@ -2,6 +2,8 @@
 Tests for :mod:`nova_api` and :mod:`nova_objects`.
 """
 
+from __future__ import unicode_literals
+
 from twisted.trial.unittest import SynchronousTestCase
 
 from mimic.test.helpers import json_request, request
@@ -40,14 +42,14 @@ class KeyPairTests(SynchronousTestCase):
             }
 
         resp, body = self.successResultOf(json_request(
-            self, self.helper.root, "POST", self.helper.uri + '/os-keypairs',
+            self, self.helper.root, b"POST", self.helper.uri + '/os-keypairs',
             kp_body
         ))
         return resp, body
 
     def get_keypairs_list(self):
         resp, body = self.successResultOf(json_request(
-            self, self.helper.root, "GET", self.helper.uri + '/os-keypairs'
+            self, self.helper.root, b"GET", self.helper.uri + '/os-keypairs'
         ))
         return resp, body
 
@@ -67,7 +69,7 @@ class KeyPairTests(SynchronousTestCase):
         self.assertTrue(len(body['keypair']['user_id']) > 1)
 
     def test_error_create_keypair(self):
-        test_error_body = "{{a]"
+        test_error_body = b"{{a]"
         resp, body = self.create_keypair(test_error_body)
         self.assertEqual(resp.code, 400)
         self.assertSubstring("Malformed", str(body))
@@ -80,7 +82,7 @@ class KeyPairTests(SynchronousTestCase):
 
     def test_delete_keypair(self):
         resp = self.successResultOf(request(
-            self, self.helper.root, "DELETE", self.helper.uri +
+            self, self.helper.root, b"DELETE", self.helper.uri +
             '/os-keypairs/' + self.keypair_name
         ))
 
@@ -90,7 +92,7 @@ class KeyPairTests(SynchronousTestCase):
 
     def test_error_delete_keypair(self):
         resp = self.successResultOf(request(
-            self, self.helper.root, "DELETE", self.helper.uri +
+            self, self.helper.root, b"DELETE", self.helper.uri +
             '/os-keypairs/keydoesntexist'
         ))
 

--- a/mimic/test/test_loadbalancer.py
+++ b/mimic/test/test_loadbalancer.py
@@ -2,6 +2,8 @@
 Unit tests for the
 """
 
+from __future__ import unicode_literals
+
 import json
 import treq
 
@@ -138,7 +140,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
             lb_body['loadBalancer']['nodes'] = nodes
 
         resp, body = self.successResultOf(json_request(
-            self, api_helper.root, "POST", api_helper.uri + '/loadbalancers',
+            self, api_helper.root, b"POST", api_helper.uri + '/loadbalancers',
             lb_body
         ))
         return body['loadBalancer']['id']
@@ -169,9 +171,9 @@ class LoadbalancerAPITests(SynchronousTestCase):
         lb_id = self._create_loadbalancer('test_lb') + lb_id_offset
         status_key = status_key or '"status"'
         status_val = status_val or 'PENDING_DELETE'
-        payload = '{{{0}: "{1}"}}'.format(status_key, status_val)
+        payload = b'{{{0}: "{1}"}}'.format(status_key, status_val)
         set_attributes_req = request(
-            self, self.root, "PATCH", "{0}/loadbalancer/{1}/attributes".format(
+            self, self.root, b"PATCH", "{0}/loadbalancer/{1}/attributes".format(
                 ctl_uri, lb_id
             ),
             payload
@@ -193,7 +195,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
         r = self._patch_attributes_request()
         self.assertEqual(r.resp.code, 204)
 
-        get_lb = request(self, self.root, "GET", self.uri + '/loadbalancers/' + str(r.lb_id))
+        get_lb = request(self, self.root, b"GET", self.uri + '/loadbalancers/' + str(r.lb_id))
         get_lb_response = self.successResultOf(get_lb)
         get_lb_response_body = self.successResultOf(
             treq.json_content(get_lb_response)
@@ -250,7 +252,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
         """
         lb_name = 'mimic_lb'
         resp, body = self.successResultOf(json_request(
-            self, self.root, "POST", self.uri + '/loadbalancers',
+            self, self.root, b"POST", self.uri + '/loadbalancers',
             {
                 "loadBalancer": {
                     "name": lb_name,
@@ -268,7 +270,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
         """
         Test to verify :func:`add_load_balancer` on ``POST /v1.0/<tenant_id>/loadbalancers``
         """
-        create_lb = request(self, self.root, "POST", self.uri + '/loadbalancers', "")
+        create_lb = request(self, self.root, b"POST", self.uri + '/loadbalancers', b"")
         create_lb_response = self.successResultOf(create_lb)
         self.assertEqual(create_lb_response.code, 400)
 
@@ -276,7 +278,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
         """
         Test to verify :func:`add_load_balancer` on ``POST /v1.0/<tenant_id>/loadbalancers``
         """
-        create_lb = request(self, self.root, "POST", self.uri + '/loadbalancers', "{ bad request: }")
+        create_lb = request(self, self.root, b"POST", self.uri + '/loadbalancers', b"{ bad request: }")
         create_lb_response = self.successResultOf(create_lb)
         self.assertEqual(create_lb_response.code, 400)
 
@@ -287,7 +289,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
         """
         lb_name = 'mimic_lb'
         resp, body = self.successResultOf(json_request(
-            self, self.root, "POST", self.uri + '/loadbalancers',
+            self, self.root, b"POST", self.uri + '/loadbalancers',
             {
                 "loadBalancer": {
                     "name": lb_name,
@@ -315,7 +317,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
         """
         test1_id = self._create_loadbalancer('test1')
         test2_id = self._create_loadbalancer('test2')
-        list_lb = request(self, self.root, "GET", self.uri + '/loadbalancers')
+        list_lb = request(self, self.root, b"GET", self.uri + '/loadbalancers')
         list_lb_response = self.successResultOf(list_lb)
         list_lb_response_body = self.successResultOf(treq.json_content(list_lb_response))
         self.assertEqual(list_lb_response.code, 200)
@@ -337,7 +339,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
                               "port": 80, "condition": "ENABLED"}
                              for i in range(1, 4)])
         list_resp, list_body = self.successResultOf(json_request(
-            self, self.root, "GET", self.uri + '/loadbalancers'))
+            self, self.root, b"GET", self.uri + '/loadbalancers'))
         self.assertEqual(list_resp.code, 200)
         self.assertEqual(len(list_body['loadBalancers']), 2)
 
@@ -356,7 +358,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
         # These will fail if the servers weren't created
         test1_id = self._create_loadbalancer('test1')
         test2_id = self._create_loadbalancer('test2')
-        delete_lb = request(self, self.root, 'DELETE', self.uri + '/loadbalancers/' + str(test1_id))
+        delete_lb = request(self, self.root, b'DELETE', self.uri + '/loadbalancers/' + str(test1_id))
         del_lb_response = self.successResultOf(delete_lb)
         # This response code does not match the Rackspace documentation which specifies a 200 response
         # See comment: http://bit.ly/1AVHs3v
@@ -364,7 +366,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
         del_lb_response_body = self.successResultOf(treq.content(del_lb_response))
         self.assertEqual(del_lb_response_body, '')
         # List lb to make sure the correct lb is gone and the other remains
-        list_lb = request(self, self.root, "GET", self.uri + '/loadbalancers')
+        list_lb = request(self, self.root, b"GET", self.uri + '/loadbalancers')
         list_lb_response = self.successResultOf(list_lb)
         list_lb_response_body = self.successResultOf(treq.json_content(list_lb_response))
         self.assertTrue(len(list_lb_response_body['loadBalancers']), 1)
@@ -379,7 +381,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
         lb_id = self._create_loadbalancer(
             nodes=[{"address": "1.2.3.4", "port": 80, "condition": "ENABLED"}])
         resp, body = self.successResultOf(json_request(
-            self, self.root, "GET", self.uri + '/loadbalancers/' + str(lb_id)))
+            self, self.root, b"GET", self.uri + '/loadbalancers/' + str(lb_id)))
         self.assertEqual(resp.code, 200)
         self.assertEqual(body['loadBalancer']['id'], lb_id)
         self.assertNotIn('nodeCount', body['loadBalancer'])
@@ -393,7 +395,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
         """
         lb_id = self._create_loadbalancer()
         resp, body = self.successResultOf(json_request(
-            self, self.root, "GET", self.uri + '/loadbalancers/' + str(lb_id)))
+            self, self.root, b"GET", self.uri + '/loadbalancers/' + str(lb_id)))
         self.assertEqual(resp.code, 200)
         self.assertEqual(body['loadBalancer']['id'], lb_id)
         self.assertNotIn('nodeCount', body['loadBalancer'])
@@ -403,7 +405,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
         """
         Test to verify :func:`get_load_balancers` for a non existant load balancer id.
         """
-        get_lb = request(self, self.root, "GET", self.uri + '/loadbalancers/123')
+        get_lb = request(self, self.root, b"GET", self.uri + '/loadbalancers/123')
         get_lb_response = self.successResultOf(get_lb)
         self.assertEqual(get_lb_response.code, 404)
 
@@ -411,7 +413,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
         """
         Test to verify :func:`delete_load_balancers` for a non existant load balancer.
         """
-        delete_lb = request(self, self.root, 'DELETE', self.uri + '/loadbalancers/123')
+        delete_lb = request(self, self.root, b'DELETE', self.uri + '/loadbalancers/123')
         delete_lb_response = self.successResultOf(delete_lb)
         self.assertEqual(delete_lb_response.code, 404)
 
@@ -419,7 +421,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
         """
         Test to verify :func:`list_load_balancers` when no loadbalancers exist.
         """
-        list_lb = request(self, self.root, 'GET', self.uri + '/loadbalancers')
+        list_lb = request(self, self.root, b'GET', self.uri + '/loadbalancers')
         list_lb_response = self.successResultOf(list_lb)
         self.assertEqual(list_lb_response.code, 200)
         list_lb_response_body = self.successResultOf(treq.json_content(list_lb_response))
@@ -436,7 +438,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
 
         list_lb_response, list_lb_response_body = self.successResultOf(
             request_with_content(
-                self, self.root, "GET",
+                self, self.root, b"GET",
                 other_tenant.get_service_endpoint("cloudLoadBalancers")
                 + "/loadbalancers"))
 
@@ -456,7 +458,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
 
         list_lb_response, list_lb_response_body = self.successResultOf(
             request_with_content(
-                self, helper.root, "GET",
+                self, helper.root, b"GET",
                 helper.get_service_endpoint("cloudLoadBalancers", "DFW")
                 + "/loadbalancers"))
 
@@ -470,7 +472,7 @@ def _bulk_delete(test_case, root, uri, lb_id, node_ids):
     """Bulk delete multiple nodes."""
     query = '?' + '&'.join('id=' + str(node_id) for node_id in node_ids)
     endpoint = uri + '/loadbalancers/' + str(lb_id) + '/nodes' + query
-    d = request(test_case, root, "DELETE", endpoint)
+    d = request(test_case, root, b"DELETE", endpoint)
     response = test_case.successResultOf(d)
     body = test_case.successResultOf(treq.content(response))
     if body == '':
@@ -486,7 +488,7 @@ def _update_clb_node(test_case, helper, lb_id, node_id, update_data,
     Return the response for updating a CLB node.
     """
     return test_case.successResultOf(request_func(
-        test_case, helper.root, "PUT",
+        test_case, helper.root, b"PUT",
         "{0}/loadbalancers/{1}/nodes/{2}".format(
             helper.get_service_endpoint("cloudLoadBalancers"),
             lb_id, node_id),
@@ -508,7 +510,7 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
         self.root = self.helper.root
         self.uri = self.helper.uri
         create_lb = request(
-            self, self.root, "POST", self.uri + '/loadbalancers',
+            self, self.root, b"POST", self.uri + '/loadbalancers',
             json.dumps({
                 "loadBalancer": {
                     "name": "test_lb",
@@ -535,7 +537,7 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
         """
         responses = [
             request(
-                self, self.root, "POST", self.uri + '/loadbalancers/' +
+                self, self.root, b"POST", self.uri + '/loadbalancers/' +
                 str(self.create_lb_response_body["loadBalancer"]["id"]) + '/nodes',
                 json.dumps({"nodes": [{"address": address,
                                        "port": 80,
@@ -551,7 +553,7 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
     def _get_nodes(self, lb_id):
         """Get all the nodes in a LB."""
         list_nodes = request(
-            self, self.root, "GET", self.uri + '/loadbalancers/' +
+            self, self.root, b"GET", self.uri + '/loadbalancers/' +
             str(lb_id) + '/nodes')
         response = self.successResultOf(list_nodes)
         body = self.successResultOf(treq.json_content(response))
@@ -578,7 +580,7 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
         Test to verify :func: `add_node` creates multiple node successfully.
         """
         create_multiple_nodes = request(
-            self, self.root, "POST", self.uri + '/loadbalancers/' +
+            self, self.root, b"POST", self.uri + '/loadbalancers/' +
             str(self.lb_id) + '/nodes',
             json.dumps({"nodes": [{"address": "127.0.0.2",
                                    "port": 80,
@@ -600,7 +602,7 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
         Test to verify :func: `add_node` does not allow creation of duplicate nodes.
         """
         create_duplicate_nodes = request(
-            self, self.root, "POST", self.uri + '/loadbalancers/' +
+            self, self.root, b"POST", self.uri + '/loadbalancers/' +
             str(self.lb_id) + '/nodes',
             json.dumps({"nodes": [{"address": "127.0.0.1",
                                    "port": 80,
@@ -621,14 +623,14 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
 
         for port in range(101, 126):
             request(
-                self, self.root, "POST", self.uri + '/loadbalancers/' +
+                self, self.root, b"POST", self.uri + '/loadbalancers/' +
                 str(self.lb_id) + '/nodes',
                 json.dumps({"nodes": [{"address": "127.0.0.1",
                                        "port": port,
                                        "condition": "ENABLED"}]})
             )
         create_over_node = request(
-            self, self.root, "POST", self.uri + '/loadbalancers/' +
+            self, self.root, b"POST", self.uri + '/loadbalancers/' +
             str(self.lb_id) + '/nodes',
             json.dumps({"nodes": [{"address": "127.0.0.2",
                                    "port": 130,
@@ -657,7 +659,7 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
                                   "type": "SECONDARY"})
 
         create_over_node = request(
-            self, self.root, "POST", self.uri + '/loadbalancers/' +
+            self, self.root, b"POST", self.uri + '/loadbalancers/' +
             str(self.lb_id) + '/nodes',
             json.dumps({"nodes": add_node_list})
         )
@@ -669,8 +671,8 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
         Test to verify :func: `add_node` does not fail on bad request.
         """
         create_duplicate_nodes = request(
-            self, self.root, "POST", self.uri + '/loadbalancers/' +
-            str(self.lb_id) + '/nodes', "")
+            self, self.root, b"POST", self.uri + '/loadbalancers/' +
+            str(self.lb_id) + '/nodes', b"")
 
         create_node_response = self.successResultOf(create_duplicate_nodes)
         self.assertEqual(create_node_response.code, 400)
@@ -680,8 +682,8 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
         Test to verify :func: `add_node` does not fail on bad request.
         """
         create_duplicate_nodes = request(
-            self, self.root, "POST", self.uri + '/loadbalancers/' +
-            str(self.lb_id) + '/nodes', "{ bad request: }")
+            self, self.root, b"POST", self.uri + '/loadbalancers/' +
+            str(self.lb_id) + '/nodes', b"{ bad request: }")
 
         create_node_response = self.successResultOf(create_duplicate_nodes)
         self.assertEqual(create_node_response.code, 400)
@@ -692,7 +694,7 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
         on non existant load balancers.
         """
         create_duplicate_nodes = request(
-            self, self.root, "POST", self.uri + '/loadbalancers/123/nodes',
+            self, self.root, b"POST", self.uri + '/loadbalancers/123/nodes',
             json.dumps({"nodes": [{"address": "127.0.0.1",
                                    "port": 80,
                                    "condition": "ENABLED",
@@ -706,7 +708,7 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
         Test to verify :func: `list_node` lists the nodes on the loadbalancer.
         """
         list_nodes = request(
-            self, self.root, "GET", self.uri + '/loadbalancers/' +
+            self, self.root, b"GET", self.uri + '/loadbalancers/' +
             str(self.lb_id) + '/nodes')
         list_nodes_response = self.successResultOf(list_nodes)
         list_nodes_response_body = self.successResultOf(treq.json_content(
@@ -719,7 +721,7 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
         Test to verify :func: `list_node` lists the nodes on the loadbalancer.
         """
         list_nodes = request(
-            self, self.root, "GET", self.uri + '/loadbalancers/123/nodes')
+            self, self.root, b"GET", self.uri + '/loadbalancers/123/nodes')
         list_nodes_response = self.successResultOf(list_nodes)
         self.assertEqual(list_nodes_response.code, 404)
 
@@ -728,7 +730,7 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
         Test to verify :func: `get_node` gets the nodes on the loadbalancer.
         """
         get_nodes = request(
-            self, self.root, "GET", self.uri + '/loadbalancers/' +
+            self, self.root, b"GET", self.uri + '/loadbalancers/' +
             str(self.lb_id) + '/nodes/'
             + str(self.node[0]["id"]))
         get_node_response = self.successResultOf(get_nodes)
@@ -745,7 +747,7 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
         non existant loadbalancer.
         """
         get_nodes = request(
-            self, self.root, "GET", self.uri + '/loadbalancers/123' +
+            self, self.root, b"GET", self.uri + '/loadbalancers/123' +
             '/nodes/' + str(self.node[0]["id"]))
         get_node_response = self.successResultOf(get_nodes)
         self.assertEqual(get_node_response.code, 404)
@@ -755,7 +757,7 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
         Test to verify :func: `get_node` does not get a non existant node.
         """
         get_nodes = request(
-            self, self.root, "GET", self.uri + '/loadbalancers/' +
+            self, self.root, b"GET", self.uri + '/loadbalancers/' +
             str(self.lb_id) + '/nodes/123')
         get_node_response = self.successResultOf(get_nodes)
         self.assertEqual(get_node_response.code, 404)
@@ -765,7 +767,7 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
         Test to verify :func: `delete_node` deletes the node on the loadbalancer.
         """
         delete_nodes = request(
-            self, self.root, "DELETE", self.uri + '/loadbalancers/' +
+            self, self.root, b"DELETE", self.uri + '/loadbalancers/' +
             str(self.lb_id) + '/nodes/'
             + str(self.node[0]["id"]))
         delete_node_response = self.successResultOf(delete_nodes)
@@ -773,7 +775,7 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
 
         # assert that it lists correctly after
         list_nodes_resp, list_nodes_body = self.successResultOf(json_request(
-            self, self.root, "GET", self.uri + '/loadbalancers/' +
+            self, self.root, b"GET", self.uri + '/loadbalancers/' +
             str(self.lb_id) + '/nodes'))
         self.assertEqual(list_nodes_resp.code, 200)
         self.assertEqual(len(list_nodes_body["nodes"]), 0)
@@ -784,7 +786,7 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
         non existant loadbalancer.
         """
         delete_nodes = request(
-            self, self.root, "DELETE", self.uri + '/loadbalancers/123' +
+            self, self.root, b"DELETE", self.uri + '/loadbalancers/123' +
             '/nodes/' + str(self.node[0]["id"]))
         delete_node_response = self.successResultOf(delete_nodes)
         self.assertEqual(delete_node_response.code, 404)
@@ -794,7 +796,7 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
         Test to verify :func: `delete_node` does not delete a non existant node.
         """
         delete_nodes = request(
-            self, self.root, "DELETE", self.uri + '/loadbalancers/' +
+            self, self.root, b"DELETE", self.uri + '/loadbalancers/' +
             str(self.lb_id) + '/nodes/123')
         delete_node_response = self.successResultOf(delete_nodes)
         self.assertEqual(delete_node_response.code, 404)
@@ -912,7 +914,7 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
             {"node": 1},
             {"nodes": {"weight": 1}},
             [],
-            "not JSON",
+            b"not JSON",
             {"node": {"weight": "not a number", "address": "1.1.1.1"}},
             {"node": {"condition": "INVALID", "id": 1}},
             {"node": {"type": "INVALID", "weight": 1000}},
@@ -1027,7 +1029,7 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
 
         # check if feed is updated
         d = request(
-            self, self.root, "GET",
+            self, self.root, b"GET",
             "{0}/loadbalancers/{1}/nodes/{2}.atom".format(self.uri, self.lb_id,
                                                           self.node[0]["id"]))
         feed_response = self.successResultOf(d)
@@ -1045,7 +1047,7 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
         XML
         """
         d = request(
-            self, self.root, "GET",
+            self, self.root, b"GET",
             "{0}/loadbalancers/{1}/nodes/{2}.atom".format(self.uri, self.lb_id, 0))
         feed_response = self.successResultOf(d)
         self.assertEqual(feed_response.code, 404)
@@ -1061,7 +1063,7 @@ class LoadbalancerNodeAPITests(SynchronousTestCase):
         "load balancer not found" XML
         """
         d = request(
-            self, self.root, "GET",
+            self, self.root, b"GET",
             "{0}/loadbalancers/{1}/nodes/{2}.atom".format(self.uri, 0, 0))
         feed_response = self.successResultOf(d)
         self.assertEqual(feed_response.code, 404)
@@ -1091,7 +1093,7 @@ class LoadbalancerAPINegativeTests(SynchronousTestCase):
         Helper method to create a load balancer with the given metadata
         """
         create_lb = request(
-            self, self.root, "POST", self.uri + '/loadbalancers',
+            self, self.root, b"POST", self.uri + '/loadbalancers',
             json.dumps({
                 "loadBalancer": {
                     "name": "test_lb",
@@ -1109,7 +1111,7 @@ class LoadbalancerAPINegativeTests(SynchronousTestCase):
         Adds a node to the load balancer and returns the response object
         """
         create_node = request(
-            self, self.root, "POST", self.uri + '/loadbalancers/'
+            self, self.root, b"POST", self.uri + '/loadbalancers/'
             + str(lb_id) + '/nodes',
             json.dumps({"nodes": [{"address": "127.0.0.1",
                                    "port": 80,
@@ -1124,7 +1126,7 @@ class LoadbalancerAPINegativeTests(SynchronousTestCase):
         Makes the `GET` call for the given loadbalancer id and returns the
         load balancer object.
         """
-        get_lb = request(self, self.root, "GET", self.uri + '/loadbalancers/' + str(lb_id))
+        get_lb = request(self, self.root, b"GET", self.uri + '/loadbalancers/' + str(lb_id))
         get_lb_response = self.successResultOf(get_lb)
         get_lb_response_body = self.successResultOf(treq.json_content(get_lb_response))
         return get_lb_response_body
@@ -1133,7 +1135,7 @@ class LoadbalancerAPINegativeTests(SynchronousTestCase):
         """
         Deletes the given load balancer id and returns the response
         """
-        delete_lb = request(self, self.root, "DELETE", self.uri + '/loadbalancers/' +
+        delete_lb = request(self, self.root, b"DELETE", self.uri + '/loadbalancers/' +
                             str(lb_id))
         return self.successResultOf(delete_lb)
 
@@ -1178,7 +1180,7 @@ class LoadbalancerAPINegativeTests(SynchronousTestCase):
         create_node_response = self._add_node_to_lb(lb["id"])
         self.assertEqual(create_node_response.code, 422)
         # An lb in ERROR state can be deleted
-        delete_lb = request(self, self.root, "DELETE", self.uri + '/loadbalancers/' +
+        delete_lb = request(self, self.root, b"DELETE", self.uri + '/loadbalancers/' +
                             str(lb["id"]))
         delete_lb_response = self.successResultOf(delete_lb)
         self.assertEqual(delete_lb_response.code, 202)
@@ -1202,11 +1204,11 @@ class LoadbalancerAPINegativeTests(SynchronousTestCase):
         create_node_response = self._add_node_to_lb(lb["id"])
         self.assertEqual(create_node_response.code, 422)
         delete_nodes = request(
-            self, self.root, "DELETE", self.uri + '/loadbalancers/' +
+            self, self.root, b"DELETE", self.uri + '/loadbalancers/' +
             str(lb["id"]) + '/nodes/123')
         self.assertEqual(self.successResultOf(delete_nodes).code, 422)
         # An lb in PENDING-UPDATE state can be deleted
-        delete_lb = request(self, self.root, "DELETE", self.uri + '/loadbalancers/' +
+        delete_lb = request(self, self.root, b"DELETE", self.uri + '/loadbalancers/' +
                             str(lb["id"]))
         delete_lb_response = self.successResultOf(delete_lb)
         self.assertEqual(delete_lb_response.code, 202)
@@ -1259,28 +1261,28 @@ class LoadbalancerAPINegativeTests(SynchronousTestCase):
 
         # GET node on load balancer in DELETED status results in 410
         get_node = request(
-            self, self.root, "GET", self.uri + '/loadbalancers/' +
+            self, self.root, b"GET", self.uri + '/loadbalancers/' +
             str(lb["id"]) + '/nodes/123')
         get_node_response = self.successResultOf(get_node)
         self.assertEqual(get_node_response.code, 410)
 
         # GET node feed on load balancer in DELETED status results in 410
         node_feed = request(
-            self, self.root, "GET", self.uri + '/loadbalancers/' +
+            self, self.root, b"GET", self.uri + '/loadbalancers/' +
             str(lb["id"]) + '/nodes/123.atom')
         node_feed_response = self.successResultOf(node_feed)
         self.assertEqual(node_feed_response.code, 410)
 
         # List node on load balancer in DELETED status results in 410
         list_nodes = request(
-            self, self.root, "GET", self.uri + '/loadbalancers/' + str(lb["id"])
+            self, self.root, b"GET", self.uri + '/loadbalancers/' + str(lb["id"])
             + '/nodes')
         self.assertEqual(self.successResultOf(list_nodes).code, 410)
 
         # Progress past "deleting now"
         self.helper.clock.advance(4000)
         list_nodes = request(
-            self, self.root, "GET", self.uri + '/loadbalancers/' + str(lb["id"])
+            self, self.root, b"GET", self.uri + '/loadbalancers/' + str(lb["id"])
             + '/nodes')
         self.assertEqual(self.successResultOf(list_nodes).code, 404)
 

--- a/mimic/test/test_maas.py
+++ b/mimic/test/test_maas.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import json
 import treq
 from twisted.internet.task import Clock
@@ -55,7 +57,7 @@ class MaasAPITests(SynchronousTestCase):
         postdata = {}
         postdata['agent_id'] = None
         postdata['label'] = label
-        req = request(self, self.root, "POST", self.uri + '/entities',
+        req = request(self, self.root, b"POST", self.uri + '/entities',
                       json.dumps(postdata))
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 201)
@@ -77,7 +79,7 @@ class MaasAPITests(SynchronousTestCase):
         postdata['target_resolver'] = None
         postdata['type'] = 'remote.ping'
         checks_endpoint = '{0}/entities/{1}/checks'.format(self.uri, entity_id)
-        req = request(self, self.root, "POST", checks_endpoint,
+        req = request(self, self.root, b"POST", checks_endpoint,
                       json.dumps(postdata))
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 201)
@@ -95,7 +97,7 @@ class MaasAPITests(SynchronousTestCase):
         postdata['label'] = label
         postdata['notification_plan_id'] = 'npTechnicalContactsEmail'
         alarms_endpoint = '{0}/entities/{1}/alarms'.format(self.uri, entity_id)
-        req = request(self, self.root, "POST", alarms_endpoint,
+        req = request(self, self.root, b"POST", alarms_endpoint,
                       json.dumps(postdata))
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 201)
@@ -111,7 +113,7 @@ class MaasAPITests(SynchronousTestCase):
         postdata = {'label': label}
         postdata['type'] = 'email'
         postdata['details'] = {'address': 'zoehardman4ever@hedkandi.co.uk'}
-        req = request(self, self.root, "POST", self.uri + '/notifications', json.dumps(postdata))
+        req = request(self, self.root, b"POST", self.uri + '/notifications', json.dumps(postdata))
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 201)
         nt_id = resp.headers.getRawHeaders('x-object-id')[0]
@@ -124,7 +126,7 @@ class MaasAPITests(SynchronousTestCase):
         Util create notification plan
         """
         postdata = {'label': label}
-        req = request(self, self.root, "POST", self.uri + '/notification_plans', json.dumps(postdata))
+        req = request(self, self.root, b"POST", self.uri + '/notification_plans', json.dumps(postdata))
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 201)
         np_id = resp.headers.getRawHeaders('x-object-id')[0]
@@ -134,7 +136,7 @@ class MaasAPITests(SynchronousTestCase):
 
     def createSuppression(self, label):
         postdata = {'label': label}
-        req = request(self, self.root, "POST", self.uri + '/suppressions', json.dumps(postdata))
+        req = request(self, self.root, b"POST", self.uri + '/suppressions', json.dumps(postdata))
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 201)
         sp_id = resp.headers.getRawHeaders('x-object-id')[0]
@@ -193,7 +195,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         test list entity
         """
-        req = request(self, self.root, "GET", self.uri + '/entities')
+        req = request(self, self.root, b"GET", self.uri + '/entities')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -201,13 +203,13 @@ class MaasAPITests(SynchronousTestCase):
         for q in range(1, 101):
             self.createEntity('Cinnamon' + str(q))
         for q in range(1, 101):
-            req = request(self, self.root, "GET", self.uri + '/entities/?limit=' + str(q))
+            req = request(self, self.root, b"GET", self.uri + '/entities/?limit=' + str(q))
             resp = self.successResultOf(req)
             self.assertEquals(resp.code, 200)
             data = self.get_responsebody(resp)
             self.assertEquals(data['metadata']['count'], q)
             marker = data['metadata']['next_marker']
-        req = request(self, self.root, "GET", self.uri + '/entities/?marker=' + marker)
+        req = request(self, self.root, b"GET", self.uri + '/entities/?marker=' + marker)
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -218,7 +220,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         test get entity
         """
-        req = request(self, self.root, "GET", self.uri + '/entities/' + self.entity_id)
+        req = request(self, self.root, b"GET", self.uri + '/entities/' + self.entity_id)
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -229,7 +231,7 @@ class MaasAPITests(SynchronousTestCase):
         Attempting to get an entity with a nonexistent ID returns 404.
         """
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "GET", '{0}/entities/whatever'.format(self.uri)))
+            json_request(self, self.root, b"GET", '{0}/entities/whatever'.format(self.uri)))
         self.assertEquals(resp.code, 404)
         self.assertEquals(data['type'], 'notFoundError')
 
@@ -237,14 +239,14 @@ class MaasAPITests(SynchronousTestCase):
         """
         Test getting the audit log.
         """
-        req = request(self, self.root, "GET", self.uri + '/audits?limit=2')
+        req = request(self, self.root, b"GET", self.uri + '/audits?limit=2')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
         self.assertEquals(data['metadata']['count'], 2)
         self.assertEquals(data['values'][0]['app'], 'entities')
 
-        req = request(self, self.root, "GET", self.uri +
+        req = request(self, self.root, b"GET", self.uri +
                       '/audits?marker=' + data['metadata']['next_marker'])
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
@@ -256,7 +258,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         Test getting the audit log with `reverse` set to True.
         """
-        req = request(self, self.root, "GET", self.uri + '/audits?limit=2&reverse=true')
+        req = request(self, self.root, b"GET", self.uri + '/audits?limit=2&reverse=true')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -268,7 +270,7 @@ class MaasAPITests(SynchronousTestCase):
         If the marker is not found, the audit log returns results from the
         beginning.
         """
-        req = request(self, self.root, "GET", self.uri +
+        req = request(self, self.root, b"GET", self.uri +
                       '/audits?marker=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
@@ -279,7 +281,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         test get check
         """
-        req = request(self, self.root, "GET",
+        req = request(self, self.root, b"GET",
                       self.uri + '/entities/' + self.entity_id + '/checks/' + self.check_id)
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
@@ -291,7 +293,7 @@ class MaasAPITests(SynchronousTestCase):
         Trying to GET a nonexistent check causes a 404.
         """
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "GET", '{0}/entities/{1}/checks/Whut'.format(
+            json_request(self, self.root, b"GET", '{0}/entities/{1}/checks/Whut'.format(
                 self.uri, self.entity_id)))
         self.assertEquals(resp.code, 404)
         self.assertEquals(data['type'], 'notFoundError')
@@ -300,7 +302,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         test get check
         """
-        req = request(self, self.root, "GET",
+        req = request(self, self.root, b"GET",
                       self.uri + '/entities/' + self.entity_id + '/checks')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
@@ -314,7 +316,7 @@ class MaasAPITests(SynchronousTestCase):
         MaaS returns 400 Bad Request.
         """
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "POST",
+            json_request(self, self.root, b"POST",
                          '{0}/entities/{1}/checks'.format(self.uri, self.entity_id),
                          json.dumps({'label': 'wow-check'})))
         self.assertEquals(resp.code, 400)
@@ -328,7 +330,7 @@ class MaasAPITests(SynchronousTestCase):
         that it knows how to use.
         """
         resp = self.successResultOf(
-            request(self, self.root, "POST", '{0}/entities'.format(self.uri),
+            request(self, self.root, b"POST", '{0}/entities'.format(self.uri),
                     json.dumps({'label': 'foo', 'whut': 'WAT'})))
         self.assertEquals(resp.code, 201)
 
@@ -337,16 +339,16 @@ class MaasAPITests(SynchronousTestCase):
         update entity
         """
         entity_endpoint = '{0}/entities/{1}'.format(self.uri, self.entity_id)
-        req = request(self, self.root, "GET", entity_endpoint)
+        req = request(self, self.root, b"GET", entity_endpoint)
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
         data['label'] = 'Iamamwhoami'
-        req = request(self, self.root, "PUT", entity_endpoint, json.dumps(data))
+        req = request(self, self.root, b"PUT", entity_endpoint, json.dumps(data))
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 204)
         self.assertEquals(entity_endpoint, resp.headers.getRawHeaders('location')[0])
-        req = request(self, self.root, "GET", entity_endpoint)
+        req = request(self, self.root, b"GET", entity_endpoint)
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -357,10 +359,11 @@ class MaasAPITests(SynchronousTestCase):
         Update an entity, fields not specified in the body don't change.
         """
         data = {'agent_id': 'ag13378901234'}
-        req = request(self, self.root, "PUT", self.uri + '/entities/' + self.entity_id, json.dumps(data))
+        req = request(self, self.root, b"PUT", self.uri + '/entities/' + self.entity_id,
+                      json.dumps(data))
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 204)
-        req = request(self, self.root, "GET", self.uri + '/entities/' + self.entity_id)
+        req = request(self, self.root, b"GET", self.uri + '/entities/' + self.entity_id)
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -373,8 +376,8 @@ class MaasAPITests(SynchronousTestCase):
         description of the alarm.
 
         """
-        req = request(self, self.root, "GET",
-                      self.uri + '/entities/' + self.entity_id + '/alarms/' + self.alarm_id, '')
+        req = request(self, self.root, b"GET",
+                      self.uri + '/entities/' + self.entity_id + '/alarms/' + self.alarm_id)
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -384,8 +387,8 @@ class MaasAPITests(SynchronousTestCase):
         """
         Getting an alarm that does not exist should 404
         """
-        req = request(self, self.root, "GET",
-                      self.uri + '/entities/' + self.entity_id + '/alarms/alDoesNotExist', '')
+        req = request(self, self.root, b"GET",
+                      self.uri + '/entities/' + self.entity_id + '/alarms/alDoesNotExist')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 404)
 
@@ -395,7 +398,7 @@ class MaasAPITests(SynchronousTestCase):
         MaaS returns 400 Bad Request.
         """
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "POST",
+            json_request(self, self.root, b"POST",
                          '{0}/entities/{1}/alarms'.format(self.uri, self.entity_id),
                          json.dumps({'label': 'wow-alarm',
                                      'notification_plan_id': self.np_id})))
@@ -409,7 +412,7 @@ class MaasAPITests(SynchronousTestCase):
         property, MaaS returns 400 Bad Request.
         """
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "POST",
+            json_request(self, self.root, b"POST",
                          '{0}/entities/{1}/alarms'.format(self.uri, self.entity_id),
                          json.dumps({'label': 'wow-alarm',
                                      'check_id': self.check_id})))
@@ -423,16 +426,16 @@ class MaasAPITests(SynchronousTestCase):
         """
         check_endpoint = '{0}/entities/{1}/checks/{2}'.format(
             self.uri, self.entity_id, self.check_id)
-        req = request(self, self.root, "GET", check_endpoint)
+        req = request(self, self.root, b"GET", check_endpoint)
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
         data['label'] = 'Iamamwhoami'
-        req = request(self, self.root, "PUT", check_endpoint, json.dumps(data))
+        req = request(self, self.root, b"PUT", check_endpoint, json.dumps(data))
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 204)
         self.assertEquals(check_endpoint, resp.headers.getRawHeaders('location')[0])
-        req = request(self, self.root, "GET", check_endpoint)
+        req = request(self, self.root, b"GET", check_endpoint)
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -443,13 +446,13 @@ class MaasAPITests(SynchronousTestCase):
         Update a check, fields not specified in the body don't change.
         """
         data = {'target_alias': 'internet7_v4'}
-        req = request(self, self.root, "PUT",
+        req = request(self, self.root, b"PUT",
                       self.uri + '/entities/' + self.entity_id + '/checks/' + self.check_id,
                       json.dumps(data))
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 204)
-        req = request(self, self.root, "GET",
-                      self.uri + '/entities/' + self.entity_id + '/checks/' + self.check_id, '')
+        req = request(self, self.root, b"GET",
+                      self.uri + '/entities/' + self.entity_id + '/checks/' + self.check_id)
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -463,7 +466,7 @@ class MaasAPITests(SynchronousTestCase):
         that it knows how to use.
         """
         resp = self.successResultOf(
-            request(self, self.root, "POST",
+            request(self, self.root, b"POST",
                     '{0}/entities/{1}/checks'.format(self.uri, self.entity_id),
                     json.dumps({'label': 'check-foo',
                                 'type': 'remote.ping',
@@ -474,18 +477,18 @@ class MaasAPITests(SynchronousTestCase):
         """
         update alarm
         """
-        req = request(self, self.root, "GET", self.uri + '/views/overview')
+        req = request(self, self.root, b"GET", self.uri + '/views/overview')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         alarm = self.get_responsebody(resp)['values'][0]['alarms'][0]
         alarm['label'] = 'Iamamwhoami'
         alarm_endpoint = '{0}/entities/{1}/alarms/{2}'.format(
             self.uri, self.entity_id, self.alarm_id)
-        req = request(self, self.root, "PUT", alarm_endpoint, json.dumps(alarm))
+        req = request(self, self.root, b"PUT", alarm_endpoint, json.dumps(alarm))
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 204)
         self.assertEquals(alarm_endpoint, resp.headers.getRawHeaders('location')[0])
-        req = request(self, self.root, "GET", self.uri + '/views/overview')
+        req = request(self, self.root, b"GET", self.uri + '/views/overview')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         alarm2 = self.get_responsebody(resp)['values'][0]['alarms'][0]
@@ -498,13 +501,13 @@ class MaasAPITests(SynchronousTestCase):
 
         """
         data = {'notification_plan_id': 'np123456'}
-        req = request(self, self.root, "PUT",
+        req = request(self, self.root, b"PUT",
                       self.uri + '/entities/' + self.entity_id + '/alarms/' + self.alarm_id,
                       json.dumps(data))
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 204)
-        req = request(self, self.root, "GET",
-                      self.uri + '/entities/' + self.entity_id + '/alarms/' + self.alarm_id, '')
+        req = request(self, self.root, b"GET",
+                      self.uri + '/entities/' + self.entity_id + '/alarms/' + self.alarm_id)
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -518,7 +521,7 @@ class MaasAPITests(SynchronousTestCase):
         that it knows how to use.
         """
         resp = self.successResultOf(
-            request(self, self.root, "POST",
+            request(self, self.root, b"POST",
                     '{0}/entities/{1}/alarms'.format(self.uri, self.entity_id),
                     json.dumps({'label': 'alarm-foo',
                                 'check_id': self.check_id,
@@ -531,11 +534,11 @@ class MaasAPITests(SynchronousTestCase):
         """
         delete alarm
         """
-        req = request(self, self.root, "DELETE",
+        req = request(self, self.root, b"DELETE",
                       self.uri + '/entities/' + self.entity_id + '/alarms/' + self.alarm_id)
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 204)
-        req = request(self, self.root, "GET", self.uri + '/views/overview')
+        req = request(self, self.root, b"GET", self.uri + '/views/overview')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         self.assertEquals(0, len(self.get_responsebody(resp)['values'][0]['alarms']))
@@ -545,7 +548,7 @@ class MaasAPITests(SynchronousTestCase):
         Deleting an alarm that does not exist causes a 404.
         """
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "DELETE",
+            json_request(self, self.root, b"DELETE",
                          '{0}/entities/{1}/alarms/alWhut'.format(self.uri, self.entity_id)))
         self.assertEquals(resp.code, 404)
         self.assertEquals(data['details'],
@@ -556,7 +559,7 @@ class MaasAPITests(SynchronousTestCase):
         The test-check API should return fake test-check results.
         """
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "POST",
+            json_request(self, self.root, b"POST",
                          self.uri + '/entities/' + self.entity_id + '/test-check',
                          json.dumps({'type': 'agent.disk'})))
         self.assertEquals(resp.code, 200)
@@ -567,14 +570,14 @@ class MaasAPITests(SynchronousTestCase):
         """
         The test-check control API can set available=False.
         """
-        resp = self.successResultOf(request(self, self.root, "PUT",
+        resp = self.successResultOf(request(self, self.root, b"PUT",
                                     '{0}/entities/{1}/checks/test_responses/{2}'.format(
                                         self.ctl_uri, self.entity_id, 'agent.load_average'),
                                     json.dumps([{'available': False}])))
         self.assertEquals(resp.code, 204)
 
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "POST",
+            json_request(self, self.root, b"POST",
                          self.uri + '/entities/' + self.entity_id + '/test-check',
                          json.dumps({'type': 'agent.load_average'})))
         self.assertEquals(resp.code, 200)
@@ -584,14 +587,14 @@ class MaasAPITests(SynchronousTestCase):
         """
         The test-check control API can set the status message.
         """
-        resp = self.successResultOf(request(self, self.root, "PUT",
+        resp = self.successResultOf(request(self, self.root, b"PUT",
                                     '{0}/entities/{1}/checks/test_responses/{2}'.format(
                                         self.ctl_uri, self.entity_id, 'agent.memory'),
                                     json.dumps([{'status': 'whuuut'}])))
         self.assertEquals(resp.code, 204)
 
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "POST",
+            json_request(self, self.root, b"POST",
                          self.uri + '/entities/' + self.entity_id + '/test-check',
                          json.dumps({'type': 'agent.memory'})))
         self.assertEquals(resp.code, 200)
@@ -604,7 +607,7 @@ class MaasAPITests(SynchronousTestCase):
         Subsequent requests to set the same metrics on the same check type
         for the same entity will override.
         """
-        resp = self.successResultOf(request(self, self.root, "PUT",
+        resp = self.successResultOf(request(self, self.root, b"PUT",
                                     '{0}/entities/{1}/checks/test_responses/{2}'.format(
                                         self.ctl_uri, self.entity_id, 'remote.http'),
                                     json.dumps([{'metrics': {'duration': {'data': 123}},
@@ -612,14 +615,14 @@ class MaasAPITests(SynchronousTestCase):
         self.assertEquals(resp.code, 204)
 
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "POST",
+            json_request(self, self.root, b"POST",
                          self.uri + '/entities/' + self.entity_id + '/test-check',
                          json.dumps({'type': 'remote.http',
                                      'monitoring_zones_poll': ['mzdfw']})))
         self.assertEquals(resp.code, 200)
         self.assertEquals(123, data[0]['metrics']['duration']['data'])
 
-        resp = self.successResultOf(request(self, self.root, "PUT",
+        resp = self.successResultOf(request(self, self.root, b"PUT",
                                     '{0}/entities/{1}/checks/test_responses/{2}'.format(
                                         self.ctl_uri, self.entity_id, 'remote.http'),
                                     json.dumps([{'metrics': {'duration': {'data': 456}},
@@ -627,7 +630,7 @@ class MaasAPITests(SynchronousTestCase):
         self.assertEquals(resp.code, 204)
 
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "POST",
+            json_request(self, self.root, b"POST",
                          self.uri + '/entities/' + self.entity_id + '/test-check',
                          json.dumps({'type': 'remote.http',
                                      'monitoring_zones_poll': ['mzdfw']})))
@@ -644,20 +647,20 @@ class MaasAPITests(SynchronousTestCase):
         options = {'data': 'really great forty-three character sentence'}
 
         resp = self.successResultOf(
-            request(self, self.root, "PUT",
+            request(self, self.root, b"PUT",
                     '{0}/entities/{1}/checks/test_responses/{2}'.format(
                         self.ctl_uri, self.entity_id, 'agent.filesystem'),
                     json.dumps([{'metrics': {'options': options}}])))
         self.assertEquals(resp.code, 204)
 
         resp = self.successResultOf(
-            request(self, self.root, "DELETE",
+            request(self, self.root, b"DELETE",
                     '{0}/entities/{1}/checks/test_responses/{2}'.format(
                         self.ctl_uri, self.entity_id, 'agent.filesystem')))
         self.assertEquals(resp.code, 204)
 
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "POST",
+            json_request(self, self.root, b"POST",
                          self.uri + '/entities/' + self.entity_id + '/test-check',
                          json.dumps({'type': 'agent.filesystem'})))
         self.assertEquals(resp.code, 200)
@@ -669,13 +672,13 @@ class MaasAPITests(SynchronousTestCase):
         and no control override is in place, nothing happens.
         """
         resp = self.successResultOf(
-            request(self, self.root, "DELETE",
+            request(self, self.root, b"DELETE",
                     '{0}/entities/{1}/checks/test_responses/{2}'.format(
                         self.ctl_uri, self.entity_id, 'agent.network')))
         self.assertEquals(resp.code, 204)
 
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "POST",
+            json_request(self, self.root, b"POST",
                          self.uri + '/entities/' + self.entity_id + '/test-check',
                          json.dumps({'type': 'agent.network'})))
         self.assertEquals(resp.code, 200)
@@ -687,7 +690,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         for check_type in ['remote.http', 'remote.ping']:
             (resp, data) = self.successResultOf(
-                json_request(self, self.root, "POST",
+                json_request(self, self.root, b"POST",
                              '{0}/entities/{1}/test-check'.format(self.uri, self.entity_id),
                              json.dumps({'type': check_type})))
             self.assertEquals(resp.code, 200)
@@ -699,7 +702,7 @@ class MaasAPITests(SynchronousTestCase):
         Test test-alarm API in normal operation.
         """
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "POST",
+            json_request(self, self.root, b"POST",
                          self.uri + '/entities/' + self.entity_id + '/test-alarm',
                          json.dumps({'criteria': 'return new AlarmStatus(OK);',
                                      'check_data': [{}]})))
@@ -713,14 +716,14 @@ class MaasAPITests(SynchronousTestCase):
         """
         Test test-alarm API setting the state parameter.
         """
-        resp = self.successResultOf(request(self, self.root, "PUT",
+        resp = self.successResultOf(request(self, self.root, b"PUT",
                                             '{0}/entities/{1}/alarms/test_response'.format(
                                                 self.ctl_uri, self.entity_id),
                                             json.dumps([{'state': 'OK'}])))
         self.assertEquals(resp.code, 204)
 
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "POST",
+            json_request(self, self.root, b"POST",
                          self.uri + '/entities/' + self.entity_id + '/test-alarm',
                          json.dumps({'criteria': 'return new AlarmStatus(OK);',
                                      'check_data': [{}]})))
@@ -734,7 +737,7 @@ class MaasAPITests(SynchronousTestCase):
         Users can set the status field on the response from the test-alarm API.
         """
         resp = self.successResultOf(
-            request(self, self.root, "PUT",
+            request(self, self.root, b"PUT",
                     '{0}/entities/{1}/alarms/test_response'.format(
                         self.ctl_uri, self.entity_id),
                     json.dumps([{'state': 'OK',
@@ -742,7 +745,7 @@ class MaasAPITests(SynchronousTestCase):
         self.assertEquals(resp.code, 204)
 
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "POST",
+            json_request(self, self.root, b"POST",
                          self.uri + '/entities/' + self.entity_id + '/test-alarm',
                          json.dumps({'criteria': 'return new AlarmStatus(OK);',
                                      'check_data': [{}]})))
@@ -756,20 +759,20 @@ class MaasAPITests(SynchronousTestCase):
         causes the response to be cleared and not returned later.
         """
         resp = self.successResultOf(
-            request(self, self.root, "PUT",
+            request(self, self.root, b"PUT",
                     '{0}/entities/{1}/alarms/test_response'.format(
                         self.ctl_uri, self.entity_id),
                     json.dumps([{'state': 'OK',
                                  'status': 'test-alarm working OK'}])))
         self.assertEquals(resp.code, 204)
 
-        resp = self.successResultOf(request(self, self.root, "DELETE",
+        resp = self.successResultOf(request(self, self.root, b"DELETE",
                                             '{0}/entities/{1}/alarms/test_response'.format(
                                                 self.ctl_uri, self.entity_id)))
         self.assertEquals(resp.code, 204)
 
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "POST",
+            json_request(self, self.root, b"POST",
                          self.uri + '/entities/' + self.entity_id + '/test-alarm',
                          json.dumps({'criteria': 'return new AlarmStatus(OK);',
                                      'check_data': [{}]})))
@@ -789,21 +792,21 @@ class MaasAPITests(SynchronousTestCase):
                            'message': 'Object does not exist'}
 
         resp = self.successResultOf(
-            request(self, self.root, "POST",
+            request(self, self.root, b"POST",
                     '{0}/entities/{1}/alarms/test_errors'.format(
                         self.ctl_uri, self.entity_id),
                     json.dumps({'code': 400, 'response': parse_error})))
         self.assertEquals(resp.code, 201)
 
         resp = self.successResultOf(
-            request(self, self.root, "POST",
+            request(self, self.root, b"POST",
                     '{0}/entities/{1}/alarms/test_errors'.format(
                         self.ctl_uri, self.entity_id),
                     json.dumps({'code': 404, 'response': not_found_error})))
         self.assertEquals(resp.code, 201)
 
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "POST",
+            json_request(self, self.root, b"POST",
                          '{0}/entities/{1}/test-alarm'.format(self.uri, self.entity_id),
                          json.dumps({'criteria': 'return new AlarmStatus(OK);',
                                      'check_data': [{}]})))
@@ -811,7 +814,7 @@ class MaasAPITests(SynchronousTestCase):
         self.assertEquals(data, parse_error)
 
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "POST",
+            json_request(self, self.root, b"POST",
                          '{0}/entities/{1}/test-alarm'.format(self.uri, self.entity_id),
                          json.dumps({'criteria': 'return new AlarmStatus(OK);',
                                      'check_data': [{}]})))
@@ -822,7 +825,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         get all alarms for the entity
         """
-        req = request(self, self.root, "GET",
+        req = request(self, self.root, b"GET",
                       self.uri + '/entities/' + self.entity_id + '/alarms')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
@@ -834,11 +837,11 @@ class MaasAPITests(SynchronousTestCase):
         """
         delete check
         """
-        req = request(self, self.root, "DELETE",
+        req = request(self, self.root, b"DELETE",
                       self.uri + '/entities/' + self.entity_id + '/checks/' + self.check_id)
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 204)
-        req = request(self, self.root, "GET", self.uri + '/views/overview')
+        req = request(self, self.root, b"GET", self.uri + '/views/overview')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -850,7 +853,7 @@ class MaasAPITests(SynchronousTestCase):
         Deleting a check that does not exist causes a 404.
         """
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "DELETE",
+            json_request(self, self.root, b"DELETE",
                          '{0}/entities/{1}/checks/chWhut'.format(self.uri, self.entity_id)))
         self.assertEquals(resp.code, 404)
         self.assertEquals(data['details'],
@@ -860,11 +863,11 @@ class MaasAPITests(SynchronousTestCase):
         """
         delete entity
         """
-        req = request(self, self.root, "DELETE",
+        req = request(self, self.root, b"DELETE",
                       self.uri + '/entities/' + self.entity_id)
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 204)
-        req = request(self, self.root, "GET", self.uri + '/views/overview')
+        req = request(self, self.root, b"GET", self.uri + '/views/overview')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -876,12 +879,12 @@ class MaasAPITests(SynchronousTestCase):
         Deleting an entity that does not exist causes a 404.
         """
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "DELETE", '{0}/entities/whut'.format(self.uri)))
+            json_request(self, self.root, b"DELETE", '{0}/entities/whut'.format(self.uri)))
         self.assertEquals(resp.code, 404)
         self.assertEquals(data['details'], 'Object "Entity" with key "whut" does not exist')
 
     def test_jsonhome(self):
-        req = request(self, self.root, "GET", self.uri + '/__experiments/json_home')
+        req = request(self, self.root, b"GET", self.uri + '/__experiments/json_home')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -891,7 +894,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         fetch notification plans
         """
-        req = request(self, self.root, "GET", self.uri + '/notification_plans')
+        req = request(self, self.root, b"GET", self.uri + '/notification_plans')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -904,7 +907,7 @@ class MaasAPITests(SynchronousTestCase):
         that it knows how to use.
         """
         resp = self.successResultOf(
-            request(self, self.root, "POST",
+            request(self, self.root, b"POST",
                     '{0}/notification_plans'.format(self.uri),
                     json.dumps({'label': 'np-foo',
                                 'whut': 'WAT'})))
@@ -917,7 +920,7 @@ class MaasAPITests(SynchronousTestCase):
         that it knows how to use.
         """
         resp = self.successResultOf(
-            request(self, self.root, "POST",
+            request(self, self.root, b"POST",
                     '{0}/notifications'.format(self.uri),
                     json.dumps({'label': 'nt-foo',
                                 'details': {'address': 'bob@company.com'},
@@ -932,7 +935,7 @@ class MaasAPITests(SynchronousTestCase):
         that it knows how to use.
         """
         resp = self.successResultOf(
-            request(self, self.root, "POST",
+            request(self, self.root, b"POST",
                     '{0}/suppressions'.format(self.uri),
                     json.dumps({'label': 'sp-foo',
                                 'whut': 'WAT'})))
@@ -943,25 +946,25 @@ class MaasAPITests(SynchronousTestCase):
         fetch agent host info
         """
         for q in range(4):
-            req = request(self, self.root, "GET",
+            req = request(self, self.root, b"GET",
                           self.uri + '/views/agent_host_info?entityId=' + self.entity_id)
             resp = self.successResultOf(req)
             self.assertEquals(resp.code, 400)
             data = self.get_responsebody(resp)
             self.assertEquals(True, 'Agent does not exist' in json.dumps(data))
-        req = request(self, self.root, "GET",
+        req = request(self, self.root, b"GET",
                       self.uri + '/views/agent_host_info?entityId=' + self.entity_id)
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
         self.assertEquals(True, self.entity_id == data['values'][0]['entity_id'])
-        req = request(self, self.root, "GET",
+        req = request(self, self.root, b"GET",
                       self.uri + '/views/agent_host_info')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 400)
         data = self.get_responsebody(resp)
         self.assertEquals(True, data['type'] == 'badRequest')
-        req = request(self, self.root, "GET",
+        req = request(self, self.root, b"GET",
                       self.uri + '/views/agent_host_info?entityId=enDoesNotExist')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 404)
@@ -972,7 +975,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         fetch agent installer
         """
-        req = request(self, self.root, "POST", self.uri + '/agent_installers')
+        req = request(self, self.root, b"POST", self.uri + '/agent_installers')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 201)
         xsil = resp.headers.getRawHeaders('x-shell-installer-location')
@@ -983,7 +986,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         get available metrics
         """
-        req = request(self, self.root, "GET", self.uri + '/views/metric_list')
+        req = request(self, self.root, b"GET", self.uri + '/views/metric_list')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -996,12 +999,12 @@ class MaasAPITests(SynchronousTestCase):
         of metrics on that check to be empty.
         """
         resp = self.successResultOf(
-            request(self, self.root, "POST",
+            request(self, self.root, b"POST",
                     '{0}/entities/{1}/checks'.format(self.uri, self.entity_id),
                     json.dumps({'type': 'agent.chupacabra'})))
         self.assertEquals(resp.code, 201)
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "GET", '{0}/views/metric_list'.format(self.uri)))
+            json_request(self, self.root, b"GET", '{0}/views/metric_list'.format(self.uri)))
         self.assertEquals(resp.code, 200)
         chupacabra_check = [check for check in data['values'][0]['checks']
                             if check['type'] == 'agent.chupacabra']
@@ -1013,12 +1016,12 @@ class MaasAPITests(SynchronousTestCase):
         that check type.
         """
         resp = self.successResultOf(
-            request(self, self.root, "POST",
+            request(self, self.root, b"POST",
                     '{0}/entities/{1}/checks'.format(self.uri, self.entity_id),
                     json.dumps({'type': 'agent.cpu'})))
         self.assertEquals(resp.code, 201)
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "GET", '{0}/views/metric_list'.format(self.uri)))
+            json_request(self, self.root, b"GET", '{0}/views/metric_list'.format(self.uri)))
         self.assertEquals(resp.code, 200)
         cpu_check = [check for check in data['values'][0]['checks']
                      if check['type'] == 'agent.cpu']
@@ -1029,7 +1032,7 @@ class MaasAPITests(SynchronousTestCase):
         get datapoints for graph
         """
         metrics = []
-        req = request(self, self.root, "GET", self.uri + '/views/metric_list')
+        req = request(self, self.root, b"GET", self.uri + '/views/metric_list')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -1037,7 +1040,7 @@ class MaasAPITests(SynchronousTestCase):
             mq = {'entity_id': self.entity_id, 'check_id': self.check_id, 'metric': m['name']}
             metrics.append(mq)
         qstring = '?from=1412902262560&points=500&to=1412988662560'
-        req = request(self, self.root, "POST",
+        req = request(self, self.root, b"POST",
                       self.uri + '/__experiments/multiplot' + qstring, json.dumps({'metrics': metrics}))
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
@@ -1050,7 +1053,7 @@ class MaasAPITests(SynchronousTestCase):
         exist, the MaaS API returns a 400.
         """
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "POST",
+            json_request(self, self.root, b"POST",
                          '{0}/__experiments/multiplot?from={1}&to={2}&points={3}'.format(
                              self.uri, '1412902262560', '1412988662560', 500),
                          json.dumps({'metrics': [{'entity_id': self.entity_id,
@@ -1065,13 +1068,13 @@ class MaasAPITests(SynchronousTestCase):
         metric and empty data to be returned.
         """
         resp = self.successResultOf(
-            request(self, self.root, "POST",
+            request(self, self.root, b"POST",
                     '{0}/entities/{1}/checks'.format(self.uri, self.entity_id),
                     json.dumps({'type': 'agent.whatever'})))
         self.assertEquals(resp.code, 201)
         check_id = resp.headers.getRawHeaders('x-object-id')[0]
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "POST",
+            json_request(self, self.root, b"POST",
                          '{0}/__experiments/multiplot?from={1}&to={2}&points={3}'.format(
                              self.uri, '1412902262560', '1412988662560', 500),
                          json.dumps({'metrics': [{'entity_id': self.entity_id,
@@ -1089,7 +1092,7 @@ class MaasAPITests(SynchronousTestCase):
         metric and empty data to be returned.
         """
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "POST",
+            json_request(self, self.root, b"POST",
                          '{0}/__experiments/multiplot?from={1}&to={2}&points={3}'.format(
                              self.uri, '1412902262560', '1412988662560', 500),
                          json.dumps({'metrics': [{'entity_id': self.entity_id,
@@ -1106,7 +1109,7 @@ class MaasAPITests(SynchronousTestCase):
         type is one that Mimic knows about.
         """
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "POST",
+            json_request(self, self.root, b"POST",
                          '{0}/__experiments/multiplot?from={1}&to={2}&points={3}'.format(
                              self.uri, '1412902262560', '1412988662560', 500),
                          json.dumps({'metrics': [{'entity_id': self.entity_id,
@@ -1121,7 +1124,7 @@ class MaasAPITests(SynchronousTestCase):
         Plotting a single point should not cause a server error.
         """
         resp = self.successResultOf(
-            request(self, self.root, "POST",
+            request(self, self.root, b"POST",
                     '{0}/__experiments/multiplot?from={1}&to={2}&points={3}'.format(
                         self.uri, '1412902262560', '1412988662560', 1),
                     json.dumps({'metrics': [{'entity_id': self.entity_id,
@@ -1133,7 +1136,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         get all notification plans
         """
-        req = request(self, self.root, "GET", self.uri + '/notification_plans')
+        req = request(self, self.root, b"GET", self.uri + '/notification_plans')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -1143,12 +1146,12 @@ class MaasAPITests(SynchronousTestCase):
         """
         Get a specific notification plan
         """
-        req = request(self, self.root, "GET", self.uri + '/notification_plans/' + self.np_id)
+        req = request(self, self.root, b"GET", self.uri + '/notification_plans/' + self.np_id)
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
         self.assertEquals(data['id'], self.np_id)
-        req = request(self, self.root, "GET",
+        req = request(self, self.root, b"GET",
                       self.uri + '/notification_plans/npTechnicalContactsEmail')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
@@ -1159,7 +1162,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         Get all notification targets
         """
-        req = request(self, self.root, "GET", self.uri + '/notifications')
+        req = request(self, self.root, b"GET", self.uri + '/notifications')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -1170,11 +1173,11 @@ class MaasAPITests(SynchronousTestCase):
         Update a notification target
         """
         postdata = {'id': self.nt_id, 'label': 'changed'}
-        req = request(self, self.root, "PUT", self.uri + '/notifications/' + self.nt_id,
+        req = request(self, self.root, b"PUT", self.uri + '/notifications/' + self.nt_id,
                       json.dumps(postdata))
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 204)
-        req = request(self, self.root, "GET", self.uri + '/notifications')
+        req = request(self, self.root, b"GET", self.uri + '/notifications')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -1190,10 +1193,10 @@ class MaasAPITests(SynchronousTestCase):
         """
         Delete a notification target
         """
-        req = request(self, self.root, "DELETE", self.uri + '/notifications/' + self.nt_id)
+        req = request(self, self.root, b"DELETE", self.uri + '/notifications/' + self.nt_id)
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 204)
-        req = request(self, self.root, "GET", self.uri + '/notifications')
+        req = request(self, self.root, b"GET", self.uri + '/notifications')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -1209,7 +1212,7 @@ class MaasAPITests(SynchronousTestCase):
         Deleting a notification that does not exist causes a 404.
         """
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "DELETE", '{0}/notifications/ntWhut'.format(self.uri)))
+            json_request(self, self.root, b"DELETE", '{0}/notifications/ntWhut'.format(self.uri)))
         self.assertEquals(resp.code, 404)
         self.assertEquals(data['details'], 'Object "Notification" with key "ntWhut" does not exist')
 
@@ -1218,11 +1221,11 @@ class MaasAPITests(SynchronousTestCase):
         Update a notification plan
         """
         postdata = {'id': self.np_id, 'label': 'changed'}
-        req = request(self, self.root, "PUT", self.uri + '/notification_plans/' + self.np_id,
+        req = request(self, self.root, b"PUT", self.uri + '/notification_plans/' + self.np_id,
                       json.dumps(postdata))
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 204)
-        req = request(self, self.root, "GET", self.uri + '/notification_plans/' + self.np_id)
+        req = request(self, self.root, b"GET", self.uri + '/notification_plans/' + self.np_id)
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -1232,10 +1235,10 @@ class MaasAPITests(SynchronousTestCase):
         """
         Delete a notification plan
         """
-        req = request(self, self.root, "DELETE", self.uri + '/notification_plans/' + self.np_id)
+        req = request(self, self.root, b"DELETE", self.uri + '/notification_plans/' + self.np_id)
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 204)
-        req = request(self, self.root, "GET", self.uri + '/notification_plans')
+        req = request(self, self.root, b"GET", self.uri + '/notification_plans')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -1251,7 +1254,7 @@ class MaasAPITests(SynchronousTestCase):
         Deleting a notification plan that does not exist causes a 404.
         """
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "DELETE", '{0}/notification_plans/npWhut'.format(self.uri)))
+            json_request(self, self.root, b"DELETE", '{0}/notification_plans/npWhut'.format(self.uri)))
         self.assertEquals(resp.code, 404)
         self.assertEquals(data['details'], 'Object "NotificationPlan" with key "npWhut" does not exist')
 
@@ -1259,7 +1262,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         Get notification types
         """
-        req = request(self, self.root, "GET", self.uri + '/notification_types')
+        req = request(self, self.root, b"GET", self.uri + '/notification_types')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -1269,7 +1272,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         Get a specific suppression
         """
-        req = request(self, self.root, "GET", self.uri + '/suppressions/' + self.sp_id)
+        req = request(self, self.root, b"GET", self.uri + '/suppressions/' + self.sp_id)
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -1283,7 +1286,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         Get all the suppressions
         """
-        req = request(self, self.root, "GET", self.uri + '/suppressions')
+        req = request(self, self.root, b"GET", self.uri + '/suppressions')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -1295,11 +1298,11 @@ class MaasAPITests(SynchronousTestCase):
         Update an suppression
         """
         postdata = {'id': self.sp_id, 'label': 'changed'}
-        req = request(self, self.root, "PUT", self.uri + '/suppressions/' + self.sp_id,
+        req = request(self, self.root, b"PUT", self.uri + '/suppressions/' + self.sp_id,
                       json.dumps(postdata))
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 204)
-        req = request(self, self.root, "GET", self.uri + '/suppressions/' + self.sp_id)
+        req = request(self, self.root, b"GET", self.uri + '/suppressions/' + self.sp_id)
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -1309,10 +1312,10 @@ class MaasAPITests(SynchronousTestCase):
         """
         Delete an suppression
         """
-        req = request(self, self.root, "DELETE", self.uri + '/suppressions/' + self.sp_id)
+        req = request(self, self.root, b"DELETE", self.uri + '/suppressions/' + self.sp_id)
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 204)
-        req = request(self, self.root, "GET", self.uri + '/suppressions')
+        req = request(self, self.root, b"GET", self.uri + '/suppressions')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -1328,7 +1331,7 @@ class MaasAPITests(SynchronousTestCase):
         Deleting a suppression that does not exist causes a 404.
         """
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "DELETE", '{0}/suppressions/spWhut'.format(self.uri)))
+            json_request(self, self.root, b"DELETE", '{0}/suppressions/spWhut'.format(self.uri)))
         self.assertEquals(resp.code, 404)
         self.assertEquals(data['details'], 'Object "Suppression" with key "spWhut" does not exist')
 
@@ -1336,7 +1339,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         List the monitoring zones
         """
-        req = request(self, self.root, "GET", self.uri + '/monitoring_zones')
+        req = request(self, self.root, b"GET", self.uri + '/monitoring_zones')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -1347,7 +1350,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         List the alarm examples
         """
-        req = request(self, self.root, "GET", self.uri + '/alarm_examples')
+        req = request(self, self.root, b"GET", self.uri + '/alarm_examples')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -1358,7 +1361,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         test_alarm_count_per_np
         """
-        req = request(self, self.root, "GET", self.uri + '/views/alarmCountsPerNp')
+        req = request(self, self.root, b"GET", self.uri + '/views/alarmCountsPerNp')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -1369,17 +1372,17 @@ class MaasAPITests(SynchronousTestCase):
         """
         test_alarms_by_np
         """
-        req = request(self, self.root, "GET", self.uri + '/views/overview')
+        req = request(self, self.root, b"GET", self.uri + '/views/overview')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         alarm = self.get_responsebody(resp)['values'][0]['alarms'][0]
         alarm['notification_plan_id'] = self.np_id
-        req = request(self, self.root, "PUT",
+        req = request(self, self.root, b"PUT",
                       self.uri + '/entities/' + self.entity_id + '/alarms/' + self.alarm_id,
                       json.dumps(alarm))
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 204)
-        req = request(self, self.root, "GET", self.uri + '/views/alarmsByNp/' + self.np_id)
+        req = request(self, self.root, b"GET", self.uri + '/views/alarmsByNp/' + self.np_id)
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -1389,17 +1392,17 @@ class MaasAPITests(SynchronousTestCase):
         """
         Cant delete a notificationPlan that's being pointed to by alarms
         """
-        req = request(self, self.root, "GET", self.uri + '/views/overview')
+        req = request(self, self.root, b"GET", self.uri + '/views/overview')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         alarm = self.get_responsebody(resp)['values'][0]['alarms'][0]
         alarm['notification_plan_id'] = self.np_id
-        req = request(self, self.root, "PUT",
+        req = request(self, self.root, b"PUT",
                       self.uri + '/entities/' + self.entity_id + '/alarms/' + self.alarm_id,
                       json.dumps(alarm))
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 204)
-        req = request(self, self.root, "DELETE", self.uri + '/notification_plans/' + self.np_id)
+        req = request(self, self.root, b"DELETE", self.uri + '/notification_plans/' + self.np_id)
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 403)
         data = self.get_responsebody(resp)
@@ -1410,17 +1413,17 @@ class MaasAPITests(SynchronousTestCase):
         """
         Reset session, remove all objects
         """
-        req = request(self, self.root, "GET", self.uri + '/entities')
+        req = request(self, self.root, b"GET", self.uri + '/entities')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
         self.assertEquals(data['metadata']['count'], 1)
 
-        req = request(self, self.root, "GET", self.uri + '/mimic/reset')
+        req = request(self, self.root, b"GET", self.uri + '/mimic/reset')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
 
-        req = request(self, self.root, "GET", self.uri + '/entities')
+        req = request(self, self.root, b"GET", self.uri + '/entities')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -1430,7 +1433,7 @@ class MaasAPITests(SynchronousTestCase):
         """
         Create an entity with weird letters in the name.
         """
-        req = request(self, self.root, "POST", self.uri + '/entities',
+        req = request(self, self.root, b"POST", self.uri + '/entities',
                       json.dumps({'label': u'\u0CA0_\u0CA0'}))
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 201)
@@ -1440,13 +1443,13 @@ class MaasAPITests(SynchronousTestCase):
         The overview call returns paginated results.
         """
         self.createEntity('entity-2')
-        req = request(self, self.root, "GET", self.uri + '/views/overview?limit=1')
+        req = request(self, self.root, b"GET", self.uri + '/views/overview?limit=1')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
         self.assertEquals(data['values'][0]['entity']['label'], 'ItsAnEntity')
 
-        req = request(self, self.root, "GET", self.uri +
+        req = request(self, self.root, b"GET", self.uri +
                       '/views/overview?marker=' + data['metadata']['next_marker'])
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
@@ -1458,7 +1461,7 @@ class MaasAPITests(SynchronousTestCase):
         If the pagination marker is not present in the entities list,
         the paginated overview call returns results from the beginning.
         """
-        req = request(self, self.root, "GET", self.uri + '/views/overview?marker=enDoesNotExist')
+        req = request(self, self.root, b"GET", self.uri + '/views/overview?marker=enDoesNotExist')
         resp = self.successResultOf(req)
         self.assertEquals(resp.code, 200)
         data = self.get_responsebody(resp)
@@ -1470,7 +1473,7 @@ class MaasAPITests(SynchronousTestCase):
         regardless if other entities exist.
         """
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "GET",
+            json_request(self, self.root, b"GET",
                          '{0}/views/overview?entityId={1}'.format(
                              self.uri, self.entity_id)))
         self.assertEquals(resp.code, 200)
@@ -1482,7 +1485,7 @@ class MaasAPITests(SynchronousTestCase):
         If the user passes in a non-existing entity ID, a 404 is returned.
         """
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "GET",
+            json_request(self, self.root, b"GET",
                          '{0}/views/overview?entityId={1}'.format(
                              self.uri, 'enDoesNotExist')))
         self.assertEquals(resp.code, 404)
@@ -1494,7 +1497,7 @@ class MaasAPITests(SynchronousTestCase):
         using the control API.
         """
         resp = self.successResultOf(
-            request(self, self.root, "POST",
+            request(self, self.root, b"POST",
                     '{0}/entities/{1}/alarms/{2}/states'.format(
                         self.ctl_uri, self.entity_id, self.alarm_id),
                     json.dumps({'state': 'CRITICAL',
@@ -1502,7 +1505,7 @@ class MaasAPITests(SynchronousTestCase):
                                 'status': 'It\'s OVER... NINE... THOUSAND!!1'})))
         self.assertEquals(resp.code, 201)
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "GET", '{0}/views/latest_alarm_states'.format(self.uri)))
+            json_request(self, self.root, b"GET", '{0}/views/latest_alarm_states'.format(self.uri)))
         self.assertEquals(resp.code, 200)
         self.assertEquals(data['values'][0]['latest_alarm_states'][0]['state'], 'CRITICAL')
 
@@ -1512,7 +1515,7 @@ class MaasAPITests(SynchronousTestCase):
         the previous state is set correctly.
         """
         resp = self.successResultOf(
-            request(self, self.root, "POST",
+            request(self, self.root, b"POST",
                     '{0}/entities/{1}/alarms/{2}/states'.format(
                         self.ctl_uri, self.entity_id, self.alarm_id),
                     json.dumps({'state': 'CRITICAL',
@@ -1520,14 +1523,14 @@ class MaasAPITests(SynchronousTestCase):
                                 'status': 'It\'s OVER... NINE... THOUSAND!!1'})))
         self.assertEquals(resp.code, 201)
         resp = self.successResultOf(
-            request(self, self.root, "POST",
+            request(self, self.root, b"POST",
                     '{0}/entities/{1}/alarms/{2}/states'.format(
                         self.ctl_uri, self.entity_id, self.alarm_id),
                     json.dumps({'state': 'OK',
                                 'status': 'Meh'})))
         self.assertEquals(resp.code, 201)
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "GET", '{0}/views/latest_alarm_states'.format(self.uri)))
+            json_request(self, self.root, b"GET", '{0}/views/latest_alarm_states'.format(self.uri)))
         self.assertEquals(resp.code, 200)
         self.assertEquals(data['values'][0]['latest_alarm_states'][0]['previous_state'], 'CRITICAL')
 
@@ -1537,7 +1540,7 @@ class MaasAPITests(SynchronousTestCase):
         Mimic returns a 404.
         """
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "POST",
+            json_request(self, self.root, b"POST",
                          '{0}/entities/{1}/alarms/{2}/states'.format(
                              self.ctl_uri, self.entity_id, 'alDoesNotExist'),
                          json.dumps({'state': 'OK', 'status': 'bogus'})))
@@ -1550,7 +1553,7 @@ class MaasAPITests(SynchronousTestCase):
         Mimic returns 400 Bad Request.
         """
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "POST",
+            json_request(self, self.root, b"POST",
                          '{0}/entities/{1}/alarms/{2}/states'.format(
                              self.ctl_uri, self.entity_id, self.alarm_id),
                          json.dumps({'status': 'This wont work'})))
@@ -1564,7 +1567,7 @@ class MaasAPITests(SynchronousTestCase):
         Mimic returns 400 Bad Request.
         """
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "POST",
+            json_request(self, self.root, b"POST",
                          '{0}/entities/{1}/alarms/{2}/states'.format(
                              self.ctl_uri, self.entity_id, self.alarm_id),
                          json.dumps({'state': 'WARNING'})))
@@ -1577,7 +1580,7 @@ class MaasAPITests(SynchronousTestCase):
         Trying to set the overrides on a check that does not exist causes a 404.
         """
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "PUT",
+            json_request(self, self.root, b"PUT",
                          '{0}/entities/{1}/checks/chWhut/metrics/available'.format(
                              self.ctl_uri, self.entity_id),
                          json.dumps({'type': 'squarewave'})))
@@ -1592,7 +1595,7 @@ class MaasAPITests(SynchronousTestCase):
         causes a 400 Bad Request response.
         """
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "PUT",
+            json_request(self, self.root, b"PUT",
                          '{0}/entities/{1}/checks/{2}/metrics/available'.format(
                              self.ctl_uri, self.entity_id, self.check_id),
                          json.dumps({'type': 'lolwut'})))
@@ -1605,7 +1608,7 @@ class MaasAPITests(SynchronousTestCase):
         Users can override metrics using a square wave function.
         """
         resp = self.successResultOf(
-            request(self, self.root, "PUT",
+            request(self, self.root, b"PUT",
                     '{0}/entities/{1}/checks/{2}/metrics/available'.format(
                         self.ctl_uri, self.entity_id, self.check_id),
                     json.dumps({'type': 'squarewave',
@@ -1616,7 +1619,7 @@ class MaasAPITests(SynchronousTestCase):
                                 'monitoring_zones': ['mzord']})))
         self.assertEquals(resp.code, 204)
         (resp, data) = self.successResultOf(
-            json_request(self, self.root, "POST",
+            json_request(self, self.root, b"POST",
                          '{0}/__experiments/multiplot?from=1&to=99&points=2'.format(self.uri),
                          json.dumps({'metrics': [{'entity_id': self.entity_id,
                                                   'check_id': self.check_id,

--- a/mimic/test/test_mailgun.py
+++ b/mimic/test/test_mailgun.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from six.moves.urllib.parse import urlencode
 
 from twisted.trial.unittest import SynchronousTestCase
@@ -26,7 +28,7 @@ class MailGunAPITests(SynchronousTestCase):
         Create a message and validate the response is the
         """
         (response, content) = self.successResultOf(json_request(
-            self, root, "POST", "/cloudmonitoring.rackspace.com/messages",
+            self, root, b"POST", "/cloudmonitoring.rackspace.com/messages",
             urlencode(data)))
         self.assertEqual(200, response.code)
 
@@ -38,7 +40,7 @@ class MailGunAPITests(SynchronousTestCase):
         if to_filter:
             url = "/cloudmonitoring.rackspace.com/messages?to={0}".format(to_filter)
         (response, content) = self.successResultOf(json_request(
-            self, root, "GET", url))
+            self, root, b"GET", url))
         self.assertEqual(200, response.code)
         return content
 
@@ -57,7 +59,7 @@ class MailGunAPITests(SynchronousTestCase):
         when the `to` address is `bademail@example.com`.
         """
         response = self.successResultOf(request(
-            self, self.root, "POST", "/cloudmonitoring.rackspace.com/messages",
+            self, self.root, b"POST", "/cloudmonitoring.rackspace.com/messages",
             urlencode({"to": "bademail@example.com"})))
         self.assertEqual(500, response.code)
 
@@ -67,7 +69,7 @@ class MailGunAPITests(SynchronousTestCase):
         when the `to` address is `failingemail@example.com`.
         """
         response = self.successResultOf(request(
-            self, self.root, "POST", "/cloudmonitoring.rackspace.com/messages",
+            self, self.root, b"POST", "/cloudmonitoring.rackspace.com/messages",
             urlencode({"to": "failingemail@example.com"})))
         self.assertEqual(400, response.code)
 
@@ -103,12 +105,12 @@ class MailGunAPITests(SynchronousTestCase):
         """
         for x in range(5):
             response = self.successResultOf(request(
-                self, self.root, "POST", "/cloudmonitoring.rackspace.com/messages",
+                self, self.root, b"POST", "/cloudmonitoring.rackspace.com/messages",
                 urlencode({"to": "bademail@example.com", "subject": "test"})))
             self.assertEqual(500, response.code)
 
         (response, content) = self.successResultOf(json_request(
-            self, self.root, "GET", "/cloudmonitoring.rackspace.com/messages/500s"))
+            self, self.root, b"GET", "/cloudmonitoring.rackspace.com/messages/500s"))
         self.assertEqual(200, response.code)
         self.assertEqual(content["count"], 5)
 
@@ -124,6 +126,6 @@ class MailGunAPITests(SynchronousTestCase):
 
         (response, content) = self.successResultOf(json_request(
             self, self.root,
-            "GET", "/cloudmonitoring.rackspace.com/messages/headers?to=email@example.com"))
+            b"GET", "/cloudmonitoring.rackspace.com/messages/headers?to=email@example.com"))
         self.assertEqual(200, response.code)
         self.assertTrue(content["email@example.com"])

--- a/mimic/test/test_noit.py
+++ b/mimic/test/test_noit.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import uuid
 import xmltodict
 from twisted.trial.unittest import SynchronousTestCase
@@ -38,7 +40,7 @@ class NoitAPITests(SynchronousTestCase):
         url = "noit/checks/set/{0}".format(self.check_id)
 
         (self.response, response_body) = self.successResultOf(
-            request_with_content(self, self.root, "PUT", url,
+            request_with_content(self, self.root, b"PUT", url,
                                  body=self.create_check_xml_payload))
         self.create_json_response = xmltodict.parse(response_body)
 
@@ -47,7 +49,7 @@ class NoitAPITests(SynchronousTestCase):
         Test to verify :func:`get_all_checks` on ``GET /config/checks``
         """
         (response, body) = self.successResultOf(
-            request_with_content(self, self.root, "GET", "noit/config/checks"))
+            request_with_content(self, self.root, b"GET", "noit/config/checks"))
         self.assertEqual(response.code, 200)
         json_response = xmltodict.parse(body)
         self.assertTrue(len(json_response["checks"]["check"]) > 0)
@@ -57,7 +59,7 @@ class NoitAPITests(SynchronousTestCase):
         Test to verify :func:`test_check` on ``POST /checks/test``
         """
         (response, body) = self.successResultOf(
-            request_with_content(self, self.root, "POST", "noit/checks/test",
+            request_with_content(self, self.root, b"POST", "noit/checks/test",
                                  body=self.create_check_xml_payload))
         json_response = xmltodict.parse(body)
         self.assertEqual(response.code, 200)
@@ -71,7 +73,7 @@ class NoitAPITests(SynchronousTestCase):
         """
         self.create_check["check"]["attributes"]["module"] = 'selfcheck'
         (response, body) = self.successResultOf(
-            request_with_content(self, self.root, "POST", "noit/checks/test",
+            request_with_content(self, self.root, b"POST", "noit/checks/test",
                                  body=xmltodict.unparse(self.create_check).encode('utf-8')))
         json_response = xmltodict.parse(body)
         self.assertEqual(response.code, 200)
@@ -93,7 +95,7 @@ class NoitAPITests(SynchronousTestCase):
         """
         self.create_check["check"]["attributes"]["name"] = "rename"
         (response, body) = self.successResultOf(
-            request_with_content(self, self.root, "PUT",
+            request_with_content(self, self.root, b"PUT",
                                  "noit/checks/set/{0}".format(self.check_id),
                                  body=xmltodict.unparse(self.create_check
                                                         ).encode("utf-8")))
@@ -107,7 +109,7 @@ class NoitAPITests(SynchronousTestCase):
         Test to verify :func:`get_checks` on ``GET /checks/show/<check_id>``
         """
         (get_response, body) = self.successResultOf(
-            request_with_content(self, self.root, "GET",
+            request_with_content(self, self.root, b"GET",
                                  "noit/checks/show/{0}".format(self.check_id)))
         json_response = xmltodict.parse(body)
         self.assertEqual(get_response.code, 200)
@@ -120,7 +122,7 @@ class NoitAPITests(SynchronousTestCase):
         ``DELETE /checks/delete/<check_id>``
         """
         (del_response, body) = self.successResultOf(
-            request_with_content(self, self.root, "DELETE",
+            request_with_content(self, self.root, b"DELETE",
                                  "noit/checks/delete/{0}".format(self.check_id)))
         self.assertEqual(del_response.code, 200)
 
@@ -130,7 +132,7 @@ class NoitAPITests(SynchronousTestCase):
         when the check_id was never created.
         """
         (del_response, body) = self.successResultOf(
-            request_with_content(self, self.root, "DELETE",
+            request_with_content(self, self.root, b"DELETE",
                                  "noit/checks/delete/1234556"))
         self.assertEqual(del_response.code, 404)
 
@@ -140,10 +142,10 @@ class NoitAPITests(SynchronousTestCase):
         when the xml cannot be parsed.
         """
         (response, body) = self.successResultOf(
-            request_with_content(self, self.root, "PUT",
+            request_with_content(self, self.root, b"PUT",
                                  "noit/checks/set/{0}".format(self.check_id),
                                  body=self.create_check_xml_payload.replace(
-                                     '</check>', ' abc')))
+                                     b'</check>', b' abc')))
         self.assertEqual(response.code, 500)
 
     def test_create_check_fails_with_500_for_invalid_check_id(self):
@@ -152,7 +154,7 @@ class NoitAPITests(SynchronousTestCase):
         when the xml cannot be parsed.
         """
         (response, body) = self.successResultOf(
-            request_with_content(self, self.root, "PUT",
+            request_with_content(self, self.root, b"PUT",
                                  "noit/checks/set/123444",
                                  body=self.create_check_xml_payload))
         self.assertEqual(response.code, 500)
@@ -166,7 +168,7 @@ class NoitAPITests(SynchronousTestCase):
         invalid_check_xml_payload = xmltodict.unparse(self.create_check
                                                       ).encode("utf-8")
         (response, body) = self.successResultOf(
-            request_with_content(self, self.root, "PUT",
+            request_with_content(self, self.root, b"PUT",
                                  "noit/checks/set/{0}".format(self.check_id),
                                  body=invalid_check_xml_payload))
         self.assertEqual(response.code, 404)
@@ -180,7 +182,7 @@ class NoitAPITests(SynchronousTestCase):
         invalid_check_xml_payload = xmltodict.unparse(self.create_check
                                                       ).encode("utf-8")
         (response, body) = self.successResultOf(
-            request_with_content(self, self.root, "POST",
+            request_with_content(self, self.root, b"POST",
                                  "noit/checks/test".format(self.check_id),
                                  body=invalid_check_xml_payload))
         self.assertEqual(response.code, 404)
@@ -194,7 +196,7 @@ class NoitAPITests(SynchronousTestCase):
         check_xml_payload = xmltodict.unparse(self.create_check
                                               ).encode("utf-8")
         (response, body) = self.successResultOf(
-            request_with_content(self, self.root, "POST",
+            request_with_content(self, self.root, b"POST",
                                  "noit/checks/test".format(self.check_id),
                                  body=check_xml_payload))
         json_response = xmltodict.parse(body)

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -1,6 +1,8 @@
 """
 Tests for :mod:`nova_api` and :mod:`nova_objects`.
 """
+from __future__ import unicode_literals
+
 import json
 from six.moves.urllib.parse import urlencode, parse_qs
 
@@ -26,7 +28,7 @@ def status_of_server(test_case, server_id):
     """
     Retrieve the status of a server.
     """
-    get_server = request(test_case, test_case.root, "GET",
+    get_server = request(test_case, test_case.root, b"GET",
                          test_case.uri + '/servers/' + server_id)
     get_server_response = test_case.successResultOf(get_server)
     get_server_response_body = test_case.successResultOf(
@@ -74,7 +76,7 @@ def create_server(helper, name=None, imageRef=None, flavorRef=None,
     create_server = request_func(
         helper.test_case,
         helper.root,
-        "POST",
+        b"POST",
         '{0}/servers'.format(helper.get_service_endpoint(
             "cloudServersOpenStack", region)),
         body
@@ -102,7 +104,7 @@ def delete_server(helper, server_id):
     Delete server
     """
     d = request_with_content(
-        helper.test_case, helper.root, "DELETE",
+        helper.test_case, helper.root, b"DELETE",
         '{0}/servers/{1}'.format(helper.uri, server_id))
     resp, body = helper.test_case.successResultOf(d)
     helper.test_case.assertEqual(resp.code, 204)
@@ -113,7 +115,7 @@ def update_metdata_item(helper, server_id, key, value):
     Update metadata item
     """
     d = request_with_content(
-        helper.test_case, helper.root, "PUT",
+        helper.test_case, helper.root, b"PUT",
         '{0}/servers/{1}/metadata/{2}'.format(helper.uri, server_id, key),
         json.dumps({'meta': {key: value}}))
     resp, body = helper.test_case.successResultOf(d)
@@ -125,7 +127,7 @@ def update_metdata(helper, server_id, metadata):
     Update metadata
     """
     d = request_with_content(
-        helper.test_case, helper.root, "PUT",
+        helper.test_case, helper.root, b"PUT",
         '{0}/servers/{1}/metadata'.format(helper.uri, server_id),
         json.dumps({'metadata': metadata}))
     resp, body = helper.test_case.successResultOf(d)
@@ -137,7 +139,7 @@ def update_status(helper, control_endpoint, server_id, status):
     Update server status
     """
     d = request_with_content(
-        helper.test_case, helper.root, "POST",
+        helper.test_case, helper.root, b"POST",
         control_endpoint + "/attributes/",
         json.dumps({"status": {server_id: status}}))
     resp, body = helper.test_case.successResultOf(d)
@@ -192,7 +194,7 @@ class NovaAPITests(SynchronousTestCase):
         # Make sure we report on proper state.
         server_id = response_body['server']['id']
         get_server = request(
-            self, self.root, "GET", self.uri + '/servers/' + server_id
+            self, self.root, b"GET", self.uri + '/servers/' + server_id
         )
         get_server_response = self.successResultOf(get_server)
         response_body = self.successResultOf(
@@ -259,7 +261,7 @@ class NovaAPITests(SynchronousTestCase):
         self.assertEqual(resp.code, 202)
         server_id = body['server']['id']
         get_server = request(
-            self, self.root, "GET", self.uri + '/servers/' + server_id
+            self, self.root, b"GET", self.uri + '/servers/' + server_id
         )
         get_server_response = self.successResultOf(get_server)
         response_body = self.successResultOf(
@@ -280,7 +282,7 @@ class NovaAPITests(SynchronousTestCase):
         create_resp, create_body = create_server(self.helper, body_override=body)
         server_id = create_body['server']['id']
         get_server = request(
-            self, self.root, "GET", self.uri + '/servers/' + server_id
+            self, self.root, b"GET", self.uri + '/servers/' + server_id
         )
         get_server_response = self.successResultOf(get_server)
         response_body = self.successResultOf(
@@ -303,7 +305,7 @@ class NovaAPITests(SynchronousTestCase):
         """
         Test to verify :func:`list_servers` on ``GET /v2.0/<tenant_id>/servers``
         """
-        list_servers = request(self, self.root, "GET", self.uri + '/servers')
+        list_servers = request(self, self.root, b"GET", self.uri + '/servers')
         list_servers_response = self.successResultOf(list_servers)
         list_servers_response_body = self.successResultOf(
             treq.json_content(list_servers_response))
@@ -319,7 +321,7 @@ class NovaAPITests(SynchronousTestCase):
         when a server with that name exists
         """
         list_servers = request(
-            self, self.root, "GET", self.uri + '/servers?name=' + self.server_name)
+            self, self.root, b"GET", self.uri + '/servers?name=' + self.server_name)
         list_servers_response = self.successResultOf(list_servers)
         list_servers_response_body = self.successResultOf(
             treq.json_content(list_servers_response))
@@ -334,7 +336,7 @@ class NovaAPITests(SynchronousTestCase):
         when a server with that name does not exist
         """
         list_servers = request(
-            self, self.root, "GET", self.uri + '/servers?name=no_server')
+            self, self.root, b"GET", self.uri + '/servers?name=no_server')
         list_servers_response = self.successResultOf(list_servers)
         list_servers_response_body = self.successResultOf(
             treq.json_content(list_servers_response))
@@ -347,7 +349,7 @@ class NovaAPITests(SynchronousTestCase):
         when the server_id exists
         """
         get_server = request(
-            self, self.root, "GET", self.uri + '/servers/' + self.server_id)
+            self, self.root, b"GET", self.uri + '/servers/' + self.server_id)
         get_server_response = self.successResultOf(get_server)
         get_server_response_body = self.successResultOf(
             treq.json_content(get_server_response))
@@ -366,7 +368,7 @@ class NovaAPITests(SynchronousTestCase):
         when the server_id does not exist
         """
         response, body = self.successResultOf(json_request(
-            self, self.root, "GET", self.uri + '/servers/test-server-id'))
+            self, self.root, b"GET", self.uri + '/servers/test-server-id'))
         self.assertEqual(response.code, 404)
         self.assertEqual(body, {
             "itemNotFound": {
@@ -380,7 +382,7 @@ class NovaAPITests(SynchronousTestCase):
         Test to verify :func:`list_servers_with_details` on ``GET /v2.0/<tenant_id>/servers/detail``
         """
         list_servers_detail = request(
-            self, self.root, "GET", self.uri + '/servers/detail')
+            self, self.root, b"GET", self.uri + '/servers/detail')
         list_servers_detail_response = self.successResultOf(
             list_servers_detail)
         list_servers_detail_response_body = self.successResultOf(
@@ -403,7 +405,7 @@ class NovaAPITests(SynchronousTestCase):
         """
         create_server(self.helper, name="non-matching-name")
         response, body = self.successResultOf(json_request(
-            self, self.root, "GET",
+            self, self.root, b"GET",
             "{0}/servers/detail?name={1}".format(self.uri, self.server_name)))
         self.assertEqual(response.code, 200)
         self.assertIsNot(body['servers'], None)
@@ -420,7 +422,7 @@ class NovaAPITests(SynchronousTestCase):
         there aren't any that match the given name
         """
         response, body = self.successResultOf(json_request(
-            self, self.root, "GET",
+            self, self.root, b"GET",
             '{0}/servers/detail?name=no_server'.format(self.uri)))
         self.assertEqual(response.code, 200)
         self.assertEqual(len(body['servers']), 0)
@@ -430,14 +432,14 @@ class NovaAPITests(SynchronousTestCase):
         Test to verify :func:`delete_server` on ``DELETE /v2.0/<tenant_id>/servers/<server_id>``
         """
         delete_server = request(
-            self, self.root, "DELETE", self.uri + '/servers/' + self.server_id)
+            self, self.root, b"DELETE", self.uri + '/servers/' + self.server_id)
         delete_server_response = self.successResultOf(delete_server)
         self.assertEqual(delete_server_response.code, 204)
         self.assertEqual(self.successResultOf(treq.content(delete_server_response)),
                          b"")
         # Get and see if server actually got deleted
         get_server = request(
-            self, self.root, "GET", self.uri + '/servers/' + self.server_id)
+            self, self.root, b"GET", self.uri + '/servers/' + self.server_id)
         get_server_response = self.successResultOf(get_server)
         self.assertEqual(get_server_response.code, 404)
 
@@ -447,7 +449,7 @@ class NovaAPITests(SynchronousTestCase):
         when the server_id does not exist
         """
         delete_server = request(
-            self, self.root, "DELETE", self.uri + '/servers/test-server-id')
+            self, self.root, b"DELETE", self.uri + '/servers/test-server-id')
         delete_server_response = self.successResultOf(delete_server)
         self.assertEqual(delete_server_response.code, 404)
 
@@ -456,7 +458,7 @@ class NovaAPITests(SynchronousTestCase):
         Test to verify :func:`get_limit` on ``GET /v2.0/<tenant_id>/limits``
         """
         get_server_limits = request(
-            self, self.root, "GET", self.uri + '/limits')
+            self, self.root, b"GET", self.uri + '/limits')
         get_server_limits_response = self.successResultOf(get_server_limits)
         self.assertEqual(get_server_limits_response.code, 200)
         self.assertTrue(
@@ -466,14 +468,14 @@ class NovaAPITests(SynchronousTestCase):
         """
         Test to verify :func:`get_ips` on ``GET /v2.0/<tenant_id>/servers/<server_id>/ips``
         """
-        get_server_ips = request(self, self.root, "GET",
+        get_server_ips = request(self, self.root, b"GET",
                                  self.uri + '/servers/' + self.server_id + '/ips')
         get_server_ips_response = self.successResultOf(get_server_ips)
         get_server_ips_response_body = self.successResultOf(
             treq.json_content(get_server_ips_response))
         self.assertEqual(get_server_ips_response.code, 200)
         list_servers_detail = request(
-            self, self.root, "GET", self.uri + '/servers/detail')
+            self, self.root, b"GET", self.uri + '/servers/detail')
         list_servers_detail_response = self.successResultOf(
             list_servers_detail)
         list_servers_detail_response_body = self.successResultOf(
@@ -486,7 +488,7 @@ class NovaAPITests(SynchronousTestCase):
         Test to verify :func:`get_ips` on ``GET /v2.0/<tenant_id>/servers/<server_id>/ips``,
         when the server_id does not exist
         """
-        get_server_ips = request(self, self.root, "GET",
+        get_server_ips = request(self, self.root, b"GET",
                                  self.uri + '/servers/non-existant-server/ips')
         get_server_ips_response = self.successResultOf(get_server_ips)
         self.assertEqual(get_server_ips_response.code, 404)
@@ -501,7 +503,7 @@ class NovaAPITests(SynchronousTestCase):
                                                        "MIMIC")
         other_region_servers = self.successResultOf(
             treq.json_content(
-                self.successResultOf(request(self, self.root, "GET",
+                self.successResultOf(request(self, self.root, b"GET",
                                              service_uri + "/servers/")))
         )["servers"]
         self.assertEqual(other_region_servers, [])
@@ -517,7 +519,7 @@ class NovaAPITests(SynchronousTestCase):
 
         response, response_body = self.successResultOf(
             json_request(
-                self, self.root, "GET",
+                self, self.root, b"GET",
                 service_endpoint + '/servers'))
 
         self.assertEqual(response.code, 200)
@@ -538,7 +540,7 @@ class NovaAPITests(SynchronousTestCase):
         status = status_of_server(self, server_id)
         self.assertEqual(status, "ACTIVE")
         set_status = request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             nova_control_endpoint + "/attributes/",
             json.dumps(status_modification)
         )
@@ -566,7 +568,7 @@ class NovaAPITests(SynchronousTestCase):
         self.assertEqual(status, "ACTIVE")
         self.assertEqual(second_status, "ACTIVE")
         set_status = request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             nova_control_endpoint + "/attributes/",
             json.dumps(status_modification)
         )
@@ -586,7 +588,7 @@ class NovaAPITests(SynchronousTestCase):
         """
         resize_request = json.dumps({"resize": {"flavorRef": "2"}})
         response, body = self.successResultOf(json_request(
-            self, self.root, "POST", self.uri + '/servers/nothing/action', resize_request))
+            self, self.root, b"POST", self.uri + '/servers/nothing/action', resize_request))
         self.assertEqual(response.code, 404)
         self.assertEqual(body, {
             "itemNotFound": {
@@ -596,13 +598,13 @@ class NovaAPITests(SynchronousTestCase):
         })
 
         existing_server = request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             self.uri + '/servers/' + self.server_id + '/action', resize_request)
         existing_server_response = self.successResultOf(existing_server)
         self.assertEqual(existing_server_response.code, 202)
 
         get_resized_server = request(
-            self, self.root, "GET", self.uri + '/servers/' + self.server_id)
+            self, self.root, b"GET", self.uri + '/servers/' + self.server_id)
         get_server_response = self.successResultOf(get_resized_server)
         get_server_response_body = self.successResultOf(
             treq.json_content(get_server_response))
@@ -610,7 +612,7 @@ class NovaAPITests(SynchronousTestCase):
 
         no_resize_request = json.dumps({"non_supported_action": {"flavorRef": "2"}})
         response, body = self.successResultOf(json_request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             self.uri + '/servers/' + self.server_id + '/action', no_resize_request))
         self.assertEqual(response.code, 400)
         self.assertEqual(body, {
@@ -622,7 +624,7 @@ class NovaAPITests(SynchronousTestCase):
 
         no_flavorref_request = json.dumps({"resize": {"missingflavorRef": "5"}})
         response, body = self.successResultOf(json_request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             self.uri + '/servers/' + self.server_id + '/action', no_flavorref_request))
         self.assertEqual(response.code, 400)
         self.assertEqual(body, {
@@ -645,7 +647,7 @@ class NovaAPITests(SynchronousTestCase):
         resize_request = json.dumps({"resize": {"flavorRef": "2"}})
 
         response, body = self.successResultOf(json_request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             self.uri + '/servers/' + self.server_id + '/action', confirm_request))
         self.assertEqual(response.code, 409)
         self.assertEqual(body, {
@@ -657,7 +659,7 @@ class NovaAPITests(SynchronousTestCase):
         })
 
         response, body = self.successResultOf(json_request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             self.uri + '/servers/' + self.server_id + '/action', revert_request))
         self.assertEqual(response.code, 409)
         self.assertEqual(body, {
@@ -668,34 +670,34 @@ class NovaAPITests(SynchronousTestCase):
             }
         })
 
-        request(self, self.root, "POST",
+        request(self, self.root, b"POST",
                 self.uri + '/servers/' + self.server_id + '/action', resize_request)
         confirm = request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             self.uri + '/servers/' + self.server_id + '/action', confirm_request)
         confirm_response = self.successResultOf(confirm)
         self.assertEqual(confirm_response.code, 204)
 
         resize_request = json.dumps({"resize": {"flavorRef": "10"}})
 
-        request(self, self.root, "POST",
+        request(self, self.root, b"POST",
                 self.uri + '/servers/' + self.server_id + '/action', resize_request)
 
         resized_server = request(
-            self, self.root, "GET", self.uri + '/servers/' + self.server_id)
+            self, self.root, b"GET", self.uri + '/servers/' + self.server_id)
         resized_server_response = self.successResultOf(resized_server)
         resized_server_response_body = self.successResultOf(
             treq.json_content(resized_server_response))
         self.assertEqual(resized_server_response_body['server']['flavor']['id'], '10')
 
         revert = request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             self.uri + '/servers/' + self.server_id + '/action', revert_request)
         revert_response = self.successResultOf(revert)
         self.assertEqual(revert_response.code, 202)
 
         reverted_server = request(
-            self, self.root, "GET", self.uri + '/servers/' + self.server_id)
+            self, self.root, b"GET", self.uri + '/servers/' + self.server_id)
         reverted_server_response = self.successResultOf(reverted_server)
         reverted_server_response_body = self.successResultOf(
             treq.json_content(reverted_server_response))
@@ -715,7 +717,7 @@ class NovaAPITests(SynchronousTestCase):
         rescue_request = json.dumps({"rescue": "none"})
 
         response, body = self.successResultOf(json_request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             self.uri + '/servers/' + server_id + '/action', rescue_request))
         self.assertEqual(response.code, 409)
         self.assertEqual(body, {
@@ -727,7 +729,7 @@ class NovaAPITests(SynchronousTestCase):
         })
 
         rescue = request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             self.uri + '/servers/' + self.server_id + '/action', rescue_request)
         rescue_response = self.successResultOf(rescue)
         rescue_response_body = self.successResultOf(treq.json_content(rescue_response))
@@ -744,7 +746,7 @@ class NovaAPITests(SynchronousTestCase):
         rescue_request = json.dumps({"rescue": "none"})
         unrescue_request = json.dumps({"unrescue": "null"})
         response, body = self.successResultOf(json_request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             self.uri + '/servers/' + self.server_id + '/action', unrescue_request))
         self.assertEqual(response.code, 409)
         self.assertEqual(body, {
@@ -756,10 +758,10 @@ class NovaAPITests(SynchronousTestCase):
         })
         # Put a server in rescue status
         request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             self.uri + '/servers/' + self.server_id + '/action', rescue_request)
 
-        unrescue = request(self, self.root, "POST",
+        unrescue = request(self, self.root, b"POST",
                            self.uri + '/servers/' + self.server_id + '/action', unrescue_request)
         unrescue_response = self.successResultOf(unrescue)
         self.assertEqual(unrescue_response.code, 200)
@@ -780,7 +782,7 @@ class NovaAPITests(SynchronousTestCase):
         """
         no_reboot_type_request = json.dumps({"reboot": {"missing_type": "SOFT"}})
         response, body = self.successResultOf(json_request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             self.uri + '/servers/' + self.server_id + '/action', no_reboot_type_request))
         self.assertEqual(response.code, 400)
         self.assertEqual(body, {
@@ -792,7 +794,7 @@ class NovaAPITests(SynchronousTestCase):
 
         wrong_reboot_type_request = json.dumps({"reboot": {"type": "FIRM"}})
         response, body = self.successResultOf(json_request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             self.uri + '/servers/' + self.server_id + '/action', wrong_reboot_type_request))
         self.assertEqual(response.code, 400)
         self.assertEqual(body, {
@@ -805,20 +807,20 @@ class NovaAPITests(SynchronousTestCase):
         # Soft reboot tests
         soft_reboot_request = json.dumps({"reboot": {"type": "SOFT"}})
         soft_reboot = request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             self.uri + '/servers/' + self.server_id + '/action', soft_reboot_request)
 
         soft_reboot_response = self.successResultOf(soft_reboot)
         self.assertEqual(soft_reboot_response.code, 202)
 
         response, body = self.successResultOf(json_request(
-            self, self.root, "GET", self.uri + '/servers/' + self.server_id))
+            self, self.root, b"GET", self.uri + '/servers/' + self.server_id))
         self.assertEqual(body['server']['status'], 'REBOOT')
 
         # Advance the clock 3 seconds and check status
         self.clock.advance(3)
         rebooted_server = request(
-            self, self.root, "GET", self.uri + '/servers/' + self.server_id)
+            self, self.root, b"GET", self.uri + '/servers/' + self.server_id)
         rebooted_server_response = self.successResultOf(rebooted_server)
         rebooted_server_response_body = self.successResultOf(
             treq.json_content(rebooted_server_response))
@@ -827,13 +829,13 @@ class NovaAPITests(SynchronousTestCase):
         # Hard Reboot Tests
         hard_reboot_request = json.dumps({"reboot": {"type": "HARD"}})
         hard_reboot = request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             self.uri + '/servers/' + self.server_id + '/action', hard_reboot_request)
         hard_reboot_response = self.successResultOf(hard_reboot)
         self.assertEqual(hard_reboot_response.code, 202)
 
         hard_reboot_server = request(
-            self, self.root, "GET", self.uri + '/servers/' + self.server_id)
+            self, self.root, b"GET", self.uri + '/servers/' + self.server_id)
         hard_reboot_server_response = self.successResultOf(hard_reboot_server)
         hard_reboot_server_response_body = self.successResultOf(
             treq.json_content(hard_reboot_server_response))
@@ -842,7 +844,7 @@ class NovaAPITests(SynchronousTestCase):
         # Advance clock 6 seconds and check server status
         self.clock.advance(6)
         rebooted_server = request(
-            self, self.root, "GET", self.uri + '/servers/' + self.server_id)
+            self, self.root, b"GET", self.uri + '/servers/' + self.server_id)
         rebooted_server_response = self.successResultOf(rebooted_server)
         rebooted_server_response_body = self.successResultOf(
             treq.json_content(rebooted_server_response))
@@ -860,7 +862,7 @@ class NovaAPITests(SynchronousTestCase):
         password_request = json.dumps({"changePassword": {"adminPass": "password"}})
         bad_password_request = json.dumps({"changePassword": {"Pass": "password"}})
         response, body = self.successResultOf(json_request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             self.uri + '/servers/' + self.server_id + '/action', bad_password_request))
         self.assertEqual(response.code, 400)
         self.assertEqual(body, {
@@ -870,7 +872,7 @@ class NovaAPITests(SynchronousTestCase):
             }
         })
         password_reset = request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             self.uri + '/servers/' + self.server_id + '/action', password_request)
         password_reset_response = self.successResultOf(password_reset)
         self.assertEqual(password_reset_response.code, 202)
@@ -880,7 +882,7 @@ class NovaAPITests(SynchronousTestCase):
         metadata = {"server_error": "1"}
         server_id = quick_create_server(self.helper, metadata=metadata)
         response, body = self.successResultOf(json_request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             self.uri + '/servers/' + server_id + '/action', password_request))
         self.assertEqual(response.code, 409)
         self.assertEqual(body, {
@@ -896,7 +898,7 @@ class NovaAPITests(SynchronousTestCase):
         no_imageRef_request = json.dumps({"rebuild": {"name": "new_server"}})
 
         response, body = self.successResultOf(json_request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             self.uri + '/servers/' + self.server_id + '/action', no_imageRef_request))
         self.assertEqual(response.code, 400)
         self.assertEqual(body, {
@@ -907,7 +909,7 @@ class NovaAPITests(SynchronousTestCase):
         })
 
         response, body = self.successResultOf(json_request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             self.uri + '/servers/' + self.server_id + '/action', rebuild_request))
         self.assertEqual(response.code, 202)
         self.assertTrue('adminPass' in json.dumps(body))
@@ -916,7 +918,7 @@ class NovaAPITests(SynchronousTestCase):
 
         self.clock.advance(5)
         rebuilt_server = request(
-            self, self.root, "GET", self.uri + '/servers/' + self.server_id)
+            self, self.root, b"GET", self.uri + '/servers/' + self.server_id)
         rebuilt_server_response = self.successResultOf(rebuilt_server)
         rebuilt_server_response_body = self.successResultOf(
             treq.json_content(rebuilt_server_response))
@@ -927,7 +929,7 @@ class NovaAPITests(SynchronousTestCase):
         metadata = {"server_error": "1"}
         server_id = quick_create_server(self.helper, metadata=metadata)
         response, body = self.successResultOf(json_request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             self.uri + '/servers/' + server_id + '/action', rebuild_request))
         self.assertEqual(response.code, 409)
         self.assertEqual(body, {
@@ -968,7 +970,7 @@ class NovaAPIChangesSinceTests(SynchronousTestCase):
         params = urlencode({"changes-since": changes_since})
         resp, body = self.successResultOf(
             json_request(
-                self, self.root, "GET",
+                self, self.root, b"GET",
                 '{0}/servers/detail?{1}'.format(self.uri, params)))
         self.assertEqual(resp.code, 200)
         return body['servers']
@@ -1064,7 +1066,7 @@ class NovaAPIListServerPaginationTests(SynchronousTestCase):
             url = "{0}?{1}".format(url, urlencode(params))
 
         resp, body = self.successResultOf(
-            json_request(self, self.root, "GET", url))
+            json_request(self, self.root, b"GET", url))
 
         self.assertEqual(resp.code, code)
         return body
@@ -1518,7 +1520,7 @@ class NovaAPINegativeTests(SynchronousTestCase):
         request with no body.
         """
         create_server_response, _ = create_server(
-            self.helper, body_override="")
+            self.helper, body_override=b"")
         self.assertEquals(create_server_response.code, 400)
 
     def test_create_server_request_with_invalid_body_causes_bad_request(self):
@@ -1527,7 +1529,7 @@ class NovaAPINegativeTests(SynchronousTestCase):
         request with no body.
         """
         create_server_response, _ = create_server(
-            self.helper, body_override='{ bad request: }')
+            self.helper, body_override=b'{ bad request: }')
         self.assertEquals(create_server_response.code, 400)
 
     def test_create_server_failure(self):
@@ -1577,7 +1579,7 @@ class NovaAPINegativeTests(SynchronousTestCase):
         self.assertEquals(
             create_server_response_body['computeFault']['code'], 500)
         # List servers
-        list_servers = request(self, self.root, "GET", self.uri + '/servers')
+        list_servers = request(self, self.root, b"GET", self.uri + '/servers')
         list_servers_response = self.successResultOf(list_servers)
         self.assertEquals(list_servers_response.code, 200)
         list_servers_response_body = self.successResultOf(
@@ -1636,7 +1638,7 @@ class NovaAPINegativeTests(SynchronousTestCase):
 
         # List servers with details and verify the server is in BUILD status
         list_servers = request(
-            self, self.root, "GET", self.uri + '/servers/detail')
+            self, self.root, b"GET", self.uri + '/servers/detail')
         list_servers_response = self.successResultOf(list_servers)
         self.assertEquals(list_servers_response.code, 200)
         list_servers_response_body = self.successResultOf(
@@ -1657,7 +1659,7 @@ class NovaAPINegativeTests(SynchronousTestCase):
         # create server with metadata to set status in ERROR
         server_id = quick_create_server(self.helper, metadata=metadata)
         # get server and verify status is ERROR
-        get_server = request(self, self.root, "GET", self.uri + '/servers/' +
+        get_server = request(self, self.root, b"GET", self.uri + '/servers/' +
                              server_id)
         get_server_response = self.successResultOf(get_server)
         get_server_response_body = self.successResultOf(
@@ -1677,24 +1679,24 @@ class NovaAPINegativeTests(SynchronousTestCase):
         server_id = quick_create_server(self.helper, metadata=metadata)
         # delete server and verify the response
         delete_server = request(
-            self, self.root, "DELETE", self.uri + '/servers/' + server_id)
+            self, self.root, b"DELETE", self.uri + '/servers/' + server_id)
         delete_server_response = self.successResultOf(delete_server)
         self.assertEqual(delete_server_response.code, 500)
         # get server and verify the server was not deleted
-        get_server = request(self, self.root, "GET", self.uri + '/servers/' +
+        get_server = request(self, self.root, b"GET", self.uri + '/servers/' +
                              server_id)
         get_server_response = self.successResultOf(get_server)
         self.assertEquals(get_server_response.code, 200)
         # delete server again and verify the response
         delete_server = request(
-            self, self.root, "DELETE", self.uri + '/servers/' + server_id)
+            self, self.root, b"DELETE", self.uri + '/servers/' + server_id)
         delete_server_response = self.successResultOf(delete_server)
         self.assertEqual(delete_server_response.code, 204)
         self.assertEqual(self.successResultOf(treq.content(delete_server_response)),
                          b"")
         # get server and verify the server was deleted this time
         get_server = request(
-            self, self.root, "GET", self.uri + '/servers/' + server_id)
+            self, self.root, b"GET", self.uri + '/servers/' + server_id)
         get_server_response = self.successResultOf(get_server)
         self.assertEquals(get_server_response.code, 404)
 
@@ -1755,7 +1757,7 @@ class NovaAPINegativeTests(SynchronousTestCase):
         """
         # List servers with details and verify there are no servers
         resp, list_body = self.successResultOf(json_request(
-            self, self.root, "GET", self.uri + '/servers'))
+            self, self.root, b"GET", self.uri + '/servers'))
         self.assertEqual(resp.code, 200)
         self.assertEqual(len(list_body['servers']), 0)
 
@@ -1777,7 +1779,7 @@ class NovaAPINegativeTests(SynchronousTestCase):
 
         # List servers with details and verify there are no servers
         resp, list_body = self.successResultOf(json_request(
-            self, self.root, "GET", self.uri + '/servers'))
+            self, self.root, b"GET", self.uri + '/servers'))
         self.assertEqual(resp.code, 200)
         self.assertEqual(len(list_body['servers']), 1)
         return create_server_response, body
@@ -1839,7 +1841,7 @@ class NovaAPINegativeTests(SynchronousTestCase):
             }
         }
         set_status = request(
-            self, self.root, "POST",
+            self, self.root, b"POST",
             nova_control_endpoint + "/attributes/",
             json.dumps(status_modification)
         )
@@ -1931,7 +1933,7 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         with the given request body.
         """
         return self.successResultOf(json_request(
-            self, self.root, "PUT", self.get_server_url(None) + '/metadata',
+            self, self.root, b"PUT", self.get_server_url(None) + '/metadata',
             request_body))
 
     def set_metadata_item(self, create_metadata, key, request_body):
@@ -1940,7 +1942,7 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         endpoint with the given request body.
         """
         return self.successResultOf(json_request(
-            self, self.root, "PUT",
+            self, self.root, b"PUT",
             self.get_server_url(create_metadata) + '/metadata/' + key,
             request_body))
 
@@ -1950,7 +1952,7 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         just be the one.  Get its metadata.
         """
         resp, body = self.successResultOf(json_request(
-            self, self.root, "GET", self.uri + '/servers/detail'))
+            self, self.root, b"GET", self.uri + '/servers/detail'))
         self.assertEqual(resp.code, 200)
 
         return body['servers'][0]['metadata']
@@ -2049,7 +2051,7 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         """
         metadata = {'key': 'value', 'key2': 'anothervalue'}
         response, body = self.successResultOf(json_request(
-            self, self.root, "GET",
+            self, self.root, b"GET",
             self.get_server_url(metadata) + '/metadata'))
         self.assertEqual(response.code, 200)
         self.assertEqual(body, {'metadata': metadata})
@@ -2063,7 +2065,7 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         Getting metadata on a non-existing server results in a 404.
         """
         response, body = self.successResultOf(json_request(
-            self, self.root, "GET",
+            self, self.root, b"GET",
             self.uri + '/servers/1234/metadata'))
         self.assert_no_such_server(response, body)
 
@@ -2072,7 +2074,7 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         Setting metadata on a non-existing server results in a 404.
         """
         response, body = self.successResultOf(json_request(
-            self, self.root, "PUT",
+            self, self.root, b"PUT",
             self.uri + '/servers/1234/metadata',
             {'metadata': {}}))
         self.assert_no_such_server(response, body)
@@ -2117,7 +2119,7 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         When setting metadata with an invalid request body (not a dict), it
         should return an HTTP status code of 400:malformed request body
         """
-        self.assert_malformed_body(*self.set_metadata('meh'))
+        self.assert_malformed_body(*self.set_metadata(b'meh'))
 
     def test_set_metadata_with_invalid_metadata_object(self):
         """
@@ -2162,9 +2164,9 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         how broken the metadata is.
         """
         response, body = self.successResultOf(json_request(
-            self, self.root, "PUT",
+            self, self.root, b"PUT",
             self.uri + '/servers/1234/metadata',
-            'meh'))
+            b'meh'))
         self.assert_no_such_server(response, body)
 
     def test_set_metadata_too_many_metadata_items_takes_precedence(self):
@@ -2181,7 +2183,7 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         Setting metadata item on a non-existing server results in a 404.
         """
         response, body = self.successResultOf(json_request(
-            self, self.root, "PUT",
+            self, self.root, b"PUT",
             self.uri + '/servers/1234/metadata/key',
             {'meta': {'key': 'value'}}))
         self.assert_no_such_server(response, body)
@@ -2214,7 +2216,7 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         When setting metadata item with an invalid request body, it should
         return an HTTP status code of 400:malformed request body
         """
-        self.assert_malformed_body(*self.set_metadata_item({}, "meh", "meh"))
+        self.assert_malformed_body(*self.set_metadata_item({}, "meh", b"meh"))
 
     def test_set_metadata_item_with_wrong_key_fails(self):
         """
@@ -2313,9 +2315,9 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         takes precedence over other errors.
         """
         response, body = self.successResultOf(json_request(
-            self, self.root, "PUT",
+            self, self.root, b"PUT",
             self.uri + '/servers/1234/metadata/key',
-            'meh'))
+            b'meh'))
         self.assert_no_such_server(response, body)
 
     def test_set_metadata_item_too_many_metadata_items_takes_precedence(self):

--- a/mimic/test/test_nova_images.py
+++ b/mimic/test/test_nova_images.py
@@ -2,6 +2,8 @@
 Tests for :mod:`nova_api` and :mod:`nova_objects` for images.
 """
 
+from __future__ import unicode_literals
+
 from twisted.trial.unittest import SynchronousTestCase
 
 from mimic.test.helpers import json_request, request
@@ -32,7 +34,7 @@ class NovaAPIVirtualImageTests(SynchronousTestCase):
         Get images, assert response code is 200 and return response body.
         """
         (response, content) = self.successResultOf(json_request(
-            self, self.root, "GET", self.uri + postfix))
+            self, self.root, b"GET", self.uri + postfix))
         self.assertEqual(200, response.code)
         return content
 
@@ -41,7 +43,7 @@ class NovaAPIVirtualImageTests(SynchronousTestCase):
         Test to verify :func:`get_image` when invalid image from the
         :obj: `mimic_presets` is provided.
         """
-        get_server_image = request(self, self.root, "GET", self.uri +
+        get_server_image = request(self, self.root, b"GET", self.uri +
                                    '/images/invalid_image_id')
         get_server_image_response = self.successResultOf(get_server_image)
         self.assertEqual(get_server_image_response.code, 404)
@@ -51,7 +53,7 @@ class NovaAPIVirtualImageTests(SynchronousTestCase):
         Test to verify :func:`get_image` when invalid image from the
         :obj: `mimic_presets` is provided.
         """
-        get_server_image = request(self, self.root, "GET", self.uri +
+        get_server_image = request(self, self.root, b"GET", self.uri +
                                    '/images/any-image-ending-with-Z')
         get_server_image_response = self.successResultOf(get_server_image)
         self.assertEqual(get_server_image_response.code, 404)
@@ -61,7 +63,7 @@ class NovaAPIVirtualImageTests(SynchronousTestCase):
         Test to verify :func:`get_image` on ``GET /v2.0/<tenant_id>/images/<image_id>``
         """
         response, body = self.successResultOf(json_request(
-            self, self.root, "GET", self.uri + '/images/id_not_found'))
+            self, self.root, b"GET", self.uri + '/images/id_not_found'))
 
         self.assertEqual(response.code, 404)
         self.assertEqual(body, {
@@ -164,7 +166,7 @@ class NovaAPIOnMetalImageTests(SynchronousTestCase):
         Get images, assert response code is 200 and return response body.
         """
         (response, content) = self.successResultOf(json_request(
-            self, self.root, "GET", self.uri + postfix))
+            self, self.root, b"GET", self.uri + postfix))
         self.assertEqual(200, response.code)
         return content
 
@@ -179,7 +181,7 @@ class NovaAPIOnMetalImageTests(SynchronousTestCase):
                 onmetal_id = image['id']
                 break
         response, body = self.successResultOf(json_request(
-            self, self.root, "GET", self.uri + '/images/' + onmetal_id))
+            self, self.root, b"GET", self.uri + '/images/' + onmetal_id))
         self.assertEqual(200, response.code)
         self.assertEqual(body['image']['id'], onmetal_id)
         self.assertEqual(body['image']['metadata']['flavor_classes'], 'onmetal')

--- a/mimic/test/test_queue.py
+++ b/mimic/test/test_queue.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import json
 import treq
 
@@ -24,7 +26,7 @@ class QueueAPITests(SynchronousTestCase):
         self.core = MimicCore(Clock(), [QueueApi()])
         self.root = MimicRoot(self.core).app.resource()
         self.response = request(
-            self, self.root, "POST", "/identity/v2.0/tokens",
+            self, self.root, b"POST", "/identity/v2.0/tokens",
             json.dumps({
                 "auth": {
                     "passwordCredentials": {
@@ -40,7 +42,7 @@ class QueueAPITests(SynchronousTestCase):
         self.uri = self.json_body['access']['serviceCatalog'][0]['endpoints'][0]['publicURL']
         self.queue_name = "test_queue"
         self.create_queue = request(
-            self, self.root, "PUT", self.uri + '/queues/' + self.queue_name)
+            self, self.root, b"PUT", self.uri + '/queues/' + self.queue_name)
         self.create_queue_response = self.successResultOf(self.create_queue)
 
     def test_create_queue(self):
@@ -56,7 +58,7 @@ class QueueAPITests(SynchronousTestCase):
         """
         Test to verify :func:`list_queues` on ``GET /v2.0/<tenant_id>/queues``
         """
-        list_queues = request(self, self.root, "GET", self.uri + '/queues')
+        list_queues = request(self, self.root, b"GET", self.uri + '/queues')
         list_queues_response = self.successResultOf(list_queues)
         self.assertEqual(list_queues_response.code, 200)
 
@@ -64,7 +66,7 @@ class QueueAPITests(SynchronousTestCase):
         """
         Test to verify :func:`del_queue` on ``DELETE /v2.0/<tenant_id>/servers/<queue_name>``
         """
-        delete_queue = request(self, self.root, "DELETE", self.uri + '/queues/' + self.queue_name)
+        delete_queue = request(self, self.root, b"DELETE", self.uri + '/queues/' + self.queue_name)
         delete_queue_response = self.successResultOf(delete_queue)
         self.assertEqual(delete_queue_response.code, 204)
         self.assertEqual(self.successResultOf(treq.content(delete_queue_response)), b"")

--- a/mimic/test/test_rackconnect_v3.py
+++ b/mimic/test/test_rackconnect_v3.py
@@ -1,6 +1,9 @@
 """
 Unit tests for the Rackspace RackConnect V3 API.
 """
+
+from __future__ import unicode_literals
+
 import json
 from random import randint
 from uuid import uuid4
@@ -147,7 +150,7 @@ class RackConnectTestMixin(object):
         """
         _, resp_jsons = zip(*[
             self.successResultOf(json_request(
-                self, self.helper.root, "GET",
+                self, self.helper.root, b"GET",
                 self.helper.get_service_endpoint("rackconnect", region)
                 + "/load_balancer_pools"))
             for region in self.rcv3.regions])
@@ -182,7 +185,7 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
         By default, all tenants have one load balancer pool.
         """
         response, response_json = self.successResultOf(
-            self.json_request("GET", "/load_balancer_pools"))
+            self.json_request(b"GET", "/load_balancer_pools"))
         self.assertEqual(200, response.code)
         self.assertEqual(['application/json'],
                          response.headers.getRawHeaders('content-type'))
@@ -239,11 +242,11 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
         pool.
         """
         _, pool_list_json = self.successResultOf(
-            self.json_request("GET", "/load_balancer_pools"))
+            self.json_request(b"GET", "/load_balancer_pools"))
         pool = pool_list_json[0]
 
         pool_details_response, pool_details_json = self.successResultOf(
-            self.json_request("GET",
+            self.json_request(b"GET",
                               "/load_balancer_pools/{0}".format(pool['id'])))
 
         self.assertEqual(200, pool_details_response.code)
@@ -257,7 +260,7 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
         Getting pool on a non-uuid pool id returns a 400.
         """
         response, content = self.successResultOf(
-            self.request_with_content("GET", "/load_balancer_pools/123"))
+            self.request_with_content(b"GET", "/load_balancer_pools/123"))
 
         self.assertEqual(400, response.code)
 
@@ -267,7 +270,7 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
         """
         random_pool_id = text_type(uuid4())
         response, content = self.successResultOf(
-            self.request_with_content("GET",
+            self.request_with_content(b"GET",
                                       "/load_balancer_pools/{0}".format(random_pool_id)))
 
         self.assertEqual(404, response.code)
@@ -335,7 +338,7 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
         self.helper.clock.advance(50)
         add_data = self._get_add_nodes_json()
         response, resp_json = self.successResultOf(self.json_request(
-            "POST", "/load_balancer_pools/nodes", body=add_data))
+            b"POST", "/load_balancer_pools/nodes", body=add_data))
         self.assertEqual(201, response.code)
         self._check_added_nodes_result(50, add_data, resp_json)
 
@@ -349,7 +352,7 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
                              (text_type(uuid4()), text_type(uuid4()))]
         add_data = self._get_custom_add_nodes_json(node_and_pool_ids)
         response, resp_json = self.successResultOf(self.json_request(
-            "POST", "/load_balancer_pools/nodes", body=add_data))
+            b"POST", "/load_balancer_pools/nodes", body=add_data))
         self.assertEqual(400, response.code)
 
     def test_add_bulk_pool_nodes_to_single_non_existant_pool_id_1(self):
@@ -362,7 +365,7 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
         node_and_pool_ids = [(text_type(uuid4()), pool_id)]
         add_data = self._get_custom_add_nodes_json(node_and_pool_ids)
         response, resp_json = self.successResultOf(self.json_request(
-            "POST", "/load_balancer_pools/nodes", body=add_data))
+            b"POST", "/load_balancer_pools/nodes", body=add_data))
         self.assertEqual(409, response.code)
         self.assertEqual("Load Balancer Pool {0} does not exist".format(pool_id),
                          resp_json["errors"][0])
@@ -378,7 +381,7 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
                              (text_type(uuid4()), pool_id)]
         add_data = self._get_custom_add_nodes_json(node_and_pool_ids)
         response, resp_json = self.successResultOf(self.json_request(
-            "POST", "/load_balancer_pools/nodes", body=add_data))
+            b"POST", "/load_balancer_pools/nodes", body=add_data))
         self.assertEqual(409, response.code)
         self.assertEqual("Load Balancer Pool {0} does not exist".format(pool_id),
                          resp_json["errors"][0])
@@ -395,7 +398,7 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
                              (text_type(uuid4()), text_type(uuid4()))]
         add_data = self._get_custom_add_nodes_json(node_and_pool_ids)
         response, resp_json = self.successResultOf(self.json_request(
-            "POST", "/load_balancer_pools/nodes", body=add_data))
+            b"POST", "/load_balancer_pools/nodes", body=add_data))
         self.assertEqual(409, response.code)
         self.assertEqual(len(resp_json['errors']), 2)
 
@@ -411,12 +414,12 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
         node_and_pool_ids = [(server_id, self.get_lb_ids()[0][0])]
         add_data = self._get_custom_add_nodes_json(node_and_pool_ids)
         response, resp_json = self.successResultOf(self.json_request(
-            "POST", "/load_balancer_pools/nodes", body=add_data))
+            b"POST", "/load_balancer_pools/nodes", body=add_data))
         self.assertEqual(201, response.code)
 
         # re-adding the node
         response, resp_json = self.successResultOf(self.json_request(
-            "POST", "/load_balancer_pools/nodes", body=add_data))
+            b"POST", "/load_balancer_pools/nodes", body=add_data))
         self.assertEqual(409, response.code)
         self.assertEqual("Cloud Server {0} is already a member of "
                          "Load Balancer Pool {1}".format(server_id, self.get_lb_ids()[0][0]),
@@ -434,24 +437,24 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
         node_and_pool_ids = [(server_id, self.get_lb_ids()[0][0])]
         add_data = self._get_custom_add_nodes_json(node_and_pool_ids)
         response, resp_json = self.successResultOf(self.json_request(
-            "POST", "/load_balancer_pools/nodes", body=add_data))
+            b"POST", "/load_balancer_pools/nodes", body=add_data))
         self.assertEqual(201, response.code)
 
         # get the node count for the lb pool
         _, list_json = self.successResultOf(self.json_request(
-            "GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
+            b"GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
 
         # re-add the node to a valid lb pool id as well to a non-existant pool_id
         node_and_pool_ids.append((server_id, text_type(uuid4())))
         add_data = self._get_custom_add_nodes_json(node_and_pool_ids)
         response, resp_json = self.successResultOf(self.json_request(
-            "POST", "/load_balancer_pools/nodes", body=add_data))
+            b"POST", "/load_balancer_pools/nodes", body=add_data))
         self.assertEqual(409, response.code)
         self.assertEqual(len(resp_json["errors"]), 2)
 
         # ensure no new nodes were added to the pool
         _, list_json_again = self.successResultOf(self.json_request(
-            "GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
+            b"GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
         self.assertEqual(len(list_json_again), len(list_json))
 
     def test_add_bulk_pool_nodes_errors_with_no_node_added(self):
@@ -462,20 +465,20 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
         self.helper.clock.advance(50)
         # get the node count for the lb pool
         _, list_json = self.successResultOf(self.json_request(
-            "GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
+            b"GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
         server_id = text_type(uuid4())
         random_pool_id = text_type(uuid4())
         node_and_pool_ids = [(server_id, self.get_lb_ids()[0][0]),
                              (server_id, random_pool_id)]
         add_data = self._get_custom_add_nodes_json(node_and_pool_ids)
         response, resp_json = self.successResultOf(self.json_request(
-            "POST", "/load_balancer_pools/nodes", body=add_data))
+            b"POST", "/load_balancer_pools/nodes", body=add_data))
         self.assertEqual(409, response.code)
         self.assertEqual("Load Balancer Pool {0} does not exist".format(random_pool_id),
                          resp_json["errors"][0])
         # ensure no new nodes were added to the pool
         _, list_json_again = self.successResultOf(self.json_request(
-            "GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
+            b"GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
         self.assertEqual(len(list_json_again), len(list_json))
 
     def test_add_bulk_pool_nodes_then_list(self):
@@ -486,11 +489,11 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
         self.helper.clock.advance(50)
         add_data = self._get_add_nodes_json()
         add_response, _ = self.successResultOf(self.json_request(
-            "POST", "/load_balancer_pools/nodes", body=add_data))
+            b"POST", "/load_balancer_pools/nodes", body=add_data))
         self.assertEqual(201, add_response.code)
 
         _, list_json = self.successResultOf(self.json_request(
-            "GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
+            b"GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
         self._check_added_nodes_result(50, add_data, list_json)
 
     def test_remove_bulk_pool_nodes_success(self):
@@ -502,22 +505,22 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
 
         # add first
         resp, body = self.successResultOf(self.json_request(
-            "POST", "/load_balancer_pools/nodes", body=server_data))
+            b"POST", "/load_balancer_pools/nodes", body=server_data))
 
         # ensure the node has been added
         _, list_json = self.successResultOf(self.json_request(
-            "GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
+            b"GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
         self.assertEqual(1, len(list_json))
 
         # delete
         response, _ = self.successResultOf(self.request_with_content(
-            "DELETE", "/load_balancer_pools/nodes",
+            b"DELETE", "/load_balancer_pools/nodes",
             body=json.dumps(server_data)))
         self.assertEqual(204, response.code)
 
         # ensure there are 0
         _, list_json = self.successResultOf(self.json_request(
-            "GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
+            b"GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
         self.assertEqual(0, len(list_json))
 
     def test_remove_bulk_pool_nodes_when_pool_id_is_non_uuid(self):
@@ -528,7 +531,7 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
         node_and_pool_ids = [(text_type(uuid4()), 122)]
         add_data = self._get_custom_add_nodes_json(node_and_pool_ids)
         response, resp_json = self.successResultOf(self.json_request(
-            "DELETE", "/load_balancer_pools/nodes", body=add_data))
+            b"DELETE", "/load_balancer_pools/nodes", body=add_data))
         self.assertEqual(400, response.code)
 
     def test_remove_bulk_pool_nodes_to_single_non_existant_pool_id_1(self):
@@ -540,13 +543,13 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
         node_and_pool_ids = [(server_id, self.get_lb_ids()[0][0])]
         add_data = self._get_custom_add_nodes_json(node_and_pool_ids)
         response, resp_json = self.successResultOf(self.json_request(
-            "POST", "/load_balancer_pools/nodes", body=add_data))
+            b"POST", "/load_balancer_pools/nodes", body=add_data))
         self.assertEqual(201, response.code)
         pool_id = text_type(uuid4())
         node_and_pool_ids = [(server_id, pool_id)]
         add_data = self._get_custom_add_nodes_json(node_and_pool_ids)
         response, resp_json = self.successResultOf(self.json_request(
-            "DELETE", "/load_balancer_pools/nodes", body=add_data))
+            b"DELETE", "/load_balancer_pools/nodes", body=add_data))
         self.assertEqual(409, response.code)
         self.assertEqual("Load Balancer Pool {0} does not exist".format(pool_id),
                          resp_json["errors"][0])
@@ -561,7 +564,7 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
                              (text_type(uuid4()), pool_id)]
         add_data = self._get_custom_add_nodes_json(node_and_pool_ids)
         response, resp_json = self.successResultOf(self.json_request(
-            "DELETE", "/load_balancer_pools/nodes", body=add_data))
+            b"DELETE", "/load_balancer_pools/nodes", body=add_data))
         self.assertEqual(409, response.code)
         self.assertEqual("Load Balancer Pool {0} does not exist".format(pool_id),
                          resp_json["errors"][0])
@@ -575,7 +578,7 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
                              (text_type(uuid4()), text_type(uuid4()))]
         add_data = self._get_custom_add_nodes_json(node_and_pool_ids)
         response, resp_json = self.successResultOf(self.json_request(
-            "POST", "/load_balancer_pools/nodes", body=add_data))
+            b"POST", "/load_balancer_pools/nodes", body=add_data))
         self.assertEqual(409, response.code)
         self.assertEqual(len(resp_json['errors']), 2)
 
@@ -588,19 +591,19 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
         node_and_pool_ids = [(server_id, self.get_lb_ids()[0][0])]
         add_data = self._get_custom_add_nodes_json(node_and_pool_ids)
         response, resp_json = self.successResultOf(self.json_request(
-            "POST", "/load_balancer_pools/nodes", body=add_data))
+            b"POST", "/load_balancer_pools/nodes", body=add_data))
         self.assertEqual(201, response.code)
         response, _ = self.successResultOf(self.request_with_content(
-            "DELETE", "/load_balancer_pools/nodes",
+            b"DELETE", "/load_balancer_pools/nodes",
             body=json.dumps(add_data)))
         self.assertEqual(204, response.code)
 
         # get the node count for the lb pool
         _, list_json = self.successResultOf(self.json_request(
-            "GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
+            b"GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
 
         response, resp_json = self.successResultOf(self.request_with_content(
-            "DELETE", "/load_balancer_pools/nodes",
+            b"DELETE", "/load_balancer_pools/nodes",
             body=json.dumps(add_data)))
         self.assertEqual(409, response.code)
         resp = json.loads(resp_json)
@@ -610,7 +613,7 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
 
         # ensure no other nodes were deleted from the pool
         _, list_json_again = self.successResultOf(self.json_request(
-            "GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
+            b"GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
         self.assertEqual(len(list_json_again), len(list_json))
 
     def test_remove_bulk_pool_nodes_multiple_errors(self):
@@ -623,20 +626,20 @@ class LoadbalancerPoolAPITests(RackConnectTestMixin, SynchronousTestCase):
 
         # get the node count for the lb pool
         _, list_json = self.successResultOf(self.json_request(
-            "GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
+            b"GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
 
         node_and_pool_ids = [(server_id, self.get_lb_ids()[0][0]),
                              (server_id, random_pool_id)]
         add_data = self._get_custom_add_nodes_json(node_and_pool_ids)
         response, resp_json = self.successResultOf(self.json_request(
-            "POST", "/load_balancer_pools/nodes", body=add_data))
+            b"POST", "/load_balancer_pools/nodes", body=add_data))
         self.assertEqual(409, response.code)
         self.assertEqual("Load Balancer Pool {0} does not exist".format(random_pool_id),
                          resp_json["errors"][0])
 
         # ensure no nodes were deleted from the pool
         _, list_json_again = self.successResultOf(self.json_request(
-            "GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
+            b"GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
         self.assertEqual(len(list_json_again), len(list_json))
 
 
@@ -653,7 +656,7 @@ class LoadbalancerPoolNodesAPITests(RackConnectTestMixin,
         """
         random_pool_id = text_type(uuid4())
         response, content = self.successResultOf(self.request_with_content(
-            "GET", "/load_balancer_pools/{0}/nodes".format(random_pool_id)))
+            b"GET", "/load_balancer_pools/{0}/nodes".format(random_pool_id)))
 
         self.assertEqual(404, response.code)
         self.assertEqual("Load Balancer Pool {0} does not exist".format(random_pool_id),
@@ -665,7 +668,7 @@ class LoadbalancerPoolNodesAPITests(RackConnectTestMixin,
         no nodes
         """
         response, json_content = self.successResultOf(self.json_request(
-            "GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
+            b"GET", "/load_balancer_pools/{0}/nodes".format(self.pool_id)))
         self.assertEqual(200, response.code)
         self.assertEqual(json_content, [])
 
@@ -674,7 +677,7 @@ class LoadbalancerPoolNodesAPITests(RackConnectTestMixin,
         Getting pool nodes details is currently unimplemented
         """
         response, content = self.successResultOf(self.request_with_content(
-            "GET",
+            b"GET",
             "/load_balancer_pools/{0}/nodes/details".format(self.pool_id)))
         self.assertEqual(501, response.code)
 
@@ -683,7 +686,7 @@ class LoadbalancerPoolNodesAPITests(RackConnectTestMixin,
         Adding a single pool node is currently unimplemented
         """
         response, content = self.successResultOf(self.request_with_content(
-            "POST", "/load_balancer_pools/{0}/nodes".format(self.pool_id),
+            b"POST", "/load_balancer_pools/{0}/nodes".format(self.pool_id),
             body=json.dumps({
                 "cloud_server": {"id": "d95ae0c4-6ab8-4873-b82f-f8433840cff2"}
             })))
@@ -694,7 +697,7 @@ class LoadbalancerPoolNodesAPITests(RackConnectTestMixin,
         Getting information a single pool node is currently unimplemented
         """
         response, content = self.successResultOf(self.request_with_content(
-            "GET", "/load_balancer_pools/{0}/nodes/1".format(self.pool_id)
+            b"GET", "/load_balancer_pools/{0}/nodes/1".format(self.pool_id)
         ))
         self.assertEqual(501, response.code)
 
@@ -703,7 +706,7 @@ class LoadbalancerPoolNodesAPITests(RackConnectTestMixin,
         Removing a single pool node is currently unimplemented
         """
         response, content = self.successResultOf(self.request_with_content(
-            "DELETE", "/load_balancer_pools/{0}/nodes/1".format(self.pool_id)
+            b"DELETE", "/load_balancer_pools/{0}/nodes/1".format(self.pool_id)
         ))
         self.assertEqual(501, response.code)
 
@@ -713,7 +716,7 @@ class LoadbalancerPoolNodesAPITests(RackConnectTestMixin,
         unimplemented
         """
         response, content = self.successResultOf(self.request_with_content(
-            "GET",
+            b"GET",
             "/load_balancer_pools/{0}/nodes/1/details".format(self.pool_id)
         ))
         self.assertEqual(501, response.code)

--- a/mimic/test/test_resource.py
+++ b/mimic/test/test_resource.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import json
 import re
 
@@ -60,7 +62,7 @@ class ServiceResourceTests(SynchronousTestCase):
         (region, service_id) = one_api(self, core)
 
         request(
-            self, root, "GET",
+            self, root, b"GET",
             "http://mybase/mimicking/{0}/{1}/more/stuff".format(service_id, region)
         )
 
@@ -83,7 +85,7 @@ class ServiceResourceTests(SynchronousTestCase):
         (region, service_id) = one_api(self, core)
 
         response = self.successResultOf(request(
-            self, root, "GET",
+            self, root, b"GET",
             "http://mybase/mimicking/not_{0}/{1}".format(service_id, region)
         ))
         self.assertEqual(404, response.code)
@@ -104,7 +106,7 @@ class ServiceResourceTests(SynchronousTestCase):
         (region, service_id) = one_api(self, core)
 
         response = self.successResultOf(request(
-            self, root, "GET",
+            self, root, b"GET",
             "http://mybase/mimicking/not_{0}/{1}".format(service_id, region)
         ))
         self.assertEqual(404, response.code)
@@ -116,14 +118,14 @@ class ServiceResourceTests(SynchronousTestCase):
         and right region, the service's resource is used to respond to the
         request.
         """
-        core = MimicCore(Clock(), [ExampleAPI('response!')])
+        core = MimicCore(Clock(), [ExampleAPI(b'response!')])
         root = MimicRoot(core).app.resource()
 
         # get the region and service id registered for the example API
         (region, service_id) = one_api(self, core)
 
         (response, content) = self.successResultOf(request_with_content(
-            self, root, "GET",
+            self, root, b"GET",
             "http://mybase/mimicking/{0}/{1}".format(service_id, region)
         ))
         self.assertEqual(200, response.code)
@@ -146,7 +148,7 @@ class RootAndPresetTests(SynchronousTestCase):
         root = MimicRoot(core).app.resource()
 
         (response, content) = self.successResultOf(request_with_content(
-            self, root, 'GET', '/'))
+            self, root, b'GET', '/'))
         self.assertEqual(200, response.code)
         self.assertEqual(['text/plain'],
                          response.headers.getRawHeaders('content-type'))
@@ -163,7 +165,7 @@ class RootAndPresetTests(SynchronousTestCase):
         root = MimicRoot(core).app.resource()
 
         (response, json_content) = self.successResultOf(json_request(
-            self, root, 'GET', '/mimic/v1.0/presets'))
+            self, root, b'GET', '/mimic/v1.0/presets'))
         self.assertEqual(200, response.code)
         self.assertEqual(['application/json'],
                          response.headers.getRawHeaders('content-type'))
@@ -185,7 +187,7 @@ class RootAndPresetTests(SynchronousTestCase):
         root = MimicRoot(core, clock).app.resource()
         self.assertEqual(do.done, False)
         jreq = json_request(
-            self, root, "POST", "/mimic/v1.1/tick", body={"amount": 3.6}
+            self, root, b"POST", "/mimic/v1.1/tick", body={"amount": 3.6}
         )
         [response, json_content] = self.successResultOf(jreq)
         self.assertEqual(response.code, 200)
@@ -204,7 +206,7 @@ class RootAndPresetTests(SynchronousTestCase):
         root = MimicRoot(core).app.resource()
 
         (response, json_content) = self.successResultOf(json_request(
-            self, root, 'GET', '/fastly'))
+            self, root, b'GET', '/fastly'))
         self.assertEqual(200, response.code)
         self.assertEqual(json_content, {'status': 'ok'})
 
@@ -216,7 +218,7 @@ class RootAndPresetTests(SynchronousTestCase):
         root = MimicRoot(core).app.resource()
 
         response = self.successResultOf(request(
-            self, root, "POST", "/sendgrid/mail.send.json"))
+            self, root, b"POST", "/sendgrid/mail.send.json"))
         self.assertEqual(200, response.code)
 
 
@@ -229,14 +231,14 @@ class RequestTests(SynchronousTestCase):
         """
         Make a request and return the response.
         """
-        core = MimicCore(Clock(), [ExampleAPI('response!')])
+        core = MimicCore(Clock(), [ExampleAPI(b'response!')])
         root = MimicRoot(core).app.resource()
 
         # get the region and service id registered for the example API
         (region, service_id) = one_api(self, core)
         url = "/mimicking/{0}/{1}".format(service_id, region)
         response = self.successResultOf(request(
-            self, root, "GET", url, headers={"one": ["two"]}
+            self, root, b"GET", url, headers={b"one": [b"two"]}
         ))
         return (response, url)
 

--- a/mimic/test/test_session.py
+++ b/mimic/test/test_session.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 
 import six
 from datetime import datetime

--- a/mimic/test/test_swift.py
+++ b/mimic/test/test_swift.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 
 from json import dumps
 
@@ -25,7 +26,7 @@ class SwiftTests(SynchronousTestCase):
         self.core = MimicCore(Clock(), [SwiftMock(rackspace_flavor)])
         self.root = MimicRoot(self.core).app.resource()
         self.response = request(
-            self, self.root, "POST", "/identity/v2.0/tokens",
+            self, self.root, b"POST", "/identity/v2.0/tokens",
             dumps({
                 "auth": {
                     "passwordCredentials": {
@@ -65,7 +66,7 @@ class SwiftTests(SynchronousTestCase):
         """
         uri = (self.json_body['access']['serviceCatalog'][0]['endpoints'][0]
                ['publicURL'] + '/testcontainer')
-        create_container = request(self, self.root, "PUT", uri)
+        create_container = request(self, self.root, b"PUT", uri)
         create_container_response = self.successResultOf(create_container)
         self.assertEqual(create_container_response.code, expected_code)
         self.assertEqual(
@@ -99,10 +100,10 @@ class SwiftTests(SynchronousTestCase):
         # create a container
         uri = (self.json_body['access']['serviceCatalog'][0]['endpoints'][0]
                ['publicURL'] + '/testcontainer')
-        create_container = request(self, self.root, "PUT", uri)
+        create_container = request(self, self.root, b"PUT", uri)
         self.successResultOf(create_container)
         container_response = self.successResultOf(
-            request(self, self.root, "GET", uri)
+            request(self, self.root, b"GET", uri)
         )
         self.assertEqual(container_response.code, 200)
         container_contents = self.successResultOf(
@@ -127,7 +128,7 @@ class SwiftTests(SynchronousTestCase):
         uri = (self.json_body['access']['serviceCatalog'][0]['endpoints'][0]
                ['publicURL'] + '/testcontainer')
         container_response = self.successResultOf(
-            request(self, self.root, "GET", uri)
+            request(self, self.root, b"GET", uri)
         )
         self.assertEqual(container_response.code, 404)
         self.assertEqual(
@@ -148,18 +149,18 @@ class SwiftTests(SynchronousTestCase):
         # create a container
         uri = (self.json_body['access']['serviceCatalog'][0]['endpoints'][0]
                ['publicURL'] + '/testcontainer')
-        create_container = request(self, self.root, "PUT", uri)
+        create_container = request(self, self.root, b"PUT", uri)
         self.successResultOf(create_container)
         BODY = b'some bytes'
         object_uri = uri + "/" + "testobject"
         object_response = request(self, self.root,
-                                  "PUT", object_uri,
-                                  headers={"content-type": ["text/plain"]},
+                                  b"PUT", object_uri,
+                                  headers={b"content-type": [b"text/plain"]},
                                   body=BODY)
         self.assertEqual(self.successResultOf(object_response).code,
                          201)
         container_response = self.successResultOf(
-            request(self, self.root, "GET", uri)
+            request(self, self.root, b"GET", uri)
         )
         self.assertEqual(container_response.code, 200)
         container_contents = self.successResultOf(
@@ -170,7 +171,7 @@ class SwiftTests(SynchronousTestCase):
         self.assertEqual(container_contents[0]['content_type'], "text/plain")
         self.assertEqual(container_contents[0]['bytes'], len(BODY))
         object_response = self.successResultOf(
-            request(self, self.root, "GET", object_uri)
+            request(self, self.root, b"GET", object_uri)
         )
         self.assertEqual(object_response.code, 200)
         object_body = self.successResultOf(treq.content(object_response))

--- a/mimic/test/test_tap.py
+++ b/mimic/test/test_tap.py
@@ -2,6 +2,8 @@
 Tests for L{mimic.tap}
 """
 
+from __future__ import unicode_literals
+
 import sys
 import types
 
@@ -71,8 +73,8 @@ def addFakePluginObject(testCase, pluginPackage, pluginObject):
     """
     Add a fake plugin for the duration of the given test.
     """
-    dropinName = "a_fake_dropin"
-    dropinQualifiedName = pluginPackage.__name__ + "." + dropinName
+    dropinName = b"a_fake_dropin"
+    dropinQualifiedName = pluginPackage.__name__ + b"." + dropinName
     module = sys.modules[dropinQualifiedName] = types.ModuleType(
         dropinQualifiedName)
     testCase.addCleanup(lambda: sys.modules.pop(dropinQualifiedName))

--- a/mimic/test/test_util.py
+++ b/mimic/test/test_util.py
@@ -1,6 +1,9 @@
 """
 Unit tests for :mod:`mimic.util`
 """
+
+from __future__ import unicode_literals
+
 from twisted.trial.unittest import SynchronousTestCase
 from twisted.web.resource import Resource
 

--- a/mimic/test/test_valkyrie.py
+++ b/mimic/test/test_valkyrie.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 
 from twisted.trial.unittest import SynchronousTestCase
 from twisted.internet.task import Clock
@@ -27,7 +28,7 @@ class ValkyrieAPITests(SynchronousTestCase):
         """
         data = {"something": "anything"}
         (response, content) = self.successResultOf(json_request(self, self.root,
-                                                                "POST",
+                                                                b"POST",
                                                                 self.url + "/login", data))
         self.assertEqual(200, response.code)
 
@@ -37,7 +38,7 @@ class ValkyrieAPITests(SynchronousTestCase):
         """
         data = {"something": "anything"}
         (response, content) = self.successResultOf(json_request(self, self.root,
-                                                                "POST",
+                                                                b"POST",
                                                                 self.url + "/login_user", data))
         self.assertEqual(200, response.code)
 
@@ -46,7 +47,7 @@ class ValkyrieAPITests(SynchronousTestCase):
         Obtain list of device permissions for contact 12 on account 123456
         """
         (response, content) = self.successResultOf(
-            json_request(self, self.root, "GET",
+            json_request(self, self.root, b"GET",
                          self.url +
                          "/account/123456/permissions/contacts/devices/by_contact/12/effective"))
         self.assertEqual(200, response.code)
@@ -58,7 +59,7 @@ class ValkyrieAPITests(SynchronousTestCase):
         Obtain list of account permissions for contact 12 on account 123456
         """
         (response, content) = self.successResultOf(
-            json_request(self, self.root, "GET",
+            json_request(self, self.root, b"GET",
                          self.url +
                          "/account/123456/permissions/contacts/accounts/by_contact/12/effective"))
         self.assertEqual(200, response.code)
@@ -69,7 +70,7 @@ class ValkyrieAPITests(SynchronousTestCase):
         Obtain list of account permissions for contact 12 on account 123456
         """
         (response, content) = self.successResultOf(
-            json_request(self, self.root, "GET",
+            json_request(self, self.root, b"GET",
                          self.url +
                          "/account/123456/permissions/contacts/accounts/by_contact/34/effective"))
         self.assertEqual(200, response.code)
@@ -83,7 +84,7 @@ class ValkyrieAPITests(SynchronousTestCase):
         Obtain list of devices permissions for contact 34 on account 123456
         """
         (response, content) = self.successResultOf(
-            json_request(self, self.root, "GET",
+            json_request(self, self.root, b"GET",
                          self.url +
                          "/account/123456/permissions/contacts/devices/by_contact/34/effective"))
         self.assertEqual(200, response.code)
@@ -94,7 +95,7 @@ class ValkyrieAPITests(SynchronousTestCase):
         Obtain list of device permissions for contact 78 on account 654321
         """
         (response, content) = self.successResultOf(
-            json_request(self, self.root, "GET",
+            json_request(self, self.root, b"GET",
                          self.url +
                          "/account/654321/permissions/contacts/devices/by_contact/78/effective"))
         self.assertEqual(200, response.code)
@@ -110,7 +111,7 @@ class ValkyrieAPITests(SynchronousTestCase):
         Obtain list of all permissions for contact 90 on account 654321
         """
         (response, content) = self.successResultOf(
-            json_request(self, self.root, "GET",
+            json_request(self, self.root, b"GET",
                          self.url +
                          "/account/654321/permissions/contacts/any/by_contact/90/effective"))
         self.assertEqual(200, response.code)

--- a/mimic/util/helper.py
+++ b/mimic/util/helper.py
@@ -5,6 +5,9 @@ Helper methods
 
 :var fmt: strftime format for datetimes used in JSON.
 """
+
+from __future__ import unicode_literals
+
 import binascii
 import os
 import string


### PR DESCRIPTION
Discussed offline with @glyph last week - this change is intended to help us reason through where we need to use byte strings vs where we can use Unicode strings. The hope is that this will smooth the process of adding python3 support.

With this change, the new policy for string literals (such as there is one) is

1. All string literals are `unicode`, except
2. explicit `b"bytestring literals"`. Use these for interfacing with Klein/Twisted, but not for generally storing human readable text or as dictionary keys.