### PR TITLE
Enhancement osksadm credentials also

### DIFF
--- a/mimic/rest/identity_api.py
+++ b/mimic/rest/identity_api.py
@@ -262,12 +262,17 @@ class IdentityApi(object):
         if user_id in self.core.sessions._userid_to_session:
             username = self.core.sessions._userid_to_session[user_id].username
             password = '9d5ed678fe57bcca610140957afab571'  # echo -n B | md5sum
+            apikey = '0d61f8370cad1d412f80b84d143e1257'  # echo -n C | md5sum
             return json.dumps(
                 {
                     'credentials': {
                         'passwordCredentials': {
                             'username': username,
                             'password': password
+                        },
+                        'RAX-KSKEY:apiKeyCredentials': {
+                            'username': username,
+                            'apikey': apikey
                         }
                     }
                 }

--- a/mimic/rest/identity_api.py
+++ b/mimic/rest/identity_api.py
@@ -265,16 +265,21 @@ class IdentityApi(object):
             apikey = '0d61f8370cad1d412f80b84d143e1257'  # echo -n C | md5sum
             return json.dumps(
                 {
-                    'credentials': {
-                        'passwordCredentials': {
-                            'username': username,
-                            'password': password
+                    'credentials': [
+                        {
+                            'passwordCredentials': {
+                                'username': username,
+                                'password': password
+                            }
                         },
-                        'RAX-KSKEY:apiKeyCredentials': {
-                            'username': username,
-                            'apikey': apikey
+                        {
+                            'RAX-KSKEY:apiKeyCredentials': {
+                                'username': username,
+                                'apikey': apikey
+                            }
                         }
-                    }
+                    ],
+                    "credentials_links": []
                 }
             )
         else:

--- a/mimic/rest/identity_api.py
+++ b/mimic/rest/identity_api.py
@@ -275,7 +275,7 @@ class IdentityApi(object):
                         {
                             'RAX-KSKEY:apiKeyCredentials': {
                                 'username': username,
-                                'apikey': apikey
+                                'apiKey': apikey
                             }
                         }
                     ],

--- a/mimic/rest/identity_api.py
+++ b/mimic/rest/identity_api.py
@@ -250,6 +250,33 @@ class IdentityApi(object):
             "updated": seconds_to_timestamp(time.time())
         }))
 
+    @app.route('/v2.0/users/<string:user_id>/OS-KSADM/credentials',
+               methods=['GET'])
+    def get_user_credentials_osksadm(self, request, user_id):
+        """
+        Support, such as it is, for the credentials call.
+
+        reference: http://developer.openstack.org/api-ref-identity-v2-ext.html
+            #listCredentials
+        """
+        if user_id in self.core.sessions._userid_to_session:
+            username = self.core.sessions._userid_to_session[user_id].username
+            password = '9d5ed678fe57bcca610140957afab571'  # echo -n B | md5sum
+            return json.dumps(
+                {
+                    'credentials': {
+                        'passwordCredentials': {
+                            'username': username,
+                            'password': password
+                        }
+                    }
+                }
+            )
+        else:
+            request.setResponseCode(404)
+            return json.dumps({'itemNotFound':
+                              {'code': 404, 'message': 'User ' + user_id + ' not found'}})
+
     @app.route('/v2.0/users/<string:user_id>/OS-KSADM/credentials/RAX-KSKEY:apiKeyCredentials',
                methods=['GET'])
     def rax_kskey_apikeycredentials(self, request, user_id):

--- a/mimic/test/test_identity_auth.py
+++ b/mimic/test/test_identity_auth.py
@@ -723,7 +723,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         self.assertIn('credentials', json_body)
         credential_types = {
             'passwordCredentials': 'password',
-            'RAX-KSKEY:apiKeyCredentials': 'apikey',
+            'RAX-KSKEY:apiKeyCredentials': 'apiKey',
         }
         for credential in json_body['credentials']:
             # there should only be one entry in the dict

--- a/mimic/test/test_identity_auth.py
+++ b/mimic/test/test_identity_auth.py
@@ -716,18 +716,25 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
             "/OS-KSADM/credentials"
         ))
         self.assertEqual(response.code, 200)
-        self.assertEqual(
-            json_body['credentials']['passwordCredentials']['username'],
-            username)
-        self.assertEqual(
-            len(json_body['credentials']['passwordCredentials']['password']),
-            32)
-        self.assertEqual(
-            json_body['credentials']['RAX-KSKEY:apiKeyCredentials']['username'],
-            username)
-        self.assertEqual(
-            len(json_body['credentials']['RAX-KSKEY:apiKeyCredentials']['apikey']),
-            32)
+
+        self.assertIn('credentials_links', json_body)
+        self.assertEqual(len(json_body['credentials_links']), 0)
+
+        self.assertIn('credentials', json_body)
+        credential_types = {
+            'passwordCredentials': 'password',
+            'RAX-KSKEY:apiKeyCredentials': 'apikey',
+        }
+        for credential in json_body['credentials']:
+            # there should only be one entry in the dict
+            # the key for that entry tells what kind of credential
+            # it is
+            self.assertEqual(len(credential), 1)
+
+            # however, it's more compact to validate it this way:
+            for k, v in credential.items():
+                self.assertEqual(v['username'], username)
+                self.assertEqual(len(v[credential_types[k]]), 32)
 
     def test_token_and_catalog_for_api_credentials_wrong_tenant(self):
         """

--- a/mimic/test/test_identity_auth.py
+++ b/mimic/test/test_identity_auth.py
@@ -19,6 +19,7 @@ from mimic.canned_responses.mimic_presets import get_presets
 from mimic.catalog import Entry, Endpoint
 from mimic.core import MimicCore
 from mimic.resource import MimicRoot
+from mimic.rest.identity_api import IdentityApi
 from mimic.test.behavior_tests import (
     behavior_tests_helper_class,
     register_behavior
@@ -662,8 +663,8 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         creds = {
             "auth": {
                 "passwordCredentials": {
-                    "username": "HedKandi",
-                    "password": "Ministry Of Sound UK"
+                    "username": "rfc2324_2-3-2_418",
+                    "password": "iamateapot"
                 },
                 "tenantId": "77777"
             }
@@ -681,8 +682,9 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         self.assertEqual(response.code, 200)
         self.assertEqual(json_body['RAX-KSKEY:apiKeyCredentials']['username'],
                          username)
-        self.assertTrue(
-            len(json_body['RAX-KSKEY:apiKeyCredentials']['apiKey']) == 32)
+        self.assertEqual(
+            len(json_body['RAX-KSKEY:apiKeyCredentials']['apiKey']),
+            IdentityApi.apikey_length)
 
     def test_osksadm_credentials_list(self):
         """
@@ -699,8 +701,8 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         creds = {
             "auth": {
                 "passwordCredentials": {
-                    "username": "HedKandi",
-                    "password": "Ministry Of Sound UK"
+                    "username": "rfc2324_2-3-2_418",
+                    "password": "iamateapot"
                 },
                 "tenantId": "77777"
             }
@@ -722,8 +724,10 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
 
         self.assertIn('credentials', json_body)
         credential_types = {
-            'passwordCredentials': 'password',
-            'RAX-KSKEY:apiKeyCredentials': 'apiKey',
+            'RAX-KSKEY:apiKeyCredentials': {
+                'value': 'apiKey',
+                'length': IdentityApi.apikey_length
+            }
         }
         for credential in json_body['credentials']:
             # there should only be one entry in the dict
@@ -734,7 +738,9 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
             # however, it's more compact to validate it this way:
             for k, v in credential.items():
                 self.assertEqual(v['username'], username)
-                self.assertEqual(len(v[credential_types[k]]), 32)
+                self.assertEqual(
+                    len(v[credential_types[k]['value']]),
+                    credential_types[k]['length'])
 
     def test_token_and_catalog_for_api_credentials_wrong_tenant(self):
         """

--- a/mimic/test/test_identity_auth.py
+++ b/mimic/test/test_identity_auth.py
@@ -722,6 +722,12 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         self.assertEqual(
             len(json_body['credentials']['passwordCredentials']['password']),
             32)
+        self.assertEqual(
+            json_body['credentials']['RAX-KSKEY:apiKeyCredentials']['username'],
+            username)
+        self.assertEqual(
+            len(json_body['credentials']['RAX-KSKEY:apiKeyCredentials']['apikey']),
+            32)
 
     def test_token_and_catalog_for_api_credentials_wrong_tenant(self):
         """


### PR DESCRIPTION
Mimic supported looking up the API Key of a user via `/v2.0/users/<userid>/OS-KSADM/credentials/RAX-KSKEY:apiKeyCredentials`; however, tools like `pyrax` had support for doing the generic credentials lookup via `/v2.0/users/<userid>/OS-KSADM/credentials` which Mimic was not supporting. This adds the additional functionality so that either method can be used. It also includes a separate API key when doing so to aid with debugging, and also provides a similar password credentials.