### PR TITLE
Implement keystone get_version

### DIFF
--- a/mimic/canned_responses/auth.py
+++ b/mimic/canned_responses/auth.py
@@ -148,6 +148,8 @@ def get_endpoints(tenant_id, entry_generator, prefix_for_endpoint):
 def get_version_v2(base_uri):
     """
     Canned response for keystone v2 version.
+
+    Cf: http://developer.openstack.org/api-ref-identity-v2.html#listVersions-v2
     """
     return {
         "version": {

--- a/mimic/canned_responses/auth.py
+++ b/mimic/canned_responses/auth.py
@@ -143,3 +143,29 @@ def get_endpoints(tenant_id, entry_generator, prefix_for_endpoint):
                 "id": endpoint.endpoint_id,
             })
     return {"endpoints": result}
+
+
+def get_version_v2(base_uri):
+    """
+    Canned response for keystone v2 version.
+    """
+
+    return {
+        "version": {
+            "status": "stable",
+            "updated": "2014-04-17T00:00:00Z",
+            "media-types": [{
+                "base": "application/json",
+                "type": "application/vnd.openstack.identity-v2.0+json"
+            }],
+            "id": "v2.0",
+            "links": [{
+                "href": base_uri.rstrip("/") + "/identity/v2.0",
+                "rel": "self"
+            }, {
+                "href": "http://docs.openstack.org/",
+                "type": "text/html",
+                "rel": "describedby"
+            }]
+        }
+    }

--- a/mimic/canned_responses/auth.py
+++ b/mimic/canned_responses/auth.py
@@ -149,7 +149,6 @@ def get_version_v2(base_uri):
     """
     Canned response for keystone v2 version.
     """
-
     return {
         "version": {
             "status": "stable",

--- a/mimic/rest/identity_api.py
+++ b/mimic/rest/identity_api.py
@@ -16,7 +16,8 @@ from mimic.canned_responses.auth import (
     get_token,
     get_endpoints,
     format_timestamp,
-    impersonator_user_role)
+    impersonator_user_role,
+    get_version_v2)
 from mimic.canned_responses.mimic_presets import get_presets
 from mimic.core import MimicCore
 from mimic.model.behaviors import make_behavior_api
@@ -191,6 +192,14 @@ class IdentityApi(object):
     registry_collection = attr.ib(
         validator=attr.validators.instance_of(BehaviorRegistryCollection))
     app = MimicApp()
+
+    @app.route('/v2.0', methods=['GET'])
+    def get_version(self, request):
+        """
+        Returns keystone version.
+        """
+        base_uri = base_uri_from_request(request)
+        return json.dumps(get_version_v2(base_uri))
 
     @app.route('/v2.0/tokens', methods=['POST'])
     def get_token_and_service_catalog(self, request):

--- a/mimic/test/test_identity.py
+++ b/mimic/test/test_identity.py
@@ -27,25 +27,25 @@ class IdentitySessionTests(SynchronousTestCase):
         Check generation of keystone canned response, when providing only
         base_uri.
         """
-        expected = {
-            "version": {
-                "status": "stable",
-                "updated": "2014-04-17T00:00:00Z",
-                "media-types": [{
-                    "base": "application/json",
-                    "type": "application/vnd.openstack.identity-v2.0+json"
-                }],
-                "id": "v2.0",
-                "links": [{
-                    "href": "http://ip_server:port/identity/v2.0",
-                    "rel": "self"
-                }, {
-                    "href": "http://docs.openstack.org/",
-                    "type": "text/html",
-                    "rel": "describedby"
-                }]
-            }
-         }
+        expected = {"version":
+                    {"status": "stable",
+                     "updated": "2014-04-17T00:00:00Z",
+                     "media-types":
+                     [{
+                         "base": "application/json",
+                         "type": "application/vnd.openstack.identity-v2.0+json"
+                     }],
+                     "id": "v2.0",
+                     "links":
+                     [{
+                         "href": "http://ip_server:port/identity/v2.0",
+                         "rel": "self"
+                     }, {
+                         "href": "http://docs.openstack.org/",
+                         "type": "text/html",
+                         "rel": "describedby"}]
+                     }
+                    }
         result = get_version_v2("http://ip_server:port/")
 
         self.assertEqual(json.dumps(result, sort_keys=True),

--- a/mimic/test/test_identity.py
+++ b/mimic/test/test_identity.py
@@ -4,9 +4,12 @@ Tests for identity model objects.
 
 from __future__ import absolute_import, division, unicode_literals
 
+import json
+
 from twisted.internet.task import Clock
 from twisted.trial.unittest import SynchronousTestCase
 
+from mimic.canned_responses.auth import get_version_v2
 from mimic.model.identity import IdentitySession
 from mimic.session import SessionStore
 
@@ -18,6 +21,35 @@ class IdentitySessionTests(SynchronousTestCase):
     def setUp(self):
         self.clock = Clock()
         self.session_store = SessionStore(self.clock)
+
+    def test_get_version(self):
+        """
+        Check generation of keystone canned response, when providing only
+        base_uri.
+        """
+        expected = {
+            "version": {
+                "status": "stable",
+                "updated": "2014-04-17T00:00:00Z",
+                "media-types": [{
+                    "base": "application/json",
+                    "type": "application/vnd.openstack.identity-v2.0+json"
+                }],
+                "id": "v2.0",
+                "links": [{
+                    "href": "http://ip_server:port/identity/v2.0",
+                    "rel": "self"
+                }, {
+                    "href": "http://docs.openstack.org/",
+                    "type": "text/html",
+                    "rel": "describedby"
+                }]
+            }
+         }
+        result = get_version_v2("http://ip_server:port/")
+
+        self.assertEqual(json.dumps(result, sort_keys=True),
+                         json.dumps(expected, sort_keys=True))
 
     def test_get_identity_session(self):
         """

--- a/mimic/test/test_identity_auth.py
+++ b/mimic/test/test_identity_auth.py
@@ -16,6 +16,7 @@ from mimic.canned_responses.auth import (
     get_endpoints
 )
 from mimic.canned_responses.mimic_presets import get_presets
+from mimic.canned_responses.auth import get_version_v2
 from mimic.catalog import Entry, Endpoint
 from mimic.core import MimicCore
 from mimic.resource import MimicRoot
@@ -345,6 +346,21 @@ def impersonate_user(test_case, root,
                                     "user": {"username": username or "test1"}}},
         headers=headers
     ))
+
+
+class TestGetVersion(SynchronousTestCase):
+    def test_get_version(self):
+        """
+        Mock keystone "get_version".
+
+        Cf: http://developer.openstack.org/api-ref-identity-v2.html
+        #listVersions-v2
+        """
+        core, root = core_and_root([])
+
+        response, json_body = self.successResultOf(json_request(
+        self, root, b"GET", "/identity/v2.0/"))
+        self.assertEqual(200, response.code)
 
 
 class GetAuthTokenAPITests(SynchronousTestCase):

--- a/mimic/test/test_identity_auth.py
+++ b/mimic/test/test_identity_auth.py
@@ -16,7 +16,6 @@ from mimic.canned_responses.auth import (
     get_endpoints
 )
 from mimic.canned_responses.mimic_presets import get_presets
-from mimic.canned_responses.auth import get_version_v2
 from mimic.catalog import Entry, Endpoint
 from mimic.core import MimicCore
 from mimic.resource import MimicRoot
@@ -351,7 +350,7 @@ def impersonate_user(test_case, root,
 class TestGetVersion(SynchronousTestCase):
     def test_get_version(self):
         """
-        Mock keystone "get_version".
+        Test keystone mock "get_version".
 
         Cf: http://developer.openstack.org/api-ref-identity-v2.html
         #listVersions-v2
@@ -359,7 +358,7 @@ class TestGetVersion(SynchronousTestCase):
         core, root = core_and_root([])
 
         response, json_body = self.successResultOf(json_request(
-        self, root, b"GET", "/identity/v2.0/"))
+            self, root, b"GET", "/identity/v2.0/"))
         self.assertEqual(200, response.code)
 
 


### PR DESCRIPTION
Recent novaclient versions and openstackclient require keystone
resource /identity/v2.0. This commit provides it.