### PR TITLE
start mock for block storage

### DIFF
--- a/mimic/plugins/cinder_plugin.py
+++ b/mimic/plugins/cinder_plugin.py
@@ -1,0 +1,6 @@
+"""
+Plugin for Cinder mock.
+"""
+from mimic.rest.cinder_api import CinderApi
+
+cinder = CinderApi()

--- a/mimic/rest/cinder_api.py
+++ b/mimic/rest/cinder_api.py
@@ -1,0 +1,72 @@
+# -*- test-case-name: mimic.test.test_cinder -*-
+"""
+Defines a mock for Cinder
+"""
+
+import json
+from uuid import uuid4
+from six import text_type
+from zope.interface import implementer
+from twisted.plugin import IPlugin
+from mimic.rest.mimicapp import MimicApp
+from mimic.catalog import Entry
+from mimic.catalog import Endpoint
+from mimic.imimic import IAPIMock
+
+
+@implementer(IAPIMock, IPlugin)
+class CinderApi(object):
+    """
+    Rest endpoints for mocked Cinder Api.
+    """
+    def __init__(self, regions=["DFW", "ORD", "IAD"]):
+        """
+        Create a CinderApi.
+        """
+        self._regions = regions
+
+    def catalog_entries(self, tenant_id):
+        """
+        List catalog entries for the Cinder API.
+        """
+        return [
+            Entry(
+                tenant_id, "volume", "cloudBlockStorage",
+                [
+                    Endpoint(tenant_id, region, text_type(uuid4()), prefix="v2")
+                    for region in self._regions
+                ]
+            )
+        ]
+
+    def resource_for_region(self, region, uri_prefix, session_store):
+        """
+        Get an :obj:`twisted.web.iweb.IResource` for the given URI prefix;
+        implement :obj:`IAPIMock`.
+        """
+        return CinderMock(self, uri_prefix, session_store, region).app.resource()
+
+
+class CinderMock(object):
+    """
+    DNS Mock
+    """
+    def __init__(self, api_mock, uri_prefix, session_store, name):
+        """
+        Create a Cinder region with a given URI prefix
+        """
+        self.uri_prefix = uri_prefix
+        self._api_mock = api_mock
+        self._session_store = session_store
+        self._name = name
+
+    app = MimicApp()
+
+    @app.route('/v2/<string:tenant_id>/volumes', methods=['GET'])
+    def get_volumes(self, request, tenant_id):
+        """
+        Lists summary information for all Block Storage volumes that the tenant can access.
+        http://developer.openstack.org/api-ref-blockstorage-v2.html#getVolumesSimple
+        """
+        request.setResponseCode(200)
+        return json.dumps({'volumes': []})

--- a/mimic/test/test_cinder.py
+++ b/mimic/test/test_cinder.py
@@ -1,0 +1,34 @@
+"""
+Tests for cinder api
+"""
+
+from __future__ import absolute_import, division, unicode_literals
+from twisted.trial.unittest import SynchronousTestCase
+from mimic.test.helpers import json_request
+from mimic.rest.cinder_api import CinderApi
+from mimic.test.fixtures import APIMockHelper
+
+
+class CinderTests(SynchronousTestCase):
+    """
+    Tests for cinder using the Cinder Api plugin.
+    """
+    def setUp(self):
+        """
+        Initialize core and root
+        """
+        cinder_api = CinderApi(['DFW'])
+        self.helper = APIMockHelper(self, [cinder_api])
+        self.root = self.helper.root
+        self.uri = self.helper.uri
+
+    def test_get_blockstorage_volume_list(self):
+        """
+        Requesting block storage volumes for a tenant returns 200 and an empty list
+        if no volumes are available for the given tenant
+        http://developer.openstack.org/api-ref-blockstorage-v2.html#getVolumesSimple
+        """
+        (response, content) = self.successResultOf(json_request(
+            self, self.root, b"GET", self.uri + '/volumes'))
+        self.assertEqual(200, response.code)
+        self.assertEqual(content, {'volumes': []})

--- a/mimic/test/test_core.py
+++ b/mimic/test/test_core.py
@@ -7,7 +7,7 @@ from mimic.core import MimicCore
 from mimic.plugins import (nova_plugin, loadbalancer_plugin, swift_plugin,
                            queue_plugin, maas_plugin, rackconnect_v3_plugin,
                            glance_plugin, cloudfeeds_plugin, heat_plugin,
-                           dns_plugin)
+                           dns_plugin, cinder_plugin)
 
 
 class CoreBuildingTests(SynchronousTestCase):
@@ -44,7 +44,8 @@ class CoreBuildingTests(SynchronousTestCase):
             swift_plugin.swift,
             cloudfeeds_plugin.cloudfeeds,
             cloudfeeds_plugin.cloudfeeds_control,
-            dns_plugin.dns
+            dns_plugin.dns,
+            cinder_plugin.cinder
         ))
         self.assertEqual(
             plugin_apis,


### PR DESCRIPTION
This is the beginning of the cinder plugin. It has one route to get the list of volumes, which addresses issue, #485