### PR TITLE
refactor(*): rewrite 2.6 dict comprehensions

### DIFF
--- a/mimic/canned_responses/fastly.py
+++ b/mimic/canned_responses/fastly.py
@@ -71,7 +71,7 @@ class FastlyResponse(object):
                  response for fastly_client.create_service()
                  ("/service") request.
         """
-        data = dict((key, value[0]) for key, value in url_data)
+        data = {key: value[0] for key, value in url_data}
 
         publish_key = uuid.uuid4().hex
         service_id = uuid.uuid4().hex
@@ -149,7 +149,7 @@ class FastlyResponse(object):
                  ("/service/<service_id>/version/<service_version>/domain")
                  request.
         """
-        request_dict = dict((k, v[0]) for k, v in url_data)
+        request_dict = {k: v[0] for k, v in url_data}
         domain_name = request_dict['name']
 
         create_domain = {
@@ -187,7 +187,7 @@ class FastlyResponse(object):
                  ("/service/<service_id>/version/<service_version>/backend")
                  request.
         """
-        request_dict = dict((k, v[0]) for k, v in url_data)
+        request_dict = {k: v[0] for k, v in url_data}
 
         create_backend = {
             u'comment': '',
@@ -231,7 +231,7 @@ class FastlyResponse(object):
                  ("/service/<service_id>/version/<service_version>/condition")
                  request.
         """
-        request_dict = dict((k, v[0]) for k, v in url_data)
+        request_dict = {k: v[0] for k, v in url_data}
 
         create_condition = {
             u"type": "REQUEST",
@@ -259,7 +259,7 @@ class FastlyResponse(object):
                  ("/service/<service_id>/version/<service_version>/cache_settings")
                  request.
         """
-        request_dict = dict((k, v[0]) for k, v in url_data)
+        request_dict = {k: v[0] for k, v in url_data}
 
         create_cache_settings = {
             "stale_ttl": request_dict.get("stale_ttl", 0),
@@ -287,7 +287,7 @@ class FastlyResponse(object):
                  ("/service/<service_id>/version/<service_version>/response_object)
                  request.
         """
-        request_dict = dict((k, v[0]) for k, v in url_data)
+        request_dict = {k: v[0] for k, v in url_data}
 
         create_response_object = {
             "status": request_dict["status"],
@@ -317,7 +317,7 @@ class FastlyResponse(object):
                  ("/service/<service_id>/version/<service_version>/settings)
                  request.
         """
-        request_dict = dict((k, v[0]) for k, v in url_data)
+        request_dict = {k: v[0] for k, v in url_data}
 
         create_settings = {
             "service_id": service_id,

--- a/mimic/model/clb_objects.py
+++ b/mimic/model/clb_objects.py
@@ -139,7 +139,7 @@ class CLB(object):
         """
         entries = ('name', 'protocol', 'id', 'port', 'algorithm', 'status',
                    'timeout', 'created', 'virtualIps', 'updated')
-        result = dict((entry, self._json[entry]) for entry in entries)
+        result = {entry: self._json[entry] for entry in entries}
         result['nodeCount'] = len(self.nodes)
         return result
 
@@ -563,10 +563,10 @@ class RegionalCLBCollection(object):
             "weight: '{weight}', condition: '{condition}'")
         # first, store whether address and port were provided - if they were
         # that's a validation error not a schema error
-        things_wrong = dict([(k, True) for k in ("address", "port", "id")
-                             if k in node_updates])
-        node_updates = dict([(k, v) for k, v in node_updates.items()
-                             if k not in ("address", "port")])
+        things_wrong = {k: True for k in ("address", "port", "id")
+                        if k in node_updates}
+        node_updates = {k: node_updates[k] for k in node_updates
+                        if k not in ("address", "port")}
         # use the Node.from_json to check the schema
         try:
             Node.from_json(dict(address="1.1.1.1", port=80, **node_updates))

--- a/mimic/model/glance_objects.py
+++ b/mimic/model/glance_objects.py
@@ -202,7 +202,7 @@ class GlanceAdminImageStore(object):
         Create a new Image object and add it to the
         :obj: `glance_admin_image_store`
         """
-        image = Image(**dict((str(k), v) for k, v in attributes.items()))
+        image = Image(**{str(k): attributes[k] for k in attributes})
         self.glance_admin_image_store.append(image)
         return image
 

--- a/mimic/model/maas_objects.py
+++ b/mimic/model/maas_objects.py
@@ -514,13 +514,11 @@ class CheckType(object):
                   'available': self.test_check_available.get(ench_key, True),
                   'status': self.test_check_status.get(
                       ench_key, 'code=200,rt=0.4s,bytes=99'),
-                  'metrics': dict([(m.name,
-                                    m.get_value_for_test_check(
-                                        entity_id=entity_id,
-                                        check_id=check_id,
-                                        monitoring_zone=monitoring_zone,
-                                        timestamp=timestamp))
-                                   for m in self.metrics])}
+                  'metrics': {m.name: m.get_value_for_test_check(entity_id=entity_id,
+                                                                 check_id=check_id,
+                                                                 monitoring_zone=monitoring_zone,
+                                                                 timestamp=timestamp)
+                              for m in self.metrics}}
                  for monitoring_zone in monitoring_zones])
 
 
@@ -539,12 +537,10 @@ class SingleHostInfoType(object):
         """
         return {'timestamp': timestamp,
                 'error': None,
-                'info': dict([(metric.name,
-                               metric.get_value(
-                                   entity_id=entity_id,
-                                   agent_id=agent_id,
-                                   timestamp=timestamp))
-                              for metric in self.metrics])}
+                'info': {metric.name: metric.get_value(entity_id=entity_id,
+                                                       agent_id=agent_id,
+                                                       timestamp=timestamp)
+                         for metric in self.metrics}}
 
 
 @attr.s
@@ -562,13 +558,11 @@ class MultiHostInfoType(object):
         """
         return {'timestamp': timestamp,
                 'error': None,
-                'info': [dict([(metric.name,
-                                metric.get_value(
-                                    entity_id=entity_id,
-                                    agent_id=agent_id,
-                                    block_index=i,
-                                    timestamp=timestamp))
-                               for metric in self.metrics])
+                'info': [{metric.name: metric.get_value(entity_id=entity_id,
+                                                        agent_id=agent_id,
+                                                        block_index=i,
+                                                        timestamp=timestamp)
+                          for metric in self.metrics}
                          for i in range(num_blocks)]}
 
 
@@ -596,18 +590,15 @@ class Agent(object):
         """
         current_timestamp = int(1000 * clock.seconds())
 
-        return dict([(rtype,
-                      (available_types[rtype].get_info(
-                          entity_id,
-                          self.id,
-                          current_timestamp,
-                          self.counts[rtype])
-                       if rtype in self.counts
-                       else available_types[rtype].get_info(
-                           entity_id,
-                           self.id,
-                           current_timestamp)))
-                     for rtype in requested_types])
+        return {rtype: available_types[rtype].get_info(entity_id,
+                                                       self.id,
+                                                       current_timestamp,
+                                                       self.counts[rtype])
+                if rtype in self.counts
+                else available_types[rtype].get_info(entity_id,
+                                                     self.id,
+                                                     current_timestamp)
+                for rtype in requested_types}
 
     def list_connections(self):
         """

--- a/mimic/resource.py
+++ b/mimic/resource.py
@@ -227,8 +227,8 @@ class MimicLoggingRequest(MimicRequest, object):
             "{body}",
             method=self.method.decode("utf-8"), url=self.uri.decode("utf-8"),
             headers=json.dumps(
-                dict((k.decode("utf-8"), [vv.decode("utf-8") for vv in v])
-                     for (k, v) in self.requestHeaders.getAllRawHeaders())
+                {k.decode("utf-8"): [vv.decode("utf-8") for vv in v]
+                 for (k, v) in self.requestHeaders.getAllRawHeaders()}
             ),
             body=("\n" + content.decode("utf-8") + "\n" if content else ""))
         return super(MimicLoggingRequest, self).process()
@@ -251,8 +251,8 @@ class MimicLoggingRequest(MimicRequest, object):
             method=self.method.decode("utf-8"), url=self.uri.decode("utf-8"),
             code=self.code,
             headers=json.dumps(
-                dict((k.decode("utf-8"), [vv.decode("utf-8") for vv in v])
-                     for (k, v) in self.responseHeaders.getAllRawHeaders())),
+                {k.decode("utf-8"): [vv.decode("utf-8") for vv in v]
+                 for (k, v) in self.responseHeaders.getAllRawHeaders()}),
             body=("\n" + content.decode("utf-8") + "\n" if content else ""))
         return super(MimicLoggingRequest, self).finish()
 

--- a/mimic/rest/fastly_api.py
+++ b/mimic/rest/fastly_api.py
@@ -19,8 +19,8 @@ def text_urldata(urldata):
 
     :return: a dictionary mapping text to lists of text.
     """
-    return dict([(k.decode("utf-8"), [vv.decode("utf-8") for vv in v])
-                 for [k, v] in urldata.items()])
+    return {k.decode("utf-8"): [vv.decode("utf-8") for vv in urldata[k]]
+            for k in urldata}
 
 
 class FastlyApi(object):
@@ -85,9 +85,8 @@ class FastlyApi(object):
 
         https://docs.fastly.com/api/config#service_3
         """
-        url_data = text_urldata(request.args).items()
-        data = dict((key, value) for key, value in url_data)
-        service_name = data['name'][0]
+        url_data = text_urldata(request.args)
+        service_name = url_data['name'][0]
 
         response = self.fastly_response.get_service_by_name(service_name)
         return json.dumps(response)

--- a/mimic/rest/maas_api.py
+++ b/mimic/rest/maas_api.py
@@ -134,7 +134,7 @@ def _only_keys(dict_ins, keys):
     """
     Filters out unwanted keys of a dict.
     """
-    return dict([(k, dict_ins[k]) for k in dict_ins if k in keys])
+    return {k: dict_ins[k] for k in dict_ins if k in keys}
 
 
 def create_entity(clock, params):
@@ -539,12 +539,9 @@ class MaasMock(object):
                 )
 
     def _audit(self, app, request, tenant_id, status, content=b''):
-        headers = dict([
-            (k.decode("utf-8"),
-             [vv.decode("utf-8") if isinstance(vv, bytes) else vv for vv in v])
-            for k, v in request.getAllHeaders().items()
-            if k != b'x-auth-token']
-        )
+        headers = {k.decode("utf-8"): [vv.decode("utf-8") if isinstance(vv, bytes) else vv for vv in v]
+                   for k, v in request.getAllHeaders().items()
+                   if k != b'x-auth-token'}
 
         record = {
             'id': text_type(uuid4()),
@@ -1603,10 +1600,10 @@ class MaasMock(object):
         multiplot_request = json.loads(content.decode("utf-8"))
 
         requested_check_ids = set([metric['check_id'] for metric in multiplot_request['metrics']])
-        checks_by_id = dict([(check.id, check)
-                             for entity in entities.values()
-                             for check in entity.checks.values()
-                             if check.id in requested_check_ids])
+        checks_by_id = {check.id: check
+                        for entity in entities.values()
+                        for check in entity.checks.values()
+                        if check.id in requested_check_ids}
 
         for requested_metric in multiplot_request['metrics']:
             if requested_metric['check_id'] not in checks_by_id:

--- a/mimic/test/test_nova.py
+++ b/mimic/test/test_nova.py
@@ -2107,8 +2107,8 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         should return an HTTP status code of 403 and an error message saying
         there are too many items.
         """
-        metadata = dict(("key{0}".format(i), "value{0}".format(i))
-                        for i in range(100))
+        metadata = {"key{0}".format(i): "value{0}".format(i)
+                    for i in range(100)}
         self.assert_maximum_metadata(
             *create_server(self.helper, metadata=metadata))
 
@@ -2126,7 +2126,7 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         When ``create_server`` is passed metadata with too many items and
         invalid metadata values, the too many items error takes precedence.
         """
-        metadata = dict(("key{0}".format(i), []) for i in range(100))
+        metadata = {"key{0}".format(i): [] for i in range(100)}
         self.assert_maximum_metadata(
             *create_server(self.helper, metadata=metadata))
 
@@ -2237,8 +2237,8 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         should return an HTTP status code of 403 and an error message saying
         there are too many items.
         """
-        metadata = dict(("key{0}".format(i), "value{0}".format(i))
-                        for i in range(100))
+        metadata = {"key{0}".format(i): "value{0}".format(i)
+                    for i in range(100)}
         self.assert_maximum_metadata(
             *self.set_metadata({"metadata": metadata}))
 
@@ -2267,7 +2267,7 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         When ``set_metadata`` is passed metadata with too many items and
         invalid metadata values, the too many items error takes precedence.
         """
-        metadata = dict(("key{0}".format(i), []) for i in range(100))
+        metadata = {"key{0}".format(i): [] for i in range(100)}
         self.assert_maximum_metadata(
             *self.set_metadata({"metadata": metadata}))
 
@@ -2367,8 +2367,8 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         it should return an HTTP status code of 403 and an error message
         saying there are too many items.
         """
-        metadata = dict(("key{0}".format(i), "value{0}".format(i))
-                        for i in range(40))
+        metadata = {"key{0}".format(i): "value{0}".format(i)
+                    for i in range(40)}
         self.assert_maximum_metadata(
             *self.set_metadata_item(metadata, 'newkey',
                                     {"meta": {"newkey": "newval"}}))
@@ -2380,15 +2380,15 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         key, it should succeed (because it replaces the original metadata
         item).
         """
-        metadata = dict(("key{0}".format(i), "value{0}".format(i))
-                        for i in range(40))
+        metadata = {"key{0}".format(i): "value{0}".format(i)
+                    for i in range(40)}
         response, body = self.set_metadata_item(
             metadata, 'key0', {"meta": {"key0": "newval"}})
         self.assertEqual(response.code, 200)
         self.assertEqual(body, {"meta": {"key0": "newval"}})
 
-        expected = dict(("key{0}".format(i), "value{0}".format(i))
-                        for i in range(1, 40))
+        expected = {"key{0}".format(i): "value{0}".format(i)
+                    for i in range(1, 40)}
         expected['key0'] = 'newval'
         self.assertEqual(self.get_created_server_metadata(), expected)
 
@@ -2418,8 +2418,8 @@ class NovaAPIMetadataTests(SynchronousTestCase):
         When ``set_metadata_item`` is passed metadata with too many items and
         invalid metadata values, the too many items error takes precedence.
         """
-        metadata = dict(("key{0}".format(i), "value{0}".format(i))
-                        for i in range(40))
+        metadata = {"key{0}".format(i): "value{0}".format(i)
+                    for i in range(40)}
         self.assert_maximum_metadata(
             *self.set_metadata_item(metadata, 'key', {"meta": {"key": []}}))
 


### PR DESCRIPTION
This change rewrites some dict comprehension expressions from when 2.6 compatibility was a requirement. In particular we don't have to

```python
dict((k, v) for k, v in comprehension)
```

in favor of the 2.7 syntax for dict comprehensions

```python
{k: v for k, v in comprehension}
```