### PR TITLE
Correct mac app build failures.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,4 +182,3 @@ docker build -t mimic . && docker run --restart=no --rm=true -p 8900:8900 mimic
 ```
 
 This will expose Mimic on port 8900, so you can access it directly from the host. The default port exposure is intended for communication between containers; see the Docker documentation for more information. If you're using `boot2docker`, run `boot2docker ip` to find the right IP.
-

--- a/README.md
+++ b/README.md
@@ -182,3 +182,4 @@ docker build -t mimic . && docker run --restart=no --rm=true -p 8900:8900 mimic
 ```
 
 This will expose Mimic on port 8900, so you can access it directly from the host. The default port exposure is intended for communication between containers; see the Docker documentation for more information. If you're using `boot2docker`, run `boot2docker ip` to find the right IP.
+

--- a/bundle/start-app.py
+++ b/bundle/start-app.py
@@ -26,6 +26,10 @@ from twisted.web.server import Site
 from twisted.python import log
 from twisted.plugin import getPlugins, IPlugin
 
+# required by pkg_resources.resource_string, which is used by treq; so trick
+# modulegraph into including it.
+import pkg_resources._vendor.packaging
+
 from sys import stdout
 
 # This is the port on which mimic will listen for requests. It has been

--- a/bundle/start-app.py
+++ b/bundle/start-app.py
@@ -24,11 +24,11 @@ from twisted.internet.endpoints import serverFromString
 from twisted.internet.task import Clock
 from twisted.web.server import Site
 from twisted.python import log
-from twisted.plugin import getPlugins, IPlugin
 
-# required by pkg_resources.resource_string, which is used by treq; so trick
-# modulegraph into including it.
-import pkg_resources._vendor.packaging
+# The following are required by pkg_resources.resource_string, which is used by
+# treq; so trick modulegraph into including it.
+from pkg_resources._vendor.packaging import version, specifiers
+version, specifiers # pacify pyflakes
 
 from sys import stdout
 

--- a/requirements/mac-app.txt
+++ b/requirements/mac-app.txt
@@ -8,4 +8,4 @@ py2app==0.9
 pyobjc-core==3.0.4
 pyobjc-framework-CFNetwork==3.0.4
 pyobjc-framework-Cocoa==3.0.4
-
+setuptools==19.6

--- a/requirements/mac-app.txt
+++ b/requirements/mac-app.txt
@@ -9,3 +9,4 @@ pyobjc-core==3.0.4
 pyobjc-framework-CFNetwork==3.0.4
 pyobjc-framework-Cocoa==3.0.4
 setuptools==19.6
+


### PR DESCRIPTION
`setuptools` was automatically upgraded on our build infrastructure, which caused the Mac app build to start failing.

The root cause here is that `pkg_resources`, within setuptools, started doing some dynamic-importing tricks in `pkg_resources._vendor`, which in turn caused these modules to stop getting detected as necessary by `modulegraph`.  `treq` depends on these modules, because it uses `pkg_resources.resource_string`, which does the aforementioned dynamic importing.

The solution is to add some static imports of these internal modules to the main script, which informs `modulegraph` of their necessity, causing them to be included in the app bundle properly. 