### PR TITLE
chore(clb_objects): remove dependency on toolz

### DIFF
--- a/mimic/model/clb_objects.py
+++ b/mimic/model/clb_objects.py
@@ -14,8 +14,6 @@ import attr
 
 from six import text_type
 
-from toolz.dicttoolz import dissoc
-
 from twisted.internet.interfaces import IReactorTime
 from twisted.python import log
 
@@ -89,7 +87,7 @@ class Node(object):
         """
         :return: a JSON dictionary representing the node.
         """
-        return dissoc(attr.asdict(self), "feed_events")
+        return attr.asdict(self, filter=lambda aa, _: aa.name != "feed_events")
 
     def same_as(self, other):
         """

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -22,7 +22,6 @@ requests==2.9.1
 service-identity==16.0.0
 six==1.10.0
 testtools==1.7.1 # rq.filter: <1.8.0
-toolz==0.7.4
 traceback2==1.4.0
 treq==15.1.0
 Twisted==15.5.0

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ def setup_options(name, version):
             "attrs>=15.1.0",
             "testtools>=1.7.1,<1.8.0",
             "iso8601>=0.1.10",
-            "toolz>=0.7.4"
         ],
         package_dir={"mimic": "mimic"},
         packages=find_packages(exclude=[]) + ["twisted.plugins"],


### PR DESCRIPTION
`attrs` has a built in functionality for filtering out keys when
serializing to a dict. We used `toolz.dicttoolz.dissoc` in one place for
doing this, but we can use a filter to `attr.asdict` and remove the
dependency.