### PR TITLE
feat(queue_api): list and post messages

### DIFF
--- a/mimic/model/queue_objects.py
+++ b/mimic/model/queue_objects.py
@@ -6,8 +6,44 @@ from __future__ import absolute_import, division, unicode_literals
 
 import attr
 from six import text_type
+from twisted.internet.interfaces import IReactorTime
 
 from mimic.util.helper import random_hex_generator
+
+
+@attr.s
+class Message(object):
+    """
+    A Message object in Cloud Queues.
+    """
+    ttl = attr.ib(validator=attr.validators.instance_of(int))
+    body = attr.ib(validator=attr.validators.instance_of(dict))
+    queue_name = attr.ib(validator=attr.validators.instance_of(text_type))
+    posted_by = attr.ib(validator=attr.validators.instance_of(text_type))
+    posted_at = attr.ib(validator=attr.validators.instance_of(int))
+    id = attr.ib(validator=attr.validators.instance_of(text_type),
+                 default=attr.Factory(lambda: random_hex_generator(12)))
+
+    def to_json(self, current_time):
+        """
+        A representation of this message that can be serialized via json.dumps.
+        """
+        return {'body': self.body,
+                'age': current_time - self.posted_at,
+                'href': self.href(),
+                'ttl': self.ttl}
+
+    def href(self):
+        """
+        Returns the URL path representing this message.
+        """
+        return '/v1/queues/{0}/messages/{1}'.format(self.queue_name, self.id)
+
+    def is_expired_at(self, current_time):
+        """
+        Returns True if the message is expired at the given time.
+        """
+        return (self.posted_at + self.ttl) < current_time
 
 
 @attr.s
@@ -20,6 +56,13 @@ class Queue(object):
                  default=attr.Factory(lambda: random_hex_generator(4)))
     _messages = attr.ib(default=attr.Factory(list))
 
+    def _clear_expired_messages(self, current_time):
+        """
+        Clears expired messages from the queue.
+        """
+        self._messages[:] = [message for message in self._messages
+                             if not message.is_expired_at(current_time)]
+
     def brief_json(self):
         """
         A brief representation of this queue that can be serialized
@@ -28,6 +71,36 @@ class Queue(object):
         return {'href': '/v1/queues/{0}'.format(self.name),
                 'name': self.name}
 
+    def post_messages(self, messages, client_id, current_time):
+        """
+        Posts a series of messages to the message queue.
+        """
+        self._clear_expired_messages(current_time)
+        new_messages = [Message(ttl=message['ttl'],
+                                body=message['body'],
+                                queue_name=self.name,
+                                posted_by=client_id,
+                                posted_at=current_time)
+                        for message in messages]
+        self._messages.extend(new_messages)
+        response_json = {'partial': False,
+                         'resources': [message.href() for message in new_messages]}
+        return response_json, 201
+
+    def list_messages(self, client_id, current_time, echo):
+        """
+        Lists messages (that the client can see).
+
+        If the echo parameter is set to true, the client sees all messages.
+        Otherwise, the client only sees messages posted by other clients.
+        """
+        self._clear_expired_messages(current_time)
+        response_json = {'messages': [message.to_json(current_time)
+                                      for message in self._messages
+                                      if echo or message.posted_by != client_id],
+                         'links': []}
+        return (response_json, 200) if response_json['messages'] else (None, 204)
+
 
 @attr.s
 class QueueCollection(object):
@@ -35,7 +108,16 @@ class QueueCollection(object):
     Models a collection of objects in the Cloud Queues business domain
     for a single tenant in a single region.
     """
+    _clock = attr.ib(validator=attr.validators.provides(IReactorTime))
     _queues = attr.ib(default=attr.Factory(list))
+
+    def _current_time(self):
+        """
+        Cloud Queues deals with time mostly in integer numbers of seconds.
+
+        This method gives the time in seconds, truncated to an integer.
+        """
+        return int(self._clock.seconds())
 
     def add_queue(self, queue_name):
         """
@@ -59,3 +141,21 @@ class QueueCollection(object):
         self._queues[:] = [queue for queue in self._queues
                            if queue.name != queue_name]
         return None, 204
+
+    def list_messages_for_queue(self, queue_name, client_id, echo):
+        """
+        Lists all messages in the named queue.
+        """
+        for queue in self._queues:
+            if queue.name == queue_name:
+                return queue.list_messages(client_id, self._current_time(), echo)
+        return None, 204
+
+    def post_messages_to_queue(self, queue_name, messages, client_id):
+        """
+        Post a series of messages to the named queue.
+        """
+        for queue in self._queues:
+            if queue.name == queue_name:
+                return queue.post_messages(messages, client_id, self._current_time())
+        return None, 404

--- a/mimic/test/test_queue.py
+++ b/mimic/test/test_queue.py
@@ -8,7 +8,7 @@ from twisted.internet.task import Clock
 
 from mimic.core import MimicCore
 from mimic.resource import MimicRoot
-from mimic.test.helpers import request
+from mimic.test.helpers import json_request, request
 from mimic.rest.queue_api import QueueApi
 
 
@@ -23,7 +23,8 @@ class QueueAPITests(SynchronousTestCase):
         Create a :obj:`MimicCore` with :obj:`QueueApi` as the only plugin,
         and create a queue
         """
-        self.core = MimicCore(Clock(), [QueueApi()])
+        self.clock = Clock()
+        self.core = MimicCore(self.clock, [QueueApi()])
         self.root = MimicRoot(self.core).app.resource()
         self.response = request(
             self, self.root, b"POST", "/identity/v2.0/tokens",
@@ -70,3 +71,97 @@ class QueueAPITests(SynchronousTestCase):
         delete_queue_response = self.successResultOf(delete_queue)
         self.assertEqual(delete_queue_response.code, 204)
         self.assertEqual(self.successResultOf(treq.content(delete_queue_response)), b"")
+
+    def test_post_and_list_messages(self):
+        """
+        Posting a message to the queue should cause the message to be
+        visible to another client.
+        """
+        (resp, data) = self.successResultOf(
+            json_request(self, self.root, b"POST",
+                         '{0}/queues/{1}/messages'.format(self.uri, self.queue_name),
+                         [{'ttl': 60, 'body': {'text': 'Wow'}}],
+                         headers={b'Client-ID': [b'client-1']}))
+        self.assertEquals(resp.code, 201)
+        self.assertEquals(len(data['resources']), 1)
+        (resp, data) = self.successResultOf(
+            json_request(self, self.root, b"GET",
+                         '{0}/queues/{1}/messages'.format(self.uri, self.queue_name),
+                         headers={b'Client-ID': [b'client-2']}))
+        self.assertEquals(resp.code, 200)
+        self.assertEquals(data['messages'][0]['body']['text'], 'Wow')
+
+    def test_list_messages_nonexisting_queue(self):
+        """
+        Listing messages for a non-existing queue returns 204.
+        """
+        resp = self.successResultOf(
+            request(self, self.root, b"GET",
+                    '{0}/queues/does-not-exist/messages'.format(self.uri, self.queue_name),
+                    headers={b'Client-ID': [b'client-2']}))
+        self.assertEquals(resp.code, 204)
+
+    def test_post_to_nonexisting_queue(self):
+        """
+        Attempting to post a message to a non-existing queue returns 404.
+        """
+        (resp, _) = self.successResultOf(
+            json_request(self, self.root, b"POST",
+                         '{0}/queues/does-not-exist/messages'.format(self.uri),
+                         [{'ttl': 60, 'body': {'text': 'Wow'}}],
+                         headers={b'Client-ID': [b'client-1']}))
+        self.assertEquals(resp.code, 404)
+
+    def test_same_client_message_is_invisible(self):
+        """
+        By default, the client does not see messages they themselves posted.
+        """
+        (resp, data) = self.successResultOf(
+            json_request(self, self.root, b"POST",
+                         '{0}/queues/{1}/messages'.format(self.uri, self.queue_name),
+                         [{'ttl': 60, 'body': {'text': 'Wow'}}],
+                         headers={b'Client-ID': [b'client-1']}))
+        self.assertEquals(resp.code, 201)
+        self.assertEquals(len(data['resources']), 1)
+        resp = self.successResultOf(
+            request(self, self.root, b"GET",
+                    '{0}/queues/{1}/messages'.format(self.uri, self.queue_name),
+                    headers={b'Client-ID': [b'client-1']}))
+        self.assertEquals(resp.code, 204)
+
+    def test_same_client_message_shows_with_echo(self):
+        """
+        With echo=true, the client can see messages they posted.
+        """
+        (resp, data) = self.successResultOf(
+            json_request(self, self.root, b"POST",
+                         '{0}/queues/{1}/messages'.format(self.uri, self.queue_name),
+                         [{'ttl': 60, 'body': {'text': 'Wow'}}],
+                         headers={b'Client-ID': [b'client-1']}))
+        self.assertEquals(resp.code, 201)
+        self.assertEquals(len(data['resources']), 1)
+        (resp, data) = self.successResultOf(
+            json_request(self, self.root, b"GET",
+                         '{0}/queues/{1}/messages?echo=true'.format(
+                             self.uri, self.queue_name),
+                         headers={b'Client-ID': [b'client-1']}))
+        self.assertEquals(resp.code, 200)
+        self.assertEquals(data['messages'][0]['body']['text'], 'Wow')
+
+    def test_old_messages_expire(self):
+        """
+        Messages expire after their TTL.
+        """
+        (resp, data) = self.successResultOf(
+            json_request(self, self.root, b"POST",
+                         '{0}/queues/{1}/messages'.format(self.uri, self.queue_name),
+                         [{'ttl': 60, 'body': {'text': 'Wow'}}],
+                         headers={b'Client-ID': [b'client-1']}))
+        self.assertEquals(resp.code, 201)
+        self.assertEquals(len(data['resources']), 1)
+        self.clock.advance(61)
+        resp = self.successResultOf(request(self, self.root, b"GET",
+                                            '{0}/queues/{1}/messages?echo=true'.format(
+                                                self.uri, self.queue_name),
+                                            headers={b'Client-ID': [b'client-2']}))
+        self.assertEquals(resp.code, 204)


### PR DESCRIPTION
This change adds the ability to post messages to a queue and list them
back. It also expires messages after their TTL. Making claims and
deleting messages is not supported yet.