### PR TITLE
feat(yo_api): implement new yo domain mock

### DIFF
--- a/mimic/model/yo_objects.py
+++ b/mimic/model/yo_objects.py
@@ -1,0 +1,51 @@
+"""
+Yo API data model
+"""
+
+from __future__ import absolute_import, division, unicode_literals
+
+import attr
+
+from attr.validators import instance_of
+from six import text_type
+
+from mimic.util.helper import random_hex_generator
+
+
+@attr.s
+class User(object):
+    """
+    Models a Yo user.
+    """
+    display_name = attr.ib(validator=instance_of(text_type))
+    username = attr.ib(validator=instance_of(text_type))
+    is_api_user = attr.ib(validator=instance_of(bool), default=False)
+    is_subscribable = attr.ib(validator=instance_of(bool), default=False)
+    type = attr.ib(validator=instance_of(text_type), default='user')
+    user_id = attr.ib(validator=instance_of(text_type),
+                      default=attr.Factory(lambda: random_hex_generator(12)))
+    yo_count = attr.ib(validator=instance_of(int), default=0)
+
+    def to_json(self):
+        """
+        Serializes this Yo user to a JSON-encodable dict.
+        """
+        return attr.asdict(self)
+
+
+@attr.s
+class YoCollections(object):
+    """
+    Models the global collection of Yo business objects.
+    """
+    users = attr.ib(validator=instance_of(dict), default=attr.Factory(dict))
+
+    def get_or_create_user(self, username):
+        """
+        Gets the user from the collection, or creates it if it does not exist.
+        """
+        try:
+            return self.users[username.upper()]
+        except KeyError:
+            self.users[username.upper()] = User(display_name=username, username=username.upper())
+            return self.users[username.upper()]

--- a/mimic/plugins/yo_plugin.py
+++ b/mimic/plugins/yo_plugin.py
@@ -1,0 +1,7 @@
+"""
+Plugin for Yo.
+"""
+
+from mimic.rest.yo_api import YoAPI
+
+yo = YoAPI()

--- a/mimic/rest/yo_api.py
+++ b/mimic/rest/yo_api.py
@@ -76,3 +76,17 @@ class YoAPIRoutes(object):
         return json.dumps({'success': True,
                            'yo_id': random_hex_generator(12),
                            'recipient': user.to_json()})
+
+    @app.route("/check_username/", methods=['GET'])
+    def check_username(self, request):
+        """
+        Checks to see if a user exists.
+        """
+        if b'username' not in request.args:
+            request.setResponseCode(400)
+            return json.dumps({'error': 'Must supply username',
+                               'errors': [{'message': 'Must supply username'}]})
+
+        username = request.args[b'username'][0].strip().decode("utf-8")
+        request.setResponseCode(200)
+        return json.dumps({'exists': username.upper() in self.yo_collections.users})

--- a/mimic/rest/yo_api.py
+++ b/mimic/rest/yo_api.py
@@ -1,0 +1,78 @@
+"""
+API domain mock for Yo.
+"""
+
+from __future__ import absolute_import, division, unicode_literals
+
+import attr
+import json
+
+from twisted.plugin import IPlugin
+from mimic.imimic import IAPIDomainMock
+from mimic.rest.mimicapp import MimicApp
+
+from zope.interface import implementer
+
+from mimic.model.yo_objects import YoCollections
+from mimic.util.helper import random_hex_generator
+
+
+@implementer(IAPIDomainMock, IPlugin)
+@attr.s
+class YoAPI(object):
+    """
+    API domain mock for api.justyo.co.
+    """
+    _resource = attr.ib(default=attr.Factory(lambda: YoAPIRoutes().app.resource()))
+
+    def domain(self):
+        """
+        The Yo API is found at api.justyo.co.
+        """
+        return "api.justyo.co"
+
+    def resource(self):
+        """
+        The resource for the Yo API.
+        """
+        return self._resource
+
+
+@attr.s(hash=False)
+class YoAPIRoutes(object):
+    """
+    Klein routes for Yo API methods.
+    """
+    yo_collections = attr.ib(default=attr.Factory(YoCollections))
+
+    app = MimicApp()
+
+    @app.route("/yo/", methods=['POST'])
+    def rpc_send_yo(self, request):
+        """
+        Sends a Yo RPC style.
+        """
+        body = json.loads(request.content.read().decode("utf-8"))
+
+        if 'api_key' not in body:
+            request.setResponseCode(401)
+            return json.dumps({'error': 'User does not have permissions for this request',
+                               'errors': [{'message': ('User does not have permissions '
+                                                       'for this request')}]})
+
+        if 'username' not in body:
+            request.setResponseCode(400)
+            return json.dumps({'error': 'Can\'t send Yo without a recipient.',
+                               'errors': [{'message': 'Can\'t send Yo without a recipient.'}]})
+
+        if 'link' in body and 'location' in body:
+            request.setResponseCode(400)
+            return json.dumps({'error': 'Can\'t send Yo with location and link.',
+                               'errors': [{'message': 'Can\'t send Yo with location and link.'}]})
+
+        user = self.yo_collections.get_or_create_user(body['username'])
+
+        request.setResponseCode(200)
+        return json.dumps({'success': True,
+                           'yo_id': random_hex_generator(12),
+                           'recipient': user.to_json()})

--- a/mimic/test/fixtures.py
+++ b/mimic/test/fixtures.py
@@ -80,3 +80,21 @@ class APIMockHelper(object):
         tenant_id = self.auth.service_catalog_json["access"]["token"]["tenant"]["id"]
         service_name = apis[0].catalog_entries(tenant_id)[0].name
         self.uri = self.get_service_endpoint(service_name)
+
+
+class APIDomainMockHelper(object):
+    """
+    Provides common functionality for testing API domain mocks
+    """
+
+    def __init__(self, test_case, domains):
+        """
+        Initialize a mimic core and the specified :obj:`mimic.imimic.IAPIMock`s
+        :param domains: A list of :obj:`mimic.imimic.IAPIDomainMock` objects to be initialized
+        """
+        self.test_case = test_case
+        self.clock = Clock()
+        self.core = MimicCore(self.clock, [], domains=domains)
+        self.root = MimicRoot(self.core).app.resource()
+
+        self.uri = '/domain/{0}'.format(domains[0].domain())

--- a/mimic/test/test_yo.py
+++ b/mimic/test/test_yo.py
@@ -82,3 +82,35 @@ class YoAPITests(SynchronousTestCase):
                         'location': '12 3rd St'}).encode("utf-8")))
         self.assertEquals(resp.code, 400)
         self.assertEquals(data['error'], 'Can\'t send Yo with location and link.')
+
+    def test_check_username_missing_username_errors(self):
+        """
+        Trying to check the username without specifying a username causes an error.
+        """
+        (resp, data) = self.successResultOf(json_request(
+            self, self.root, b"GET", '{0}/check_username/'.format(self.uri)))
+        self.assertEquals(resp.code, 400)
+        self.assertEquals(data['error'], 'Must supply username')
+
+    def test_check_existing_username_is_true(self):
+        """
+        Checking a username that exists gets a true response.
+        """
+        (resp, _) = self.successResultOf(json_request(
+            self, self.root, b"POST", '{0}/yo/'.format(self.uri),
+            json.dumps({'username': 'TESTUSER4',
+                        'api_key': 'A1234567890'}).encode("utf-8")))
+        self.assertEquals(resp.code, 200)
+        (resp, data) = self.successResultOf(json_request(
+            self, self.root, b"GET", '{0}/check_username/?username=TESTUSER4'.format(self.uri)))
+        self.assertEquals(resp.code, 200)
+        self.assertEquals(data['exists'], True)
+
+    def test_check_non_existing_username_is_false(self):
+        """
+        Checking a username that do not exist gives a false response.
+        """
+        (resp, data) = self.successResultOf(json_request(
+            self, self.root, b"GET", '{0}/check_username/?username=TESTUSER5'.format(self.uri)))
+        self.assertEquals(resp.code, 200)
+        self.assertEquals(data['exists'], False)

--- a/mimic/test/test_yo.py
+++ b/mimic/test/test_yo.py
@@ -1,0 +1,84 @@
+from __future__ import absolute_import, division, unicode_literals
+
+import json
+
+from twisted.trial.unittest import SynchronousTestCase
+from mimic.rest.yo_api import YoAPI
+
+from mimic.test.fixtures import APIDomainMockHelper
+from mimic.test.helpers import json_request
+
+
+class YoAPITests(SynchronousTestCase):
+    """
+    Tests for Yo API
+    """
+
+    def setUp(self):
+        """
+        Create a :obj:`APIDomainMockHelper` with :obj:`YoApi` as the only plugin
+        """
+        helper = APIDomainMockHelper(self, [YoAPI()])
+        self.root = helper.root
+        self.uri = helper.uri
+
+    def test_send_yo(self):
+        """
+        The Yo API can send a Yo.
+        """
+        (resp, data) = self.successResultOf(json_request(
+            self, self.root, b"POST", '{0}/yo/'.format(self.uri),
+            json.dumps({'username': 'TESTUSER1',
+                        'api_key': 'A1234567890'}).encode("utf-8")))
+        self.assertEquals(resp.code, 200)
+        self.assertEquals(data['success'], True)
+
+    def test_send_yo_to_same_username_gets_same_userid(self):
+        """
+        Sending a Yo to the same username twice causes the same user ID
+        to come back in the response.
+        """
+        (resp, data1) = self.successResultOf(json_request(
+            self, self.root, b"POST", '{0}/yo/'.format(self.uri),
+            json.dumps({'username': 'TESTUSER2',
+                        'api_key': 'A1234567890'}).encode("utf-8")))
+        self.assertEquals(resp.code, 200)
+        (resp, data2) = self.successResultOf(json_request(
+            self, self.root, b"POST", '{0}/yo/'.format(self.uri),
+            json.dumps({'username': 'TESTUSER2',
+                        'api_key': 'A1234567890'}).encode("utf-8")))
+        self.assertEquals(resp.code, 200)
+        self.assertEquals(data1['recipient']['user_id'], data2['recipient']['user_id'])
+
+    def test_send_yo_missing_api_key_errors(self):
+        """
+        Yo API sends an auth error if the request is missing an API key.
+        """
+        (resp, data) = self.successResultOf(json_request(
+            self, self.root, b"POST", '{0}/yo/'.format(self.uri),
+            json.dumps({'username': 'TESTUSER1'}).encode("utf-8")))
+        self.assertEquals(resp.code, 401)
+        self.assertEquals(data['error'], 'User does not have permissions for this request')
+
+    def test_send_yo_missing_username_errors(self):
+        """
+        Yo API sends a bad request error if the recipient is missing.
+        """
+        (resp, data) = self.successResultOf(json_request(
+            self, self.root, b"POST", '{0}/yo/'.format(self.uri),
+            json.dumps({'api_key': 'A1234567890'}).encode("utf-8")))
+        self.assertEquals(resp.code, 400)
+        self.assertEquals(data['error'], 'Can\'t send Yo without a recipient.')
+
+    def test_send_yo_with_link_and_location_errors(self):
+        """
+        Yo API sends a bad request error if specifying a link and location.
+        """
+        (resp, data) = self.successResultOf(json_request(
+            self, self.root, b"POST", '{0}/yo/'.format(self.uri),
+            json.dumps({'username': 'TESTUSER3',
+                        'api_key': 'A1234567890',
+                        'link': 'https://example.com/test',
+                        'location': '12 3rd St'}).encode("utf-8")))
+        self.assertEquals(resp.code, 400)
+        self.assertEquals(data['error'], 'Can\'t send Yo with location and link.')


### PR DESCRIPTION
this could be a fun thing to put in the test for #551 so that we don't have to try to include the dummy plugin.

I'm currently stuck trying to find the helper URI to send test requests against.