### PR TITLE
Fix for new setuptools

### DIFF
--- a/bundle/start-app.py
+++ b/bundle/start-app.py
@@ -27,8 +27,8 @@ from twisted.python import log
 
 # The following are required by pkg_resources.resource_string, which is used by
 # treq; so trick modulegraph into including it.
-from pkg_resources._vendor.packaging import version, specifiers
-version, specifiers # pacify pyflakes
+from pkg_resources._vendor.packaging import version, specifiers, requirements
+version, specifiers, requirements # pacify pyflakes
 
 from sys import stdout
 

--- a/bundle/start-app.py
+++ b/bundle/start-app.py
@@ -30,6 +30,11 @@ from twisted.python import log
 from pkg_resources._vendor.packaging import version, specifiers, requirements
 version, specifiers, requirements # pacify pyflakes
 
+# these packages are imported _by_ _vendor.packaging from the "extern" package,
+# which dynamically populates its own namespace.
+from pkg_resources._vendor import pyparsing, six
+pyparsing, six # pyflakes
+
 from sys import stdout
 
 # This is the port on which mimic will listen for requests. It has been


### PR DESCRIPTION
Looks like `pkg_resources` picked up a new dynamic import.