### PR TITLE
Refactor: Rename AuthApi to IdentityApi

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Request for create server that remains in building for 120 seconds:
 ## Rackspace Auth ##
 
 #### Calls supported: ####
-https://github.com/rackerlabs/mimic/blob/master/mimic/rest/auth_api.py
+https://github.com/rackerlabs/mimic/blob/master/mimic/rest/identity_api.py
 
 1. Authenticate - Given a tenant id, username and password, returns the service catalog with links to compute and load balancer links within mimic, and a test token.
 2. Impersonate user (Admin call) - Given a token created by mimic in the header, returns a test token for the username.

--- a/mimic/resource.py
+++ b/mimic/resource.py
@@ -15,8 +15,8 @@ from twisted.logger import Logger
 from mimic.canned_responses.mimic_presets import get_presets
 from mimic.model.behaviors import BehaviorRegistryCollection
 from mimic.rest.mimicapp import MimicApp
-from mimic.rest.auth_api import (
-    AuthApi,
+from mimic.rest.identity_api import (
+    IdentityApi,
     AuthControlApiBehaviors,
     base_uri_from_request
 )
@@ -61,8 +61,8 @@ class MimicRoot(object):
         """
         Get the identity ...
         """
-        return AuthApi(self.core,
-                       self.identity_behavior_registry).app.resource()
+        return IdentityApi(self.core,
+                           self.identity_behavior_registry).app.resource()
 
     @app.route("/noit", branch=True)
     def get_noit_api(self, request):

--- a/mimic/rest/identity_api.py
+++ b/mimic/rest/identity_api.py
@@ -179,7 +179,7 @@ def authenticate_failure_behavior(parameters):
 
 
 @attr.s(hash=False)
-class AuthApi(object):
+class IdentityApi(object):
     """
     Rest endpoints for mocked Auth api.
 

--- a/mimic/rest/maas_api.py
+++ b/mimic/rest/maas_api.py
@@ -20,7 +20,7 @@ from twisted.plugin import IPlugin
 
 from mimic.catalog import Entry
 from mimic.catalog import Endpoint
-from mimic.rest.auth_api import base_uri_from_request
+from mimic.rest.identity_api import base_uri_from_request
 from mimic.rest.mimicapp import MimicApp
 from mimic.imimic import IAPIMock
 from mimic.canned_responses.maas_json_home import json_home

--- a/mimic/test/test_identity_auth.py
+++ b/mimic/test/test_identity_auth.py
@@ -1,6 +1,6 @@
 """
 Tests for mimic identity (:mod:`mimic.model.identity` and
-:mod:`mimic.rest.auth_api`)
+:mod:`mimic.rest.identity_api`)
 """
 
 from __future__ import absolute_import, division, unicode_literals
@@ -351,7 +351,7 @@ class GetAuthTokenAPITests(SynchronousTestCase):
 
     """
     Tests for ``/identity/v2.0/tokens``, provided by
-    :obj:`mimic.rest.auth_api.AuthApi.get_token_and_service_catalog`
+    :obj:`mimic.rest.identity_api.IdentityApi.get_token_and_service_catalog`
     """
 
     def test_response_has_auth_token(self):
@@ -486,7 +486,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
 
     """
     Tests for ``/identity/v2.0/tokens/<token>/endpoints``, provided by
-    `:obj:`mimic.rest.auth_api.AuthApi.get_endpoints_for_token`
+    `:obj:`mimic.rest.identity_api.IdentityApi.get_endpoints_for_token`
     """
 
     def test_session_created_for_token(self):


### PR DESCRIPTION
AuthApi is going to start taking on more non-auth functionality,
and begin to reflect more of Rackspace Identity/OpenStack Keystone.
Therefore it is only fitting to rename it from AuthApi to IdentityApi.