### PR TITLE
chore(travis): remove python3.4 from allow_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ matrix:
           env: MACAPP_ENV=system
     allow_failures:
       - env: TOXENV=docs-linkcheck
-      - env: TOXENV=py34
 
 install:
   - travis_retry ./.travis/install.sh

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,9 @@ commands =
 [testenv:py34]
 deps =
     {[testenv]deps}
-    https://github.com/twisted/twisted/tarball/trunk
-    https://github.com/hawkowl/treq/tarball/py3
-    https://github.com/twisted/klein/tarball/master
+    https://github.com/twisted/twisted/tarball/931370903d1a7ad7957901921e575b9bee68ead0
+    https://github.com/hawkowl/treq/tarball/cb52811ec70c713537f3c0e3728440f69dcb4c8c
+    https://github.com/twisted/klein/tarball/dbf744c355d9a2e8cda961a834f256f556377767
 
 [testenv:docs]
 deps =


### PR DESCRIPTION
Now that we have landed support for Python 3, it's important not to
regress. This change removes Python 3 from the `allow_failures` section
in Travis so that builds will not be green while failing Python 3.