### PR TITLE
fix cryptography/pypy version match on travis

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -33,7 +33,7 @@ if [[ "$DARWIN" = true ]]; then
     pip install --user virtualenv
 else
     # temporary pyenv installation to get pypy-2.6 before container infra upgrade
-    if [[ ("${TOXENV}" == "pypy-twisted_old_logging") ||  ("${TOXENV}" == "pypy-twisted_new_logging")]]; then
+    if [[ "${TOXENV}" == "pypy" ]]; then
         git clone https://github.com/yyuu/pyenv.git ~/.pyenv
         PYENV_ROOT="$HOME/.pyenv"
         PATH="$PYENV_ROOT/bin:$PATH"

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -49,8 +49,6 @@ if [[ "${MACAPP_ENV}" == "system" ]]; then
 else
     python -m virtualenv ~/.venv
     source ~/.venv/bin/activate
-    pip install wheel
-    pip wheel cryptography lxml
     pip install tox codecov
     tox --recreate --notest
 


### PR DESCRIPTION
Wheel all the requirements, as specified in the requirements.txt, instead of treating cryptography specially.