### PR TITLE
Adding py3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,13 @@ env:
 matrix:
     include:
         - python: 2.6
-          env: TOXENV=py26-twisted_old_logging
-        - python: 2.6
-          env: TOXENV=py26-twisted_new_logging
+          env: TOXENV=py26
         - python: 2.7
-          env: TOXENV=py27-twisted_old_logging
-        - python: 2.7
-          env: TOXENV=py27-twisted_new_logging
+          env: TOXENV=py27
+        - python: 3.4
+          env: TOXENV=py34
         - python: pypy
-          env: TOXENV=pypy-twisted_old_logging
-        - python: pypy
-          env: TOXENV=pypy-twisted_new_logging
+          env: TOXENV=pypy
         - python: 2.7
           env: TOXENV=docs
         - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ matrix:
           env: MACAPP_ENV=system
     allow_failures:
       - env: TOXENV=docs-linkcheck
+      - env: TOXENV=py34
 
 install:
   - travis_retry ./.travis/install.sh

--- a/mimic/model/nova_objects.py
+++ b/mimic/model/nova_objects.py
@@ -7,7 +7,7 @@ import re
 from characteristic import attributes, Attribute
 from random import randrange
 from json import loads, dumps
-from urllib import urlencode
+from six.moves.urllib.parse import urlencode
 
 from six import string_types
 

--- a/mimic/resource.py
+++ b/mimic/resource.py
@@ -9,20 +9,7 @@ from six import text_type
 
 from twisted.web.resource import NoResource
 from twisted.web.server import Request, Site
-
-# Just import from twisted.logger if mimic drops support for twisted < 15.2.0
-try:
-    from twisted.logger import Logger
-except ImportError:
-    from twisted.python.log import msg
-
-    def log(message, **kwargs):
-        """
-        PEP3101-format the message string.
-        """
-        msg(message.format(**kwargs))
-else:
-    log = Logger("mimic").info
+from twisted.logger import Logger
 
 from mimic.canned_responses.mimic_presets import get_presets
 from mimic.model.behaviors import BehaviorRegistryCollection
@@ -36,6 +23,8 @@ from mimic.rest.noit_api import NoitApi
 from mimic.rest import (fastly_api, mailgun_api, customer_api,
                         ironic_api, glance_api, valkyrie_api)
 from mimic.util.helper import seconds_to_timestamp
+
+log = Logger("mimic").info
 
 
 class MimicRoot(object):

--- a/mimic/rest/loadbalancer_api.py
+++ b/mimic/rest/loadbalancer_api.py
@@ -147,13 +147,13 @@ class LoadBalancerControlRegion(object):
 
         try:
             regional_lbs.set_attributes(clb_id, content)
-        except BadKeysError, bke:
+        except BadKeysError as bke:
             request.setResponseCode(400)
             return json.dumps({
                 "message": str(bke),
                 "code": 400,
             })
-        except BadValueError, bve:
+        except BadValueError as bve:
             request.setResponseCode(400)
             return json.dumps({
                 "message": str(bve),

--- a/mimic/rest/maas_api.py
+++ b/mimic/rest/maas_api.py
@@ -6,7 +6,7 @@ from __future__ import division
 
 import json
 import collections
-import urlparse
+from urllib.parse import parse_qs
 import random
 import re
 from uuid import uuid4
@@ -347,7 +347,7 @@ def parse_and_flatten_qs(url):
     """
     Parses a querystring and flattens 1-arg arrays.
     """
-    qs = urlparse.parse_qs(url)
+    qs = parse_qs(url)
     flat_qs = {}
     for key in qs:
         flat_qs[key] = qs[key][0] if len(qs[key]) == 1 else qs[key]

--- a/mimic/rest/maas_api.py
+++ b/mimic/rest/maas_api.py
@@ -6,7 +6,7 @@ from __future__ import division
 
 import json
 import collections
-from urllib.parse import parse_qs
+from six.moves.urllib.parse import parse_qs
 import random
 import re
 from uuid import uuid4

--- a/mimic/rest/mailgun_api.py
+++ b/mimic/rest/mailgun_api.py
@@ -6,7 +6,7 @@ https://documentation.mailgun.com/api-sending.html
 
 import json
 import time
-import urlparse
+from urllib.parse import parse_qs
 
 from mimic.rest.mimicapp import MimicApp
 from mimic.util.helper import seconds_to_timestamp
@@ -36,7 +36,7 @@ class MailGunApi(object):
         If the `to` address is `bademail@example.com` results in error 500
         and if it is `failingemail@example.com` results in 400.
         """
-        content = urlparse.parse_qs(request.content.read())
+        content = parse_qs(request.content.read())
         to_address = content.get('to')
         headers = {}
         for key, value in content.items():

--- a/mimic/rest/mailgun_api.py
+++ b/mimic/rest/mailgun_api.py
@@ -6,7 +6,7 @@ https://documentation.mailgun.com/api-sending.html
 
 import json
 import time
-from urllib.parse import parse_qs
+from six.moves.urllib.parse import parse_qs
 
 from mimic.rest.mimicapp import MimicApp
 from mimic.util.helper import seconds_to_timestamp

--- a/mimic/test/test_mailgun.py
+++ b/mimic/test/test_mailgun.py
@@ -1,4 +1,4 @@
-import urllib
+from six.moves.urllib.parse import urlencode
 
 from twisted.trial.unittest import SynchronousTestCase
 from twisted.internet.task import Clock
@@ -27,7 +27,7 @@ class MailGunAPITests(SynchronousTestCase):
         """
         (response, content) = self.successResultOf(json_request(
             self, root, "POST", "/cloudmonitoring.rackspace.com/messages",
-            urllib.urlencode(data)))
+            urlencode(data)))
         self.assertEqual(200, response.code)
 
     def get_content_from_list_messages(self, root, to_filter=None):
@@ -58,7 +58,7 @@ class MailGunAPITests(SynchronousTestCase):
         """
         response = self.successResultOf(request(
             self, self.root, "POST", "/cloudmonitoring.rackspace.com/messages",
-            urllib.urlencode({"to": "bademail@example.com"})))
+            urlencode({"to": "bademail@example.com"})))
         self.assertEqual(500, response.code)
 
     def test_mailgun_send_message_receives_error_400(self):
@@ -68,7 +68,7 @@ class MailGunAPITests(SynchronousTestCase):
         """
         response = self.successResultOf(request(
             self, self.root, "POST", "/cloudmonitoring.rackspace.com/messages",
-            urllib.urlencode({"to": "failingemail@example.com"})))
+            urlencode({"to": "failingemail@example.com"})))
         self.assertEqual(400, response.code)
 
     def test_mailgun_get_messages(self):
@@ -104,7 +104,7 @@ class MailGunAPITests(SynchronousTestCase):
         for x in range(5):
             response = self.successResultOf(request(
                 self, self.root, "POST", "/cloudmonitoring.rackspace.com/messages",
-                urllib.urlencode({"to": "bademail@example.com", "subject": "test"})))
+                urlencode({"to": "bademail@example.com", "subject": "test"})))
             self.assertEqual(500, response.code)
 
         (response, content) = self.successResultOf(json_request(

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -3,7 +3,7 @@ Tests for :mod:`nova_api` and :mod:`nova_objects`.
 """
 import json
 from urllib import urlencode
-from urlparse import parse_qs
+from urllib.parse import parse_qs
 
 from testtools.matchers import (
     ContainsDict, Equals, MatchesDict, MatchesListwise, StartsWith)

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -2,8 +2,7 @@
 Tests for :mod:`nova_api` and :mod:`nova_objects`.
 """
 import json
-from urllib import urlencode
-from urllib.parse import parse_qs
+from six.moves.urllib.parse import urlencode, parse_qs
 
 from testtools.matchers import (
     ContainsDict, Equals, MatchesDict, MatchesListwise, StartsWith)

--- a/mimic/util/helper.py
+++ b/mimic/util/helper.py
@@ -5,6 +5,7 @@ Helper methods
 
 :var fmt: strftime format for datetimes used in JSON.
 """
+import binascii
 import os
 import string
 import calendar
@@ -87,7 +88,7 @@ def random_hex_generator(num):
     """
     Returns randomly generated n bytes of encoded hex data for the given `num`
     """
-    return os.urandom(num).encode("hex")
+    return binascii.hexlify(os.urandom(num))
 
 
 def seconds_to_timestamp(seconds, format=fmt):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 klein==15.0.0
 cryptography==0.8.2
-twisted==15.0.0
+twisted==15.4.0
 jsonschema==2.0
 treq==15.0.0
 characteristic==14.3.0

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def setup_options(name, version):
         install_requires=[
             "characteristic>=14.2.0",
             "klein>=0.2.1",
-            "twisted>=14.0.2",
+            "twisted>=15.4.0",
             "jsonschema>=2.0",
             "treq>=0.2.1",
             "six>=1.6.0",

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,9 @@
 [tox]
-envlist = {py26,py27,pypy}-twisted_{old_logging,new_logging}, docs, lint
+envlist = py26, py27, py34, pypy, docs, lint
 
 [testenv]
 deps =
     coverage==3.7.1
-    twisted_old_logging: twisted<15.2.0
-    twisted_new_logging: twisted>=15.2.0
 passenv = PIP_WHEEL_DIR PIP_FIND_LINKS
 commands =
     coverage erase


### PR DESCRIPTION
- adds py34 to tox
- allows the py34 build to fail without failing travis
- updates requirements to install twisted 15.4 
- removes references to old logging in twisted
- makes `random_hex_generator` py3 compatible
- Changes urllib to six.moves.urllib.parse to support both py27 and py34