### PR TITLE
Reassign auth preset response to allow better MaaS test coverage.

### DIFF
--- a/mimic/canned_responses/mimic_presets.py
+++ b/mimic/canned_responses/mimic_presets.py
@@ -56,4 +56,4 @@ get_presets = {"loadbalancers": {"lb_building": "On create load balancer, keeps 
                    "dedicated_racker": ["HybridOneTwoRacker"],
                    "dedicated_limited_device_permission_holder": ["HybridFiveSix"],
                    "dedicated_non_permission_holder": ["HybridSevenEight"],
-                   "dedicated_other_account_admin": ["HybridNineZero"]}}
+                   "dedicated_quasi_user_impersonator": ["HybridNineZero"]}}

--- a/mimic/rest/auth_api.py
+++ b/mimic/rest/auth_api.py
@@ -430,10 +430,6 @@ class AuthApi(object):
                     "name": "HybridOneTwo",
                     "roles": [{"id": "1",
                                "name": "monitoring:observer",
-                               "description": "Monitoring Observer"},
-                              {"id": "3",
-                               "name": "hybridRole",
-                               "description": "Hybrid Admin",
                                "tenantId": "hybrid:123456"}],
                     "RAX-AUTH:contactId": "12"
                 }
@@ -526,21 +522,27 @@ class AuthApi(object):
                     "RAX-AUTH:contactId": "78"
                 }
 
-        if token_id in get_presets["identity"]["dedicated_other_account_admin"]:
+        if token_id in get_presets["identity"]["dedicated_quasi_user_impersonator"]:
                 response["access"]["token"]["tenant"] = {
-                    "id": "hybrid:654321",
-                    "name": "hybrid:654321",
+                    "id": "hybrid:123456",
+                    "name": "hybrid:123456",
                 }
                 response["access"]["user"] = {
                     "id": "90",
                     "name": "HybridNineZero",
                     "roles": [{"id": "1",
-                               "name": "monitoring:admin",
+                               "name": "identity:user-admin",
                                "description": "Admin"},
-                              {"id": "2",
-                               "name": "admin",
-                               "description": "Admin"}],
-                    "RAX-AUTH:contactId": "90"
+                              {"id": "3",
+                               "name": "hybridRole",
+                               "description": "Hybrid Admin",
+                               "tenantId": "hybrid:123456"}]
+                }
+                response["access"]["RAX-AUTH:impersonator"] = {
+                    "id": response["access"]["user"]["id"],
+                    "name": response["access"]["user"]["name"],
+                    "roles": [{"id": "1",
+                               "name": "monitoring:service-admin"}]
                 }
 
         return json.dumps(response)

--- a/mimic/test/test_auth.py
+++ b/mimic/test/test_auth.py
@@ -1364,5 +1364,5 @@ class IdentityDedicatedFixtureTests(SynchronousTestCase):
         (response, content) = self.successResultOf(
             json_request(self, root, b"GET", url + "/HybridNineZero"))
         self.assertEqual(200, response.code)
-        self.assertEqual(content["access"]["token"]["tenant"]["id"], "hybrid:654321")
-        self.assertEqual(content["access"]["user"]["RAX-AUTH:contactId"], "90")
+        self.assertEqual(content["access"]["token"]["tenant"]["id"], "hybrid:123456")
+        self.assertEqual(content["access"]["user"]["id"], "90")


### PR DESCRIPTION
This slight change in the preset responses in the Identity API allows for the testing of an unusual class of dedicated quasi-users that carry the 'hybridRole' role.