### PR TITLE
Implement nova get_version

### DIFF
--- a/mimic/canned_responses/nova.py
+++ b/mimic/canned_responses/nova.py
@@ -30,6 +30,7 @@ def get_limit():
                           "maxTotalInstances": 200,
                           "maxTotalRAMSize": 256000}}}
 
+
 def get_version_v2(uri):
     """
     Canned response nova v2 version.

--- a/mimic/canned_responses/nova.py
+++ b/mimic/canned_responses/nova.py
@@ -29,3 +29,28 @@ def get_limit():
                           "maxTotalFloatingIps": -1,
                           "maxTotalInstances": 200,
                           "maxTotalRAMSize": 256000}}}
+
+def get_version_v2(uri):
+    """
+    Canned response nova v2 version.
+
+    Cf: http://developer.openstack.org/api-ref-compute-v2.1.html
+    #listVersionsv2.1
+    """
+    return {"version":
+            {"status": "SUPPORTED",
+             "updated": "2011-01-21T11:33:21Z",
+             "links": [{"href": uri,
+                        "rel": "self"},
+                       {"href": "http://docs.openstack.org/",
+                        "type": "text/html",
+                        "rel": "describedby"}],
+             "min_version": "",
+             "version": "",
+             "media-types":
+             [{
+                 "base": "application/json",
+                 "type": "application/vnd.openstack.compute+json;version=2"
+             }],
+             }
+            }

--- a/mimic/rest/nova_api.py
+++ b/mimic/rest/nova_api.py
@@ -17,6 +17,7 @@ from twisted.plugin import IPlugin
 from twisted.web.http import CREATED, BAD_REQUEST
 
 from mimic.canned_responses.nova import get_limit
+from mimic.canned_responses.nova import get_version_v2
 from mimic.model.keypair_objects import GlobalKeyPairCollections, KeyPair
 from mimic.rest.mimicapp import MimicApp
 from mimic.catalog import Entry
@@ -256,6 +257,13 @@ class NovaRegion(object):
         return kp_region_collection
 
     app = MimicApp()
+
+    @app.route('/v2', methods=['GET'])
+    def get_version(self, request):
+        """
+        Returns nova version.
+        """
+        return json.dumps(get_version_v2(self.url("v2")))
 
     @app.route('/v2/<string:tenant_id>/servers', methods=['POST'])
     def create_server(self, request, tenant_id):


### PR DESCRIPTION
Recent novaclient versions and openstackclient require resource
/compute/v2. This commit provides it.