### PR TITLE
CLB health monitor APIs implemented

### DIFF
--- a/mimic/model/clb_objects.py
+++ b/mimic/model/clb_objects.py
@@ -107,6 +107,7 @@ class CLB(object):
     """
     _json = attr.ib()
     nodes = attr.ib(default=attr.Factory(list))
+    health_monitor = attr.ib(default=attr.Factory(dict))
 
     def __getitem__(self, key):
         """
@@ -336,6 +337,36 @@ class RegionalCLBCollection(object):
             log.msg(self.lbs[lb_id]["status"])
             return {'loadBalancer': self.lbs[lb_id].full_json()}, 200
         return not_found_response("loadbalancer"), 404
+
+    def get_health_monitor(self, lb_id):
+        """
+        Return LB's health monitor setting
+        """
+        if lb_id not in self.lbs:
+            return not_found_response("loadbalancer"), 404
+
+        self._verify_and_update_lb_state(lb_id, False, self.clock.seconds())
+        return {"healthMonitor": self.lbs[lb_id].health_monitor}, 200
+
+    def update_health_monitor(self, lb_id, health_monitor):
+        """
+        Update LB's health monitor setting
+        """
+        if lb_id not in self.lbs:
+            return not_found_response("loadbalancer"), 404
+
+        self.lbs[lb_id].health_monitor = health_monitor["healthMonitor"]
+        return EMPTY_RESPONSE, 202
+
+    def delete_health_monitor(self, lb_id):
+        """
+        Delete LB's health monitor configuration
+        """
+        if lb_id not in self.lbs:
+            return not_found_response("loadbalancer"), 404
+
+        self.lbs[lb_id].health_monitor = {}
+        return EMPTY_RESPONSE, 202
 
     def get_node(self, lb_id, node_id):
         """

--- a/mimic/rest/loadbalancer_api.py
+++ b/mimic/rest/loadbalancer_api.py
@@ -243,6 +243,46 @@ class LoadBalancerRegion(object):
         request.setResponseCode(response_data[1])
         return json_dump(response_data[0])
 
+    @app.route("/v2/<string:tenant_id>/loadbalancers/<int:lb_id>/healthmonitor",
+               methods=["GET"])
+    def get_health_monitor(self, request, tenant_id, lb_id):
+        """
+        Return health monitor setting of given LB.
+        https://developer.rackspace.com/docs/cloud-load-balancers/v1/developer-guide/#show-health-monitor-configuration
+        """
+        body, code = self.session(tenant_id).get_health_monitor(lb_id)
+        request.setResponseCode(code)
+        return json_dump(body)
+
+    @app.route("/v2/<string:tenant_id>/loadbalancers/<int:lb_id>/healthmonitor",
+               methods=["PUT"])
+    def update_health_monitor(self, request, tenant_id, lb_id):
+        """
+        Update health monitor setting of given LB.
+        https://developer.rackspace.com/docs/cloud-load-balancers/v1/developer-guide/#update-health-monitor
+        """
+        try:
+            content = json_from_request(request)
+        except ValueError:
+            request.setResponseCode(400)
+            return json.dumps(invalid_resource("Invalid JSON request body"))
+
+        body, code = self.session(tenant_id).update_health_monitor(
+            lb_id, content)
+        request.setResponseCode(code)
+        return json_dump(body)
+
+    @app.route("/v2/<string:tenant_id>/loadbalancers/<int:lb_id>/healthmonitor",
+               methods=["DELETE"])
+    def delete_health_monitor(self, request, tenant_id, lb_id):
+        """
+        Delete health monitor setting of given LB.
+        https://developer.rackspace.com/docs/cloud-load-balancers/v1/developer-guide/#delete-health-monitor
+        """
+        body, code = self.session(tenant_id).delete_health_monitor(lb_id)
+        request.setResponseCode(code)
+        return json_dump(body)
+
     @app.route('/v2/<string:tenant_id>/loadbalancers/<int:lb_id>/nodes', methods=['POST'])
     def add_node_to_load_balancer(self, request, tenant_id, lb_id):
         """

--- a/mimic/test/test_loadbalancer.py
+++ b/mimic/test/test_loadbalancer.py
@@ -472,6 +472,63 @@ class LoadbalancerAPITests(SynchronousTestCase):
         )
         self.assertEqual(list_lb_response_body, {"loadBalancers": []})
 
+    def test_get_health_monitor(self):
+        """
+        `GET ../healthmonitor` will return empty health monitor config
+        when not already setup
+        """
+        lb_id = self._create_loadbalancer()
+        d = request_with_content(
+                self, self.root, b"GET",
+                "{}/loadbalancers/{}/healthmonitor".format(self.uri, lb_id))
+        resp, body = self.successResultOf(d)
+        self.assertEqual(resp.code, 200)
+        self.assertEqual(json.loads(body), {"healthMonitor": {}})
+
+    def test_put_health_monitor(self):
+        """
+        `GET ../healthmonitor` will return health monitor config setup via
+        `PUT ../healthmonitor`
+        """
+        lb_id = self._create_loadbalancer()
+        d = request_with_content(self, self.root, b"PUT",
+                "{}/loadbalancers/{}/healthmonitor".format(self.uri, lb_id),
+                json.dumps({"healthMonitor": {"type": "CONNECT"}}))
+        resp, body = self.successResultOf(d)
+        self.assertEqual(resp.code, 202)
+        self.assertEqual(body, b'')
+        # get and see if it is same
+        d = request_with_content(self, self.root, b"GET",
+                "{}/loadbalancers/{}/healthmonitor".format(self.uri, lb_id))
+        resp, body = self.successResultOf(d)
+        self.assertEqual(json.loads(body), {"healthMonitor": {"type": "CONNECT"}})
+
+    def test_delete_health_monitor(self):
+        """
+        `DELETE ../healthmonitor` will delete current health monitor config
+        """
+        lb_id = self._create_loadbalancer()
+        # put new health monitor config
+        d = request_with_content(self, self.root, b"PUT",
+                "{}/loadbalancers/{}/healthmonitor".format(self.uri, lb_id),
+                json.dumps({"healthMonitor": {"type": "CONNECT"}}))
+        resp, body = self.successResultOf(d)
+        self.assertEqual(resp.code, 202)
+        self.assertEqual(body, b'')
+        # delete it
+        d = request_with_content(self, self.root, b"DELETE",
+                "{}/loadbalancers/{}/healthmonitor".format(self.uri, lb_id))
+        resp, body = self.successResultOf(d)
+        self.assertEqual(resp.code, 202)
+        self.assertEqual(body, b'')
+        # and check if its empty
+        d = request_with_content(self, self.root, b"GET",
+                "{}/loadbalancers/{}/healthmonitor".format(self.uri, lb_id))
+        resp, body = self.successResultOf(d)
+        self.assertEqual(resp.code, 200)
+        self.assertEqual(json.loads(body), {"healthMonitor": {}})
+
+
 
 def _bulk_delete(test_case, root, uri, lb_id, node_ids):
     """Bulk delete multiple nodes."""

--- a/mimic/test/test_loadbalancer.py
+++ b/mimic/test/test_loadbalancer.py
@@ -486,6 +486,10 @@ class LoadbalancerAPITests(SynchronousTestCase):
         self.assertEqual(json.loads(body.decode()), {"healthMonitor": {}})
 
     def _test_health_monitor_404(self, method, req_body=b""):
+        """
+        Test if given health monitor API returns 404 with "loadbalancer not found"
+        error for unknown LB ID
+        """
         not_exists = 23355
         d = request_with_content(
             self, self.root, method,

--- a/mimic/test/test_loadbalancer.py
+++ b/mimic/test/test_loadbalancer.py
@@ -531,6 +531,20 @@ class LoadbalancerAPITests(SynchronousTestCase):
             b"PUT",
             json.dumps({"healthMonitor": {"type": "CONNECT"}}).encode())
 
+    def test_put_health_monitor_invalid_json(self):
+        """
+        `PUT ../healthmonitor` will return 400 invalid json schema
+        when body is invalid json
+        """
+        d = json_request(
+            self, self.root, b"PUT",
+            "{}/loadbalancers/{}/healthmonitor".format(self.uri, 2355),
+            b'bad json')
+        resp, body = self.successResultOf(d)
+        self.assertEqual(
+            (body, resp.code),
+            ({"message": "Invalid JSON request body", "code": 400}, 400))
+
     def test_delete_health_monitor(self):
         """
         `DELETE ../healthmonitor` will delete current health monitor config

--- a/mimic/test/test_loadbalancer.py
+++ b/mimic/test/test_loadbalancer.py
@@ -479,11 +479,11 @@ class LoadbalancerAPITests(SynchronousTestCase):
         """
         lb_id = self._create_loadbalancer()
         d = request_with_content(
-                self, self.root, b"GET",
-                "{}/loadbalancers/{}/healthmonitor".format(self.uri, lb_id))
+            self, self.root, b"GET",
+            "{}/loadbalancers/{}/healthmonitor".format(self.uri, lb_id))
         resp, body = self.successResultOf(d)
         self.assertEqual(resp.code, 200)
-        self.assertEqual(json.loads(body), {"healthMonitor": {}})
+        self.assertEqual(json.loads(body.decode()), {"healthMonitor": {}})
 
     def test_put_health_monitor(self):
         """
@@ -491,17 +491,20 @@ class LoadbalancerAPITests(SynchronousTestCase):
         `PUT ../healthmonitor`
         """
         lb_id = self._create_loadbalancer()
-        d = request_with_content(self, self.root, b"PUT",
-                "{}/loadbalancers/{}/healthmonitor".format(self.uri, lb_id),
-                json.dumps({"healthMonitor": {"type": "CONNECT"}}))
+        d = request_with_content(
+            self, self.root, b"PUT",
+            "{}/loadbalancers/{}/healthmonitor".format(self.uri, lb_id),
+            json.dumps({"healthMonitor": {"type": "CONNECT"}}).encode())
         resp, body = self.successResultOf(d)
         self.assertEqual(resp.code, 202)
         self.assertEqual(body, b'')
         # get and see if it is same
-        d = request_with_content(self, self.root, b"GET",
-                "{}/loadbalancers/{}/healthmonitor".format(self.uri, lb_id))
+        d = json_request(
+            self, self.root, b"GET",
+            "{}/loadbalancers/{}/healthmonitor".format(self.uri, lb_id))
         resp, body = self.successResultOf(d)
-        self.assertEqual(json.loads(body), {"healthMonitor": {"type": "CONNECT"}})
+        self.assertEqual(
+            body, {"healthMonitor": {"type": "CONNECT"}})
 
     def test_delete_health_monitor(self):
         """
@@ -509,25 +512,27 @@ class LoadbalancerAPITests(SynchronousTestCase):
         """
         lb_id = self._create_loadbalancer()
         # put new health monitor config
-        d = request_with_content(self, self.root, b"PUT",
-                "{}/loadbalancers/{}/healthmonitor".format(self.uri, lb_id),
-                json.dumps({"healthMonitor": {"type": "CONNECT"}}))
+        d = request_with_content(
+            self, self.root, b"PUT",
+            "{}/loadbalancers/{}/healthmonitor".format(self.uri, lb_id),
+            json.dumps({"healthMonitor": {"type": "CONNECT"}}).encode())
         resp, body = self.successResultOf(d)
         self.assertEqual(resp.code, 202)
         self.assertEqual(body, b'')
         # delete it
-        d = request_with_content(self, self.root, b"DELETE",
-                "{}/loadbalancers/{}/healthmonitor".format(self.uri, lb_id))
+        d = request_with_content(
+            self, self.root, b"DELETE",
+            "{}/loadbalancers/{}/healthmonitor".format(self.uri, lb_id))
         resp, body = self.successResultOf(d)
         self.assertEqual(resp.code, 202)
         self.assertEqual(body, b'')
         # and check if its empty
-        d = request_with_content(self, self.root, b"GET",
-                "{}/loadbalancers/{}/healthmonitor".format(self.uri, lb_id))
+        d = json_request(
+            self, self.root, b"GET",
+            "{}/loadbalancers/{}/healthmonitor".format(self.uri, lb_id))
         resp, body = self.successResultOf(d)
         self.assertEqual(resp.code, 200)
-        self.assertEqual(json.loads(body), {"healthMonitor": {}})
-
+        self.assertEqual(body, {"healthMonitor": {}})
 
 
 def _bulk_delete(test_case, root, uri, lb_id, node_ids):


### PR DESCRIPTION
Implementation of https://developer.rackspace.com/docs/cloud-load-balancers/v1/developer-guide/#document-api-operations/monitors . This is needed by autoscale to test implementation of https://github.com/rackerlabs/otter/issues/1870.