### PR TITLE
Update identity admin branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.project
 *.pydev*
 .coverage
+.coverage.*
 .DS_Store
 *.pyc
 dropin.cache
@@ -10,3 +11,4 @@ _tmp
 _trial_temp
 .tox
 *.egg-info
+*.sw?

--- a/mimic/model/identity_admin_objects.py
+++ b/mimic/model/identity_admin_objects.py
@@ -1,0 +1,41 @@
+"""
+Model objects for the Identity Admin mimic
+"""
+
+from twisted.web.http import BAD_REQUEST
+
+
+def _identity_admin_error_message(msg_type, message, status_code, request):
+    """
+    Set the response code on the request, and return a JSON blob representing
+    a Identity Admin error body, in the format Identity Admin returns error
+    messages.
+
+    :param str msg_type: What type of error this is - something like
+        "badRequest" or "itemNotFound" for Identity Admin.
+    :param str message: The message to include in the body.
+    :param int status_code: The status code to set
+    :param request: the request to set the status code on
+
+    :return: dictionary representing the error body
+    """
+    request.setResponseCode(status_code)
+    return {
+        msg_type: {
+            "message": message,
+            "code": status_code
+        }
+    }
+
+
+def bad_request(message, request):
+    """
+    Return a 400 error body associated with a Identity Admin bad request error.
+    Also sets the response code on the request.
+
+    :param str message: The message to include in the bad request body.
+    :param request: The request on which to set the response code.
+
+    :return: dictionary representing the error body.
+    """
+    return _identity_admin_error_message("badRequest", message, BAD_REQUEST, request)

--- a/mimic/rest/identity_admin_api.py
+++ b/mimic/rest/identity_admin_api.py
@@ -1,0 +1,102 @@
+# -*- test-case-name: mimic.test.test_identity_admin -*-
+"""
+Mocks for the identity admin API.
+"""
+from json import dumps, loads
+
+from zope.interface import implementer
+from twisted.plugin import IPlugin
+
+from mimic.imimic import IAPIMock
+from mimic.rest.mimicapp import MimicApp
+from mimic.model.identity_admin_objects import bad_request
+
+
+@implementer(IAPIMock, IPlugin)
+class IdentityAdminAPI(object):
+    """
+    A mock of the OpenStack Identity Admin API.
+    """
+    def catalog_entries(self, tenant_id):
+        """
+        Return the catalog entries for this tenant.
+        """
+        return []
+
+    def resource_for_region(self, region, uri_prefix, session_store):
+        """
+        Creates an identity admin resource.
+        """
+        return _IdentityAdminImpl().app.resource()
+
+
+class _IdentityAdminImpl(object):
+    """
+    Klein resources for the Identiy admin API.
+
+    TODO: come up with a way better name than IdentityAdminImpl
+    """
+    app = MimicApp()
+
+    @app.route("/v2.0/OS-KSCATALOG/endpointTemplates", methods=("POST",))
+    def add_endpoint_template(self, request):
+        """
+        Adds an endpoint template.
+        """
+        try:
+            content = loads(request.content.read())
+            content = content["OS_KSCATALOG:endpointTemplate"]
+        except (ValueError, KeyError):
+            request.setResponseCode(400)
+            return dumps(bad_request("Invalid JSON request body"))
+
+
+create_endpoint_template_schema = {
+    "title": "Identity admin create endpoint template",
+    "type": "object",
+    "properties": {
+        "OS-KSCATALOG:endpointTemplate": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "region": {
+                    "type": "string"
+                },
+                "global": {
+                    "type": "boolean",
+                    "description": "Is this auto-enabled for all tenants?"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "publicURL": {
+                    "type": "string"
+                },
+                "internalURL": {
+                    "type": "string"
+                },
+                "adminURL": {
+                    "type": "string"
+                },
+                "RAX-AUTH:tenantAlias": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "boolean"
+                },
+                "versioninfo": {
+                    "type": "string"
+                },
+                "versionlist": {
+                    "type": "string"
+                },
+            },
+            "required": ["region"]
+        }
+    }
+}

--- a/mimic/test/fixtures.py
+++ b/mimic/test/fixtures.py
@@ -77,9 +77,13 @@ class APIMockHelper(object):
         self.service_catalog_json = self.auth.service_catalog_json
         self.get_service_endpoint = self.auth.get_service_endpoint
 
-        tenant_id = self.auth.service_catalog_json["access"]["token"]["tenant"]["id"]
-        service_name = apis[0].catalog_entries(tenant_id)[0].name
-        self.uri = self.get_service_endpoint(service_name)
+        try:
+            tenant_id = (self.auth.service_catalog_json
+                         ["access"]["token"]["tenant"]["id"])
+            service_name = apis[0].catalog_entries(tenant_id)[0].name
+            self.uri = self.get_service_endpoint(service_name)
+        except IndexError:
+            self.uri = None
 
 
 class APIDomainMockHelper(object):

--- a/mimic/test/test_identity_admin.py
+++ b/mimic/test/test_identity_admin.py
@@ -1,0 +1,71 @@
+"""
+Tests for the identity admin API.
+"""
+from twisted.plugin import IPlugin
+from twisted.trial.unittest import SynchronousTestCase
+from twisted.web.resource import IResource
+
+from zope.interface.verify import verifyObject
+
+from mimic.imimic import IAPIMock
+from mimic.rest import identity_admin_api as api
+from mimic.test.fixtures import APIMockHelper
+
+
+class IdentityAdminAPITests(SynchronousTestCase):
+    """
+    Tests for the identity admin API mock.
+    """
+    def setUp(self):
+        """
+        Create a identity API mock instance for testing.
+        """
+        self.mock = api.IdentityAdminAPI()
+
+    def test_interface(self):
+        """
+        The identity admin implements the IPlugin and IAPIMock interfaces
+        faithfully.
+        """
+        verifyObject(IAPIMock, self.mock)
+        verifyObject(IPlugin, self.mock)
+
+    def _get_resource(self):
+        """
+        Gets the resource from the API mock.
+        """
+        store = None
+        return self.mock.resource_for_region("REG", "prefix", store)
+
+    def test_catalog_entires(self):
+        """
+        By default, :meth:`catalog_entries` returns an empty list.
+        """
+        self.assertEqual(self.mock.catalog_entries("1234"), [])
+
+    def test_resource_for_region(self):
+        """
+        :meth:`resource_for_region` returns an identity admin resource.
+        """
+        resource = self._get_resource()
+        verifyObject(IResource, resource)
+
+
+class EndpointTemplateCreationTests(SynchronousTestCase):
+    """
+    Tests for endpoint template creation.
+    """
+    def setUp(self):
+        self.helper = APIMockHelper(self, [api.IdentityAdminAPI()])
+
+    def test_create_endpoint_template(self):
+        """
+        Creating an endpoint template adds it to the service catalog of
+        new users.
+        """
+        before = self.helper.service_catalog_json
+        entries = [e for e in before["access"]["serviceCatalog"]
+                   if e["type"] == "mimic:added-by-admin-api"]
+        self.assertEqual(len(entries), 0)
+
+        # TODO: figure out how to get the admin URI here, which means solving


### PR DESCRIPTION
Identity-Admin functionality

- initial work by @lvh  (thanks :smiling_imp:)
- updated @lvh's old branch (identity-admin) against current master
- removed the json schema validation, it wasn't actually used outside the test which was also broken and mimic has dropped it due to lack of use
- added a bad_request object set similar to the nova set for identity-admin using the same structure to keep it clean and make things consistent with existing code