### PR TITLE
Allow builds that read stdin to fail.

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -77,7 +77,7 @@ export PIP_FIND_LINKS=".wheels";
 for req in requirements/*.txt; do
     # Ignore failures, because not all requirements are relevant on all
     # platforms.
-    ./.tox/"${TOXENV}"/bin/pip wheel -r "${req}" || true;
+    ./.tox/"${TOXENV}"/bin/pip wheel -r "${req}" < /dev/null || true;
 done;
 
 # If "installdeps" fails, "tox" exits with an error, and the "set -e" above

--- a/requirements/documentation-only.txt
+++ b/requirements/documentation-only.txt
@@ -12,6 +12,6 @@ pytz==2016.3
 restructuredtext-lint==0.14.2
 six==1.10.0
 snowballstemmer==1.2.1
-Sphinx==1.3.6
+Sphinx==1.4
 sphinx-rtd-theme==0.1.9
 stevedore==1.12.0

--- a/requirements/mac-app.txt
+++ b/requirements/mac-app.txt
@@ -4,9 +4,9 @@
 altgraph==0.12
 macholib==1.7
 modulegraph==0.12.1
-py2app==0.9
-pyobjc-core==3.0.4
-pyobjc-framework-CFNetwork==3.0.4
-pyobjc-framework-Cocoa==3.0.4
+py2app==0.10
+pyobjc-core==3.1.1
+pyobjc-framework-CFNetwork==3.1.1
+pyobjc-framework-Cocoa==3.1.1
 setuptools==20.3.1
 


### PR DESCRIPTION
PyObjC 3.1 made a small change that causes its setup.py to read from
stdin and thereby block forever on pypy.  Allow that to fail quickly
like it used to, instead of blocking.