### PR TITLE
Bug Fix: Validating existing tokens

### DIFF
--- a/mimic/rest/identity_api.py
+++ b/mimic/rest/identity_api.py
@@ -294,8 +294,7 @@ class IdentityApi(object):
         """
         Creates a new session for the given tenant_id and token_id
         and always returns response code 200.
-        Docs: http://developer.openstack.org/api-ref-identity-admin-v2.html#
-              admin-validateToken
+        Docs: http://developer.openstack.org/api-ref-identity-admin-v2.html#admin-validateToken  # noqa
         """
         request.setResponseCode(200)
         session = None

--- a/mimic/rest/identity_api.py
+++ b/mimic/rest/identity_api.py
@@ -294,13 +294,26 @@ class IdentityApi(object):
         """
         Creates a new session for the given tenant_id and token_id
         and always returns response code 200.
-        Docs: http://developer.openstack.org/api-ref-identity-v2.html#admin-tokens
+        Docs: http://developer.openstack.org/api-ref-identity-admin-v2.html#
+              admin-validateToken
         """
         request.setResponseCode(200)
+        session = None
+
+        # Attempt to get the session based on tenant_id+token if the optional
+        # tenant_id is provided; if tenant_id is not provided, then just look
+        # it up based on the token.
         tenant_id = request.args.get(b'belongsTo')
         if tenant_id is not None:
             tenant_id = tenant_id[0].decode("utf-8")
-        session = self.core.sessions.session_for_tenant_id(tenant_id, token_id)
+            session = self.core.sessions.session_for_tenant_id(
+                tenant_id, token_id)
+
+        else:
+            session = self.core.sessions.session_for_token(
+                token_id
+            )
+
         response = get_token(
             session.tenant_id,
             response_token=session.token,

--- a/mimic/test/test_identity_auth.py
+++ b/mimic/test/test_identity_auth.py
@@ -329,6 +329,19 @@ def authenticate_with_token(test_case, root, uri='/identity/v2.0/tokens',
                                                   uri, creds))
 
 
+def tenant_and_token(test_case, root, username, password):
+    """
+    Return the tenant and token for a given username+password combo
+    """
+    response, data = authenticate_with_username_password(
+        test_case, root, username=username, password=password)
+
+    return (
+        data['access']['token']['tenant']['id'],
+        data['access']['token']['id']
+    )
+
+
 def impersonate_user(test_case, root,
                      uri="http://mybase/identity/v2.0/RAX-AUTH/impersonation-tokens",
                      username=None, impersonator_token=None):
@@ -836,26 +849,10 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         """
         core, root = core_and_root([ExampleAPI()])
 
-        user = {
-            "username": "user123456",
-            "password": "654321resu"
-        }
-        admin = {
-            "username": "admin",
-            "password": "nimda"
-        }
-
-        (user_response, user_data) = authenticate_with_username_password(
-            self, root, username=user["username"], password=user["password"])
-
-        (admin_response, admin_data) = authenticate_with_username_password(
-            self, root, username=admin["username"], password=admin["password"])
-
-        user_token = user_data['access']['token']['id']
-        user_tenant = user_data['access']['token']['tenant']['id']
-
-        admin_token = admin_data['access']['token']['id']
-        admin_tenant = admin_data['access']['token']['tenant']['id']
+        user_tenant, user_token = tenant_and_token(
+            self, root, "user123456", "654321resu")
+        admin_tenant, admin_token = tenant_and_token(
+            self, root, "admin", "nimda")
 
         (response, json_body) = self.successResultOf(json_request(
             self, root, b"GET",


### PR DESCRIPTION
Validating an existing token assumed that the tenant-id was specified. If it was not (tenant_id = None) then a new session was being created. This caused problems for tools like Repose.

- Fixed the validate_token function
- Added an explicit test that operates like Repose does.