### PR TITLE
Improve tox configuration for better behavior with respect to coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ script:
   - ./.travis/run.sh
 
 after_success:
-  - "source ~/.venv/bin/activate && codecov"
+  - "source ~/.venv/bin/activate && coverage combine && codecov"
 
 notifications:
   irc:

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -50,6 +50,7 @@ else
     python -m virtualenv ~/.venv
     source ~/.venv/bin/activate
     pip install tox codecov
+    coverage erase
     tox --recreate --notest
 
     # If "installdeps" fails, "tox" exits with an error, and the "set -e" above

--- a/tox.ini
+++ b/tox.ini
@@ -6,17 +6,7 @@ deps =
     coverage==4.0.1
 passenv = PIP_WHEEL_DIR PIP_FIND_LINKS
 commands =
-    coverage erase
-    coverage run {envbindir}/trial --rterrors {posargs:mimic}
-    coverage report -m
-    coverage xml
-
-[testenv:py26]
-commands =
-    coverage erase
-    coverage run {envbindir}/trial --rterrors {posargs:mimic}
-    coverage report -m
-    coverage xml
+    coverage run -p {envbindir}/trial --rterrors {posargs:mimic}
 
 [testenv:py34]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py26, py27, py34, pypy, docs, lint
 
 [testenv]
 deps =
-    coverage==3.7.1
+    coverage==4.0.1
 passenv = PIP_WHEEL_DIR PIP_FIND_LINKS
 commands =
     coverage erase


### PR DESCRIPTION
In this PR I plan to:

- upgrade coverage.py
- make coverage reports accurate when tests are run in parallel with [`detox`](https://pypi.python.org/pypi/detox)
- move coverage reporting out of `tox` itself to the travis script so that it's easier for users to get local combined coverage with `coverage combine` and `coverage html`.
- stop running the tests in the source directory, so that we can tell if the `setup.py` is correct