### PR TITLE
feat(maas_api): add failure case for bad agent ID

### DIFF
--- a/mimic/model/maas_objects.py
+++ b/mimic/model/maas_objects.py
@@ -12,7 +12,7 @@ from uuid import uuid4
 from characteristic import attributes, Attribute
 from six import text_type
 
-from mimic.util.helper import Matcher, random_hex_generator, random_port, random_string
+from mimic.util.helper import random_hex_generator, random_port, random_string
 
 METRIC_TYPE_INTEGER = 'i'
 METRIC_TYPE_NUMBER = 'n'
@@ -667,7 +667,7 @@ class MaasStore(object):
         can be found in `the Rackspace Cloud Monitoring Developer Guide, appendix B
             <http://docs.rackspace.com/cm/api/v1.0/cm-devguide/content/appendix-check-types.html>`_
         """
-        self.agents = []
+        self.agents = {}
         self.alarm_states = []
 
         self.check_types = {
@@ -855,7 +855,6 @@ class MaasStore(object):
         Lists connections for an agent, or returns empty list if there is no such agent.
         """
         try:
-            agent = self.agents[self.agents.index(Matcher(lambda agent: agent.id == agent_id))]
-            return agent.list_connections()
-        except ValueError:
+            return self.agents[agent_id].list_connections()
+        except KeyError:
             return []

--- a/mimic/test/test_maas.py
+++ b/mimic/test/test_maas.py
@@ -1164,6 +1164,22 @@ class MaasAPITests(SynchronousTestCase):
         self.assertEquals(len(connections_by_agent_id[agent_id]), 3)
         self.assertEquals(len(connections_by_agent_id['agent-that-does-not-exist']), 0)
 
+    def test_agenthostinfo_bad_agent_id_returns_400(self):
+        """
+        Setting a wrong agent ID on the entity and getting host info causes a 400.
+        """
+        resp = self.successResultOf(
+            request(self, self.root, b"PUT",
+                    '{0}/entities/{1}'.format(self.uri, self.entity_id),
+                    json.dumps({'agent_id': 'LOLWUT'}).encode("utf-8")))
+        self.assertEquals(resp.code, 204)
+        (resp, data) = self.successResultOf(
+            json_request(self, self.root, b"GET",
+                         '{0}/views/agent_host_info?entityId={1}&include=system'.format(
+                             self.uri, self.entity_id)))
+        self.assertEquals(resp.code, 400)
+        self.assertEquals(data['details'], 'Agent LOLWUT does not exist')
+
     def test_create_agent_missing_entity_returns_404(self):
         """
         Trying to create an agent on an entity that does not exist causes a 404.


### PR DESCRIPTION
When an entity is assigned an agent ID that does not map to an existing
agent, trying to fetch the host info for that entity throws a 400.