### PR TITLE
CLB node status changes

### DIFF
--- a/mimic/model/clb_objects.py
+++ b/mimic/model/clb_objects.py
@@ -154,6 +154,14 @@ class CLB(object):
         return result
 
 
+node_creation = EventDescription()
+
+
+@node_creation.declare_criterion("clb_id")
+def clb_id_criterion(value):
+    return Criterion(name='clb_id', predicate=lambda v: v == value)
+
+
 @attr.s
 class BadKeysError(Exception):
     """

--- a/mimic/model/clb_objects.py
+++ b/mimic/model/clb_objects.py
@@ -61,7 +61,7 @@ class Node(object):
         default="ENABLED")
     id = attr.ib(validator=attr.validators.instance_of(int),
                  default=attr.Factory(lambda: randrange(999999)))
-    status = attr.ib(validator=attr.validators.instance_of(text_type),
+    status = attr.ib(validator=one_of_validator("ONLINE", "OFFLINE"),
                      default="ONLINE")
     feed_events = attr.ib(default=[])
 
@@ -565,7 +565,11 @@ class RegionalCLBCollection(object):
                     "per load balancer.".format(self.node_limit), 413)
                 return (resource, 413)
 
-            # Update node status based on health monitor
+            # Node status will be OFFLINE if health monitor is enabled in CLB
+            # ONLINE if health monitor is disabled
+            if self.lbs[lb_id].health_monitor != {}:
+                for node in nodes:
+                    node.status = "OFFLINE"
 
             self._verify_and_update_lb_state(
                 lb_id, current_timestamp=current_timestamp)

--- a/mimic/model/clb_objects.py
+++ b/mimic/model/clb_objects.py
@@ -154,14 +154,6 @@ class CLB(object):
         return result
 
 
-node_creation = EventDescription()
-
-
-@node_creation.declare_criterion("clb_id")
-def clb_id_criterion(value):
-    return Criterion(name='clb_id', predicate=lambda v: v == value)
-
-
 @attr.s
 class BadKeysError(Exception):
     """
@@ -572,6 +564,8 @@ class RegionalCLBCollection(object):
                     "Nodes must not exceed {0} "
                     "per load balancer.".format(self.node_limit), 413)
                 return (resource, 413)
+
+            # Update node status based on health monitor
 
             self._verify_and_update_lb_state(
                 lb_id, current_timestamp=current_timestamp)

--- a/mimic/rest/loadbalancer_api.py
+++ b/mimic/rest/loadbalancer_api.py
@@ -124,7 +124,7 @@ class LoadBalancerControlRegion(object):
 
     def _collection_from_tenant(self, tenant_id):
         """
-        Retrieve the server collection for this region for the given tenant.
+        Retrieve the CLB collection for this region for the given tenant.
         """
         return (self.api_mock.lb_api._get_session(self.session_store, tenant_id)
                 .collection_for_region(self.region))

--- a/mimic/test/fixtures.py
+++ b/mimic/test/fixtures.py
@@ -77,8 +77,8 @@ class APIMockHelper(object):
         self.service_catalog_json = self.auth.service_catalog_json
         self.get_service_endpoint = self.auth.get_service_endpoint
 
-        tenant_id = self.auth.service_catalog_json["access"]["token"]["tenant"]["id"]
-        service_name = apis[0].catalog_entries(tenant_id)[0].name
+        self.tenant_id = self.auth.service_catalog_json["access"]["token"]["tenant"]["id"]
+        service_name = apis[0].catalog_entries(self.tenant_id)[0].name
         self.uri = self.get_service_endpoint(service_name)
 
 

--- a/mimic/test/fixtures.py
+++ b/mimic/test/fixtures.py
@@ -77,6 +77,7 @@ class APIMockHelper(object):
         self.service_catalog_json = self.auth.service_catalog_json
         self.get_service_endpoint = self.auth.get_service_endpoint
 
+        # Tenant ID of test tenant authenticated against mimic identity
         self.tenant_id = self.auth.service_catalog_json["access"]["token"]["tenant"]["id"]
         service_name = apis[0].catalog_entries(self.tenant_id)[0].name
         self.uri = self.get_service_endpoint(service_name)

--- a/mimic/test/test_loadbalancer.py
+++ b/mimic/test/test_loadbalancer.py
@@ -238,7 +238,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
 
     def test_update_node_status(self):
         """
-        `PUT ../loadbalancers/lb_id/nodes/node_id/status` will update node's
+        ``PUT .../loadbalancers/lb_id/nodes/node_id/status`` will update node's
         status
         """
         # create LB with node
@@ -265,7 +265,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
 
     def test_update_node_status_bad_clb(self):
         """
-        `PUT ../loadbalancers/lb_id/nodes/node_id/status` will return 404
+        ``PUT .../loadbalancers/lb_id/nodes/node_id/status`` will return 404
         for invalid CLB ID
         """
         resp, body = self.successResultOf(json_request(
@@ -279,7 +279,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
 
     def test_update_node_status_bad_node(self):
         """
-        `PUT ../loadbalancers/lb_id/nodes/node_id/status` will return 404
+        ``PUT .../loadbalancers/lb_id/nodes/node_id/status`` will return 404
         for invalid node ID on a valid CLB
         """
         lb_id = self._create_loadbalancer()
@@ -295,7 +295,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
 
     def test_update_node_status_invalid_json(self):
         """
-        `PUT ../loadbalancers/lb_id/nodes/node_id/status` will return 400
+        ``PUT .../loadbalancers/lb_id/nodes/node_id/status`` will return 400
         for invalid JSON body
         """
         # create LB with node
@@ -315,7 +315,7 @@ class LoadbalancerAPITests(SynchronousTestCase):
 
     def test_update_node_status_bad_request(self):
         """
-        `PUT ../loadbalancers/lb_id/nodes/node_id/status` will return 400
+        ``PUT .../loadbalancers/lb_id/nodes/node_id/status`` will return 400
         for JSON body that doesn't have "status"
         """
         # create LB with node


### PR DESCRIPTION
Closes #629.

- Newly created CLB node's status will be OFFLINE if corresponding CLB's health monitor is disabled.
- Control plane API is implemented to update CLB node status.