### PR TITLE
feat(maas_api): list agent connections

### DIFF
--- a/mimic/rest/maas_api.py
+++ b/mimic/rest/maas_api.py
@@ -1158,6 +1158,35 @@ class MaasMock(object):
                          'next_marker': None,
                          'next_href': None}})
 
+    @app.route('/v1.0/<string:tenant_id>/views/connections', methods=['GET'])
+    def view_connections(self, request, tenant_id):
+        """
+        Lists agent connections.
+        """
+        maas_store = self._entity_cache_for_tenant(tenant_id).maas_store
+
+        if b'agentId' not in request.args:
+            request.setResponseCode(400)
+            return json.dumps({'type': 'badRequest',
+                               'code': 400,
+                               'message': 'Validation error for key \'agentId\'',
+                               'details': 'You must specify an agentId',
+                               'txnId': '.fake.mimic.transaction.id.c-1111111.ts-123444444.v-12344frf'})
+
+        agent_ids = request.args[b'agentId']
+        decoded_agent_ids = [agent_id.decode("utf-8") for agent_id in agent_ids]
+        connections = [{'agent_id': agent_id,
+                        'connections': [connection.to_json()
+                                        for connection in maas_store.list_connections_for_agent(
+                                            agent_id)]}
+                       for agent_id in decoded_agent_ids]
+        return json.dumps({'values': connections,
+                           'metadata': {'count': len(connections),
+                                        'limit': None,
+                                        'marker': None,
+                                        'next_marker': None,
+                                        'next_href': None}})
+
     @app.route('/v1.0/<string:tenant_id>/agent_installers', methods=['POST'])
     def agent_installer(self, request, tenant_id):
         """

--- a/mimic/util/helper.py
+++ b/mimic/util/helper.py
@@ -102,6 +102,13 @@ def random_hex_generator(num):
     return binascii.hexlify(os.urandom(num)).decode('utf-8')
 
 
+def random_port():
+    """
+    Returns a random number in the range of registered non-system ports.
+    """
+    return randint(1024, 49151)
+
+
 def seconds_to_timestamp(seconds, format=fmt):
     """
     Return an ISO8601 Zulu timestamp given seconds since the epoch.


### PR DESCRIPTION
This PR adds a new API call that recently landed in MaaS and
Intelligence is starting to use. It's likely to become our new preferred
way to test if an agent is connected, since the real API has superior
performance when testing many agent connections at once.