### PR TITLE
refactor(maas_objects): better validation with attrs

### DIFF
--- a/mimic/model/clb_objects.py
+++ b/mimic/model/clb_objects.py
@@ -34,23 +34,9 @@ from mimic.model.clb_errors import (
 from mimic.util.helper import (EMPTY_RESPONSE,
                                invalid_resource,
                                not_found_response,
+                               one_of_validator,
                                seconds_to_timestamp,
                                set_resource_status)
-
-
-def _one_of_validator(*items):
-    """
-    Return an :mod:`attr` validator which raises a :class:`TypeError`
-    if the value is not equivalent to one of the provided items.
-
-    :param items: Items to compare against
-    :return: a callable that returns with None or raises :class:`TypeError`
-    """
-    def validate(inst, attribute, value):
-        if value not in items:
-            raise TypeError("{0} must be one of {1}".format(
-                attribute.name, items))
-    return validate
 
 
 @attr.s
@@ -71,11 +57,11 @@ class Node(object):
     """
     address = attr.ib(validator=attr.validators.instance_of(text_type))
     port = attr.ib(validator=attr.validators.instance_of(int))
-    type = attr.ib(validator=_one_of_validator("PRIMARY", "SECONDARY"),
+    type = attr.ib(validator=one_of_validator("PRIMARY", "SECONDARY"),
                    default="PRIMARY")
     weight = attr.ib(validator=attr.validators.instance_of(int), default=1)
     condition = attr.ib(
-        validator=_one_of_validator("ENABLED", "DISABLED", "DRAINING"),
+        validator=one_of_validator("ENABLED", "DISABLED", "DRAINING"),
         default="ENABLED")
     id = attr.ib(validator=attr.validators.instance_of(int),
                  default=attr.Factory(lambda: randrange(999999)))

--- a/mimic/test/test_maas.py
+++ b/mimic/test/test_maas.py
@@ -20,7 +20,11 @@ class MaasObjectsTests(SynchronousTestCase):
         Known types for TestCheckMetric are 'i', 'n', and 's'. Other types
         raise ValueError.
         """
-        metric = Metric(name='whuut', type='z', override_key=lambda **kw: 'x')
+        metric = Metric(name='whuut', type='i', override_key=lambda **kw: 'x')
+
+        # Update `type` after construction to bypass validation.
+        metric.type = 'z'
+
         with self.assertRaises(ValueError):
             metric.get_value_for_test_check(
                 timestamp=0,

--- a/mimic/util/helper.py
+++ b/mimic/util/helper.py
@@ -203,3 +203,18 @@ class Matcher(object):
         Implements the == comparison based on the custom matcher.
         """
         return self._match_fn(other)
+
+
+def one_of_validator(*items):
+    """
+    Return an :mod:`attr` validator which raises a :class:`TypeError`
+    if the value is not equivalent to one of the provided items.
+
+    :param items: Items to compare against
+    :return: a callable that returns with None or raises :class:`TypeError`
+    """
+    def validate(inst, attribute, value):
+        if value not in items:
+            raise TypeError("{0} must be one of {1}".format(
+                attribute.name, items))
+    return validate


### PR DESCRIPTION
This change rewrites objects in the `mimic.model.maas_objects` module to
use the `attr` library for defining fields and validation, from
`characteristic` before.