### PR TITLE
fix(maas_api): return less awkward type in catalog

### DIFF
--- a/mimic/rest/maas_api.py
+++ b/mimic/rest/maas_api.py
@@ -61,7 +61,7 @@ class MaasApi(object):
         """
         return [
             Entry(
-                tenant_id, "rax: monitor", "cloudMonitoring",
+                tenant_id, "rax:monitor", "cloudMonitoring",
                 [
                     Endpoint(tenant_id, region, text_type(uuid4()),
                              "v1.0")
@@ -1473,7 +1473,7 @@ class MaasControlApi(object):
         """
         return [
             Entry(
-                tenant_id, "rax: monitor", "cloudMonitoringControl",
+                tenant_id, "rax:monitor", "cloudMonitoringControl",
                 [
                     Endpoint(tenant_id, region, text_type(uuid4()),
                              "v1.0")


### PR DESCRIPTION
The MaaS type in the service catalog was "rax: monitor" where it should
have been "rax:monitor".