### PR TITLE
Bugfix account operations

### DIFF
--- a/mimic/rest/swift_api.py
+++ b/mimic/rest/swift_api.py
@@ -190,6 +190,21 @@ class SwiftTenantInRegion(object):
         Initialize a tenant with some containers.
         """
         self.containers = {}
+        self.metadata = {}
+
+    @app.route("/", methods=["POST"])
+    def create_account_metadata(self, request):
+        """
+        Save the meta-data
+        """
+        for k, v in request.requestHeaders.getAllRawHeaders():
+            key = k.decode("utf-8")
+            key_compare = key.lower()
+            if key_compare.startswith("x-account-meta-"):
+                metakey_name = key[len("x-account-meta-"):]
+                self.metadata[metakey_name] = v
+        request.setResponseCode(204)
+        return b""
 
     @app.route("/", methods=["HEAD"])
     def head_account(self, request):
@@ -202,7 +217,6 @@ class SwiftTenantInRegion(object):
         for container in self.containers.values():
             total_objects += container.object_count
             total_bytes += container.byte_count
-
         container_count = "{0}".format(total_containers).encode("utf-8")
         object_count = "{0}".format(total_objects).encode("utf-8")
         byte_count = "{0}".format(total_bytes).encode("utf-8")
@@ -214,9 +228,13 @@ class SwiftTenantInRegion(object):
                                               [object_count])
         request.responseHeaders.setRawHeaders(b"x-account-bytes-used",
                                               [byte_count])
+        for k, v in self.metadata.items():
+            request.responseHeaders.setRawHeaders(
+                "X-Account-Meta-{0}".format(k).encode("utf-8"),
+                v)
+
         request.setResponseCode(204)
         return b""
-
 
     @app.route("/<string:container_name>", methods=["PUT"])
     def create_container(self, request, container_name):

--- a/mimic/rest/swift_api.py
+++ b/mimic/rest/swift_api.py
@@ -191,6 +191,33 @@ class SwiftTenantInRegion(object):
         """
         self.containers = {}
 
+    @app.route("/", methods=["HEAD"])
+    def head_account(self, request):
+        """
+        Api call to get the meta-data regarding all containers for a tenant
+        """
+        total_containers = len(self.containers)
+        total_objects = 0
+        total_bytes = 0
+        for container in self.containers.values():
+            total_objects += container.object_count
+            total_bytes += container.byte_count
+
+        container_count = "{0}".format(total_containers).encode("utf-8")
+        object_count = "{0}".format(total_objects).encode("utf-8")
+        byte_count = "{0}".format(total_bytes).encode("utf-8")
+        request.responseHeaders.setRawHeaders(b"content-type",
+                                              [b"application/json"])
+        request.responseHeaders.setRawHeaders(b"x-account-container-count",
+                                              [container_count])
+        request.responseHeaders.setRawHeaders(b"x-account-object-count",
+                                              [object_count])
+        request.responseHeaders.setRawHeaders(b"x-account-bytes-used",
+                                              [byte_count])
+        request.setResponseCode(204)
+        return b""
+
+
     @app.route("/<string:container_name>", methods=["PUT"])
     def create_container(self, request, container_name):
         """

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -6,6 +6,7 @@ attrs==16.0.0
 cffi==1.6.0
 coverage==4.1
 cryptography==1.3.2
+ddt=1.1.0
 enum34==1.1.6
 extras==1.0.0
 idna==2.1

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -6,7 +6,7 @@ attrs==16.0.0
 cffi==1.6.0
 coverage==4.1
 cryptography==1.3.2
-ddt=1.1.0
+ddt==1.1.0
 enum34==1.1.6
 extras==1.0.0
 idna==2.1


### PR DESCRIPTION
Update SwiftMock for support the HEAD and POST operations at the Account level.
These calls are inseparable without ability to access the underlying model/framework to validate the storage details as one adds data and the other retrieves it.

POST allows the ability to add custom metadata on the account.
HEAD allows retrieval of the custom metadata as well as counts of total containers, total objects (in all containers), and total bytes used (by all objects in all containers).