### PR TITLE
Fix ssh key list

### DIFF
--- a/mimic/model/keypair_objects.py
+++ b/mimic/model/keypair_objects.py
@@ -62,13 +62,11 @@ class RegionalKeyPairCollection(object):
         """
         result = {"keypairs": []}
         if len(self.keypairs) > 0:
-            keypairs_json = {}
+            keypairs_json = []
             for keypair in self.keypairs:
-                keypairs_json.update(keypair.key_json())
+                keypairs_json.append(keypair.key_json())
             result = {
-                "keypairs": [
-                    keypairs_json
-                ]
+                "keypairs": keypairs_json
             }
 
         return json.dumps(result)

--- a/mimic/test/test_keypairs.py
+++ b/mimic/test/test_keypairs.py
@@ -68,6 +68,30 @@ class KeyPairTests(SynchronousTestCase):
         self.assertTrue(len(body['keypair']['fingerprint']) > 1)
         self.assertTrue(len(body['keypair']['user_id']) > 1)
 
+    def test_keypair_list_with_multiple_keys(self):
+        kp_test_body_1 = {
+            "keypair": {
+                "name": "test_key_one",
+                "public_key": "ssh-rsa testkeyone"
+            }
+        }
+
+        kp_test_body_2 = {
+            "keypair": {
+                "name": "test_key_two",
+                "public_key": "ssh-rsa testkeytwo"
+            }
+        }
+        self.create_keypair(kp_test_body_1)
+        self.create_keypair(kp_test_body_2)
+        resp, body = self.get_keypairs_list()
+        self.assertEqual(body['keypairs'][0]['keypair']
+                         ['name'], self.keypair_name)
+        self.assertEqual(body['keypairs'][1]['keypair']
+                         ['name'], "test_key_one")
+        self.assertEqual(body['keypairs'][2]['keypair']
+                         ['name'], "test_key_two")
+
     def test_error_create_keypair(self):
         test_error_body = b"{{a]"
         resp, body = self.create_keypair(test_error_body)


### PR DESCRIPTION
There is a bug in the current implementation of listing ssh keys that causes only the last key created to be returned in the list call.  Changing the data structure from a dict to a list will fix the issue