### PR TITLE
fix the pypy builder to be able to build its own Cryptography wheels if necessary

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -3,12 +3,23 @@
 set -e
 set -x
 
+UPDATED_BREW="false";
+
+function _brew_update () {
+    if "${UPDATED_BREW}"; then
+        return 0;
+    else
+        UPDATED_BREW=true;
+        brew update;
+    fi;
+}
+
 if [[ "${MACAPP_ENV}" == "system" ]]; then
     # If we are testing the mac app environment, it's a bit of a special case;
     # the only setup we need to do is to ensure that homebrew python is the
     # default.
 
-    brew update;
+    _brew_update;
     brew install python;
     exit 0;
 fi;
@@ -19,11 +30,24 @@ else
     DARWIN="false";
 fi
 
+
 # Do we need to use a Python from pyenv, or will the system one suffice?
 PYENV_PYTHON="";
 
 if [[ "${TOXENV}" == "pypy" ]]; then
     PYENV_PYTHON="pypy-4.0.1";
+    if [[ "$DARWIN" == "true" ]]; then
+        _brew_update;
+        brew install openssl;
+
+        # Set up build environment so we can create Cryptography wheels if
+        # necessary.
+        local kegpath="$(brew --prefix)/opt/openssl";
+        export LDFLAGS="-L${kegpath}/lib $LDFLAGS";
+        export CPPFLAGS="-I${kegpath}/include $CPPFLAGS";
+        export CFLAGS="${LDFLAGS} ${CPPFLAGS} ${CFLAGS}";
+        export PATH="${kegpath}/bin:$PATH";
+    fi;
 fi;
 
 # If we need a python not available in Travis's environment, install pyenv in a
@@ -31,7 +55,7 @@ fi;
 
 if [[ -n "${PYENV_PYTHON}" ]]; then
     if [[ "$DARWIN" == "true" ]]; then
-        brew update;
+        _brew_update;
         brew install pyenv || brew upgrade pyenv;
     else
         git clone https://github.com/yyuu/pyenv.git ~/.pyenv;

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -42,7 +42,7 @@ if [[ "${TOXENV}" == "pypy" ]]; then
 
         # Set up build environment so we can create Cryptography wheels if
         # necessary.
-        local kegpath="$(brew --prefix)/opt/openssl";
+        kegpath="$(brew --prefix)/opt/openssl";
         export LDFLAGS="-L${kegpath}/lib $LDFLAGS";
         export CPPFLAGS="-I${kegpath}/include $CPPFLAGS";
         export CFLAGS="${LDFLAGS} ${CPPFLAGS} ${CFLAGS}";

--- a/requirements/documentation-only.txt
+++ b/requirements/documentation-only.txt
@@ -1,5 +1,5 @@
 # Documentation only required deps
-alabaster==0.7.8
+alabaster==0.7.9
 Babel==2.3.4
 chardet==2.3.0
 doc8==0.7.0
@@ -8,10 +8,10 @@ Jinja2==2.8
 MarkupSafe==0.23
 pbr==1.10.0
 Pygments==2.1.3
-pytz==2016.4
-restructuredtext-lint==0.14.3
+pytz==2016.6.1
+restructuredtext-lint==0.17.0
 six==1.10.0
 snowballstemmer==1.2.1
-Sphinx==1.4.2
+Sphinx==1.4.5
 sphinx-rtd-theme==0.1.9
-stevedore==1.14.0
+stevedore==1.17.0

--- a/requirements/lint-only.txt
+++ b/requirements/lint-only.txt
@@ -1,5 +1,5 @@
-flake8==2.5.4
-mccabe==0.5.0
+flake8==3.0.4
+mccabe==0.5.2
 pep257==0.7.0
 pep8==1.7.0
 pyflakes==1.2.3

--- a/requirements/mac-app.txt
+++ b/requirements/mac-app.txt
@@ -8,5 +8,5 @@ py2app==0.10
 pyobjc-core==3.1.1
 pyobjc-framework-CFNetwork==3.1.1
 pyobjc-framework-Cocoa==3.1.1
-setuptools==22.0.0
+setuptools==25.1.6
 

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -3,9 +3,9 @@
 # install coverage", and running 'pip freeze'.
 
 attrs==16.0.0
-cffi==1.6.0
-coverage==4.1
-cryptography==1.3.2
+cffi==1.7.0
+coverage==4.2
+cryptography==1.4
 ddt==1.1.0
 enum34==1.1.6
 extras==1.0.0
@@ -19,15 +19,15 @@ pyasn1-modules==0.0.8
 pycparser==2.14
 pyOpenSSL==16.0.0
 python-mimeparse==1.5.2
-requests==2.10.0
+requests==2.11.0
 service-identity==16.0.0
 six==1.10.0
 testtools==1.7.1 # rq.filter: <1.8.0
 traceback2==1.4.0
 treq==15.1.0
-Twisted==16.2.0
+Twisted==16.3.0
 unittest2==1.1.0
 Werkzeug==0.11.10
 wheel==0.29.0
 xmltodict==0.10.2
-zope.interface==4.1.3
+zope.interface==4.2.0

--- a/requirements/spellcheck.txt
+++ b/requirements/spellcheck.txt
@@ -3,5 +3,5 @@
 # 'documentation.txt' because this has the native dependency of 'libenchant'
 # and may cause problems for some contributors to get set up locally.
 
-pyenchant==1.6.6
-sphinxcontrib-spelling==2.1.2
+pyenchant==1.6.7
+sphinxcontrib-spelling==2.2.0

--- a/requirements/toolchain.txt
+++ b/requirements/toolchain.txt
@@ -2,11 +2,11 @@
 
 detox==0.10.0
 eventlet==0.19.0
-greenlet==0.4.9
+greenlet==0.4.10
 pluggy==0.3.1
 py==1.4.31
 tox==2.3.1
-virtualenv==15.0.2
+virtualenv==15.0.3
 
 # Allow pip to float because its command-line interface is very stable.
 pip>=7.1.2


### PR DESCRIPTION
This should allow us to catch up with #636 .