### PR TITLE
feat(AuthApi): list tenants for auth token

### DIFF
--- a/mimic/rest/auth_api.py
+++ b/mimic/rest/auth_api.py
@@ -569,6 +569,33 @@ class AuthApi(object):
             prefix_for_endpoint=prefix_map.get)
         )
 
+    @app.route('/v2.0/tenants', methods=['GET'])
+    def list_tenants(self, request):
+        """
+        List all tenants for the specified auth token.
+
+        The token for this call is specified in the X-Auth-Token header,
+        like using the services in the service catalog. Mimic supports
+        only one tenant per session, so the number of listed tenants is
+        always 1 if the call succeeds.
+
+        For more information about this call, refer to the `Rackspace Cloud
+        Identity Developer Guide
+        <https://developer.rackspace.com/docs/cloud-identity/v2/developer-guide/#list-tenants>`_
+        """
+        try:
+            sess = self.core.sessions.existing_session_for_token(
+                request.getHeader(b'x-auth-token').decode('utf-8'))
+            return json.dumps({'tenants': [{'id': sess.tenant_id,
+                                            'name': sess.tenant_id,
+                                            'enabled': True}]})
+        except KeyError:
+            request.setResponseCode(401)
+            return json.dumps({'unauthorized': {
+                'code': 401,
+                'message': ("No valid token provided. Please use the 'X-Auth-Token'"
+                            " header with a valid token.")}})
+
 
 def base_uri_from_request(request):
     """

--- a/mimic/session.py
+++ b/mimic/session.py
@@ -127,13 +127,11 @@ class SessionStore(object):
     def session_for_token(self, token, tenant_id=None):
         """
         :param unicode token: An authentication token previously created by
-            session_for_api_key or session_for_username_password.
+            session_for_api_key or session_for_username_password, or a new
+            token initialized outside Mimic.
 
-        :return: a session for the given token, only if that token already
-                 exists.
+        :return: a session for the given token.
         :rtype: Session
-
-        :raise: :obj:`KeyError` if no such thing exists.
         """
         if token in self._token_to_session:
             s = self._token_to_session[token]
@@ -143,6 +141,22 @@ class SessionStore(object):
         else:
             s = self._new_session(token=token, tenant_id=tenant_id)
         return s
+
+    def existing_session_for_token(self, token):
+        """
+        :param unicode token: An authentication token previously created by
+            session_for_api_key, session_for_username_password, or
+            get_or_create_session_for_token.
+
+        :return: a session for the given token, only if that token already
+                 exists.
+        :rtype: Session
+
+        :raise: :obj:`KeyError` if no such thing exists.
+        """
+        if token in self._token_to_session:
+            return self._token_to_session[token]
+        raise KeyError(token)
 
     def session_for_api_key(self, username, api_key, tenant_id=None):
         """


### PR DESCRIPTION
This Identity API is used in a specific login flow to Intelligence when a user needs to bypass SSO and log in directly by POSTing us a token. In this case, we need to know their tenant so that we can request their service catalog from Identity. This change adds the auth API that Intelligence needs to log in with just a token.

The API is documented here: https://developer.rackspace.com/docs/cloud-identity/v2/developer-guide/#list-tenants