### PR TITLE
Enhancement restore external api restful interface

### DIFF
--- a/mimic/core.py
+++ b/mimic/core.py
@@ -24,34 +24,31 @@ from mimic.model.glance_objects import GlanceAdminImageStore
 from mimic.model.valkyrie_objects import ValkyrieStore
 
 
-class MimicCoreExceptions(Exception):
+class MimicCoreException(Exception):
     """
     Parent for all Exceptions related to MimicCore
     """
-    pass
 
 
-class ServiceBadInterface(MimicCoreExceptions):
+class ServiceBadInterface(MimicCoreException):
     """
     Service does not implement the required interface.
     """
-    pass
 
 
-class ServiceExistenceErrors(MimicCoreExceptions):
+class ServiceExistenceError(MimicCoreException):
     """
     Exceptions related to Service Existence
     """
 
 
-class ServiceDoesNotExist(ServiceExistenceErrors):
+class ServiceDoesNotExist(ServiceExistenceError):
     """
     API does not exist
     """
-    pass
 
 
-class ServiceExists(ServiceExistenceErrors):
+class ServiceExists(ServiceExistenceError):
     """
     API Already Exists
     """
@@ -61,21 +58,18 @@ class ServiceIdExists(ServiceExists):
     """
     API with the same ID already exists.
     """
-    pass
 
 
 class ServiceNameExists(ServiceExists):
     """
     API with the same name already exists.
     """
-    pass
 
 
-class ServiceStateError(MimicCoreExceptions):
+class ServiceStateError(MimicCoreException):
     """
     Exceptions related to Service States
     """
-    pass
 
 
 class ServiceHasTemplates(ServiceStateError):

--- a/mimic/model/identity_errors.py
+++ b/mimic/model/identity_errors.py
@@ -7,35 +7,30 @@ class EndpointTemplateException(Exception):
     """
     Parent for all Identity Endpoint Template Exceptions
     """
-    pass
 
 
 class InvalidEndpointTemplateException(EndpointTemplateException):
     """
     Parent for all Endpoint Template Validation Exceptions.
     """
-    pass
 
 
 class InvalidEndpointTemplateInterface(InvalidEndpointTemplateException):
     """
     :obj: does not implement the required interface, :obj:IEndpointTemplate.
     """
-    pass
 
 
 class InvalidEndpointTemplateMissingKey(InvalidEndpointTemplateException):
     """
     :obj: is missing a required field.
     """
-    pass
 
 
 class InvalidEndpointTemplateId(InvalidEndpointTemplateException):
     """
     :obj: has an invalid endpoint template id value.
     """
-    pass
 
 
 class InvalidEndpointTemplateServiceType(InvalidEndpointTemplateException):
@@ -43,32 +38,27 @@ class InvalidEndpointTemplateServiceType(InvalidEndpointTemplateException):
     :obj: has an invalid service type or the service type does not match
     the API it is being submitted for.
     """
-    pass
 
 
 class EndpointTemplateDisabledForTenant(EndpointTemplateException):
     """
     Specified endpoint template is disabled for the tenant.
     """
-    pass
 
 
 class EndpointTemplateExistenceException(EndpointTemplateException):
     """
     Parent of template existence exceptions.
     """
-    pass
 
 
 class EndpointTemplateAlreadyExists(EndpointTemplateExistenceException):
     """
     Endpoint Template already exists.
     """
-    pass
 
 
 class EndpointTemplateDoesNotExist(EndpointTemplateExistenceException):
     """
     Endpoint Template does not exist.
     """
-    pass

--- a/mimic/model/identity_errors.py
+++ b/mimic/model/identity_errors.py
@@ -3,14 +3,14 @@ Errors for the Identity Models
 """
 
 
-class EndpointTemplateExceptions(Exception):
+class EndpointTemplateException(Exception):
     """
     Parent for all Identity Endpoint Template Exceptions
     """
     pass
 
 
-class InvalidEndpointTemplateException(EndpointTemplateExceptions):
+class InvalidEndpointTemplateException(EndpointTemplateException):
     """
     Parent for all Endpoint Template Validation Exceptions.
     """
@@ -46,28 +46,28 @@ class InvalidEndpointTemplateServiceType(InvalidEndpointTemplateException):
     pass
 
 
-class EndpointTemplateDisabledForTenant(EndpointTemplateExceptions):
+class EndpointTemplateDisabledForTenant(EndpointTemplateException):
     """
     Specified endpoint template is disabled for the tenant.
     """
     pass
 
 
-class EndpointTemplateExistenceExceptions(EndpointTemplateExceptions):
+class EndpointTemplateExistenceException(EndpointTemplateException):
     """
     Parent of template existence exceptions.
     """
     pass
 
 
-class EndpointTemplateAlreadyExists(EndpointTemplateExistenceExceptions):
+class EndpointTemplateAlreadyExists(EndpointTemplateExistenceException):
     """
     Endpoint Template already exists.
     """
     pass
 
 
-class EndpointTemplateDoesNotExist(EndpointTemplateExistenceExceptions):
+class EndpointTemplateDoesNotExist(EndpointTemplateExistenceException):
     """
     Endpoint Template does not exist.
     """

--- a/mimic/model/identity_errors.py
+++ b/mimic/model/identity_errors.py
@@ -1,0 +1,74 @@
+"""
+Errors for the Identity Models
+"""
+
+
+class EndpointTemplateExceptions(Exception):
+    """
+    Parent for all Identity Endpoint Template Exceptions
+    """
+    pass
+
+
+class InvalidEndpointTemplateException(EndpointTemplateExceptions):
+    """
+    Parent for all Endpoint Template Validation Exceptions.
+    """
+    pass
+
+
+class InvalidEndpointTemplateInterface(InvalidEndpointTemplateException):
+    """
+    :obj: does not implement the required interface, :obj:IEndpointTemplate.
+    """
+    pass
+
+
+class InvalidEndpointTemplateMissingKey(InvalidEndpointTemplateException):
+    """
+    :obj: is missing a required field.
+    """
+    pass
+
+
+class InvalidEndpointTemplateId(InvalidEndpointTemplateException):
+    """
+    :obj: has an invalid endpoint template id value.
+    """
+    pass
+
+
+class InvalidEndpointTemplateServiceType(InvalidEndpointTemplateException):
+    """
+    :obj: has an invalid service type or the service type does not match
+    the API it is being submitted for.
+    """
+    pass
+
+
+class EndpointTemplateDisabledForTenant(EndpointTemplateExceptions):
+    """
+    Specified endpoint template is disabled for the tenant.
+    """
+    pass
+
+
+class EndpointTemplateExistenceExceptions(EndpointTemplateExceptions):
+    """
+    Parent of template existence exceptions.
+    """
+    pass
+
+
+class EndpointTemplateAlreadyExists(EndpointTemplateExistenceExceptions):
+    """
+    Endpoint Template already exists.
+    """
+    pass
+
+
+class EndpointTemplateDoesNotExist(EndpointTemplateExistenceExceptions):
+    """
+    Endpoint Template does not exist.
+    """
+    pass

--- a/mimic/model/identity_objects.py
+++ b/mimic/model/identity_objects.py
@@ -135,7 +135,7 @@ class EndpointTemplateStore(object):
         tenant
 
 
-    Note: The OpenStack documentation[0] does not specify any required
+    .. note:: The OpenStack documentation[0] does not specify any required
         parameters. For this implementation, the `id`, `region`, `type`,
         and `name` fields are required. The `name` and `type` fields
         are used for creating an instance of the :obj:`ExternalApiStore`
@@ -274,7 +274,7 @@ class ExternalApiStore(object):
     services of the same service type (e.g object-store) but with different
     service names (e.g Cloud Files, OpenStack Swift).
 
-    Note: An endpoint template typically maps to a region.
+    .. note:: An endpoint template typically maps to a region.
 
     Work-In-Progress: Implementation is unstable and subject to change.
     """
@@ -546,7 +546,7 @@ class ExternalApiStore(object):
         """
         Return the URI for the service in the given region.
 
-        Note: This only returns the public URL at present to match
+        .. note:: This only returns the public URL at present to match
             the rest of Mimic's implementation. Supporting multiple
             URL types (public vs snet vs admin) is left for another
             feature addition.

--- a/mimic/rest/decorators.py
+++ b/mimic/rest/decorators.py
@@ -1,0 +1,39 @@
+"""
+Utility Decorators for RESTful APIs
+"""
+
+from functools import wraps
+import inspect
+import json
+
+from mimic.model.identity_objects import unauthorized
+
+
+def require_auth_token(func):
+    """
+    Decorator to require the presence of a valid Auth Token
+    via the X-Auth-Token header field in a request.
+
+    .. note:: Expects to be called on an object's method for handling
+        a request.
+    .. note:: A request handler can use the keyword parameter `auth_token`
+        to receive the Auth Token extracted from the headers.
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        request = args[1]
+
+        x_auth_token = request.getHeader(b"x-auth-token")
+        if x_auth_token is None:
+            return json.dumps(unauthorized("Authentication required", request))
+
+        # function may optionally want the auth token, check its parameters
+        # to see if it is in the arg spec
+        handler_parameters = inspect.getargspec(func)
+        handler_kwargs = handler_parameters[0]
+        if 'auth_token' in handler_kwargs:
+            kwargs['auth_token'] = x_auth_token.decode('utf-8')
+
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/mimic/rest/identity_api.py
+++ b/mimic/rest/identity_api.py
@@ -48,9 +48,9 @@ from mimic.model.identity_objects import (
     conflict,
     EndpointTemplateStore,
     ExternalApiStore,
-    not_found,
-    unauthorized
+    not_found
 )
+from mimic.rest.decorators import require_auth_token
 from mimic.rest.mimicapp import MimicApp
 from mimic.session import NonMatchingTenantError
 from mimic.util.helper import (
@@ -695,6 +695,7 @@ class IdentityApi(object):
                             " header with a valid token.")}})
 
     @app.route('/v2.0/services', methods=['GET'])
+    @require_auth_token
     def list_external_api_services(self, request):
         """
         List the available external services that endpoint templates
@@ -704,10 +705,6 @@ class IdentityApi(object):
         `OpenStack Identity v2 OS-KSADM List Services
         <http://developer.openstack.org/api-ref/identity/v2-ext/index.html#list-services-admin-extension>`_
         """
-        x_auth_token = request.getHeader(b"x-auth-token")
-        if x_auth_token is None:
-            return json.dumps(unauthorized("Authentication required", request))
-
         request.setResponseCode(200)
         return json.dumps({
             "OS-KSADM:services": [
@@ -722,6 +719,7 @@ class IdentityApi(object):
                     for api_id in self.core.get_external_apis()]]})
 
     @app.route('/v2.0/services', methods=['POST'])
+    @require_auth_token
     def create_external_api_service(self, request):
         """
         Create a new external api service that endpoint templates
@@ -734,10 +732,6 @@ class IdentityApi(object):
         `OpenStack Identity v2 OS-KSADM Create Service
         <http://developer.openstack.org/api-ref/identity/v2-ext/index.html#create-service-admin-extension>`_
         """
-        x_auth_token = request.getHeader(b"x-auth-token")
-        if x_auth_token is None:
-            return json.dumps(unauthorized("Authentication required", request))
-
         try:
             content = json_from_request(request)
         except ValueError:
@@ -784,6 +778,7 @@ class IdentityApi(object):
             return b''
 
     @app.route('/v2.0/services/<string:service_id>', methods=['DELETE'])
+    @require_auth_token
     def delete_external_api_service(self, request, service_id):
         """
         Delete/Remove an existing  external service api. It must not have
@@ -792,10 +787,6 @@ class IdentityApi(object):
         `OpenStack Identity v2 OS-KSADM Delete Service
         <http://developer.openstack.org/api-ref/identity/v2-ext/index.html#delete-service-admin-extension>`_
         """
-        x_auth_token = request.getHeader(b"x-auth-token")
-        if x_auth_token is None:
-            return json.dumps(unauthorized("Authentication required", request))
-
         try:
             self.core.remove_external_api(
                 service_id
@@ -815,6 +806,7 @@ class IdentityApi(object):
             return b''
 
     @app.route('/v2.0/OS-KSCATALOG/endpointTemplates', methods=['GET'])
+    @require_auth_token
     def list_endpoint_templates(self, request):
         """
         List the available endpoint templates.
@@ -824,10 +816,6 @@ class IdentityApi(object):
         `OpenStack Identity v2 OS-KSCATALOG List Endpoint Templates
         <http://developer.openstack.org/api-ref-identity-v2-ext.html>`_
         """
-        x_auth_token = request.getHeader(b"x-auth-token")
-        if x_auth_token is None:
-            return json.dumps(unauthorized("Authentication required", request))
-
         # caller may provide a specific API to list by setting the
         # serviceid header
         external_apis_to_list = []
@@ -861,6 +849,7 @@ class IdentityApi(object):
                 request))
 
     @app.route('/v2.0/OS-KSCATALOG/endpointTemplates', methods=['POST'])
+    @require_auth_token
     def add_endpoint_templates(self, request):
         """
         Add an API endpoint template to the system. By default the API
@@ -878,10 +867,6 @@ class IdentityApi(object):
         `OpenStack Identity v2 OS-KSCATALOG Create Endpoint Template
         <http://developer.openstack.org/api-ref-identity-v2-ext.html>`_
         """
-        x_auth_token = request.getHeader(b"x-auth-token")
-        if x_auth_token is None:
-            return json.dumps(unauthorized("Authentication required", request))
-
         try:
             content = json_from_request(request)
         except ValueError:
@@ -954,6 +939,7 @@ class IdentityApi(object):
 
     @app.route('/v2.0/OS-KSCATALOG/endpointTemplates/<string:template_id>',
                methods=['PUT'])
+    @require_auth_token
     def update_endpoint_templates(self, request, template_id):
         """
         Update an API endpoint template already in the system.
@@ -967,10 +953,6 @@ class IdentityApi(object):
         `OpenStack Identity v2 OS-KSCATALOG Update Endpoint Template
         <http://developer.openstack.org/api-ref-identity-v2-ext.html>`_
         """
-        x_auth_token = request.getHeader(b"x-auth-token")
-        if x_auth_token is None:
-            return json.dumps(unauthorized("Authentication required", request))
-
         try:
             content = json_from_request(request)
         except ValueError:
@@ -1044,6 +1026,7 @@ class IdentityApi(object):
 
     @app.route('/v2.0/OS-KSCATALOG/endpointTemplates/<string:template_id>',
                methods=['DELETE'])
+    @require_auth_token
     def delete_endpoint_templates(self, request, template_id):
         """
         Delete an endpoint API template from the system.
@@ -1055,10 +1038,6 @@ class IdentityApi(object):
         `OpenStack Identity v2 OS-KSCATALOG Delete Endpoint Template
         <http://developer.openstack.org/api-ref-identity-v2-ext.html>`_
         """
-        x_auth_token = request.getHeader(b"x-auth-token")
-        if x_auth_token is None:
-            return json.dumps(unauthorized("Authentication required", request))
-
         service_id = request.getHeader(b'serviceid')
         if service_id is not None:
             api = self.core.get_external_api(service_id.decode('utf-8'))
@@ -1083,6 +1062,7 @@ class IdentityApi(object):
 
     @app.route('/v2.0/tenants/<string:tenant_id>/OS-KSCATALOG/endpoints',
                methods=['GET'])
+    @require_auth_token
     def list_endpoints_for_tenant(self, request, tenant_id):
         """
         List the available endpoints for a given tenant-id.
@@ -1092,10 +1072,6 @@ class IdentityApi(object):
         `OpenStack Identity v2 OS-KSCATALOG List Endpoints for Tenant
         <http://developer.openstack.org/api-ref-identity-v2-ext.html>`_
         """
-        x_auth_token = request.getHeader(b"x-auth-token")
-        if x_auth_token is None:
-            return json.dumps(unauthorized("Authentication required", request))
-
         # caller may provide a specific API to list by setting the
         # serviceid header
         external_apis_to_list = []
@@ -1134,6 +1110,7 @@ class IdentityApi(object):
 
     @app.route('/v2.0/tenants/<string:tenant_id>/OS-KSCATALOG/endpoints',
                methods=['POST'])
+    @require_auth_token
     def create_endpoint_for_tenant(self, request, tenant_id):
         """
         Enable a given endpoint template for a given tenantid.
@@ -1141,10 +1118,6 @@ class IdentityApi(object):
         `OpenStack Identity v2 OS-KSCATALOG Create Endpoint for Tenant
         <http://developer.openstack.org/api-ref-identity-v2-ext.html>`_
         """
-        x_auth_token = request.getHeader(b"x-auth-token")
-        if x_auth_token is None:
-            return json.dumps(unauthorized("Authentication required", request))
-
         try:
             content = json_from_request(request)
         except ValueError:
@@ -1180,6 +1153,7 @@ class IdentityApi(object):
 
     @app.route('/v2.0/tenants/<string:tenant_id>/OS-KSCATALOG/endpoints/'
                '<string:template_id>', methods=['DELETE'])
+    @require_auth_token
     def remove_endpoint_for_tenant(self, request, tenant_id, template_id):
         """
         Disable a given endpoint template for a given tenantid if it's been
@@ -1189,10 +1163,6 @@ class IdentityApi(object):
         `OpenStack Identity v2 OS-KSCATALOG Delete Endpoint for Tenant
         <http://developer.openstack.org/api-ref-identity-v2-ext.html>`_
         """
-        x_auth_token = request.getHeader(b"x-auth-token")
-        if x_auth_token is None:
-            return json.dumps(unauthorized("Authentication required", request))
-
         for api_id in self.core.get_external_apis():
             api = self.core.get_external_api(api_id)
             if api.has_template(template_id):

--- a/mimic/rest/identity_api.py
+++ b/mimic/rest/identity_api.py
@@ -304,8 +304,8 @@ class IdentityApi(object):
         """
         Support, such as it is, for the credentials call.
 
-        reference: http://developer.openstack.org/api-ref-identity-v2-ext.html
-            #listCredentials
+        `OpenStack Identity v2 Extension List Credentials
+        <http://developer.openstack.org/api-ref-identity-v2-ext.html#listCredentials>`_
         """
         if user_id in self.core.sessions._userid_to_session:
             username = self.core.sessions._userid_to_session[user_id].username
@@ -333,6 +333,8 @@ class IdentityApi(object):
     def rax_kskey_apikeycredentials(self, request, user_id):
         """
         Support, such as it is, for the apiKeysCredentials call.
+
+        reference: https://developer.rackspace.com/docs/cloud-identity/v2/api-reference/users-operations/#get-user-credentials  # noqa
         """
         if user_id in self.core.sessions._userid_to_session:
             username = self.core.sessions._userid_to_session[user_id].username
@@ -372,7 +374,8 @@ class IdentityApi(object):
         """
         Creates a new session for the given tenant_id and token_id
         and always returns response code 200.
-        Docs: http://developer.openstack.org/api-ref-identity-admin-v2.html#admin-validateToken  # noqa
+        `OpenStack Identity v2 Admin Validate Token
+        <http://developer.openstack.org/api-ref-identity-admin-v2.html#admin-validateToken>`_
         """
         request.setResponseCode(200)
         session = None
@@ -648,6 +651,9 @@ class IdentityApi(object):
         """
         Return a service catalog consisting of nova and load balancer mocked
         endpoints.
+
+        `OpenStack Identity v2 Admin Endpoints for Token
+        <http://developer.openstack.org/api-ref/identity/v2-admin/#list-endoints-for-token>`_
         """
         # FIXME: TEST
         request.setResponseCode(200)
@@ -694,8 +700,9 @@ class IdentityApi(object):
         List the available external services that endpoint templates
         may be added to.
 
-        .. note:: Part of the OS-KSADM extension.
         .. note:: Does not implement the limits or markers.
+        `OpenStack Identity v2 OS-KSADM List Services
+        <http://developer.openstack.org/api-ref/identity/v2-ext/index.html#list-services-admin-extension>`_
         """
         x_auth_token = request.getHeader(b"x-auth-token")
         if x_auth_token is None:
@@ -720,11 +727,12 @@ class IdentityApi(object):
         Create a new external api service that endpoint templates
         may be added to.
 
-        .. note:: Part of the OS-KSADM extensions.
         .. note:: Only requires 'name' and 'type' fields in the JSON. If the 'id'
             or 'description' fields are present, then they will be used;
             otherwise a UUID4 will be assigned to the 'id' field and the
             'description' will be given a generic value.
+        `OpenStack Identity v2 OS-KSADM Create Service
+        <http://developer.openstack.org/api-ref/identity/v2-ext/index.html#create-service-admin-extension>`_
         """
         x_auth_token = request.getHeader(b"x-auth-token")
         if x_auth_token is None:
@@ -781,7 +789,8 @@ class IdentityApi(object):
         Delete/Remove an existing  external service api. It must not have
         any endpoint templates assigned to it for success.
 
-        .. note:: Part of the OS-KSADM extension.
+        `OpenStack Identity v2 OS-KSADM Delete Service
+        <http://developer.openstack.org/api-ref/identity/v2-ext/index.html#delete-service-admin-extension>`_
         """
         x_auth_token = request.getHeader(b"x-auth-token")
         if x_auth_token is None:
@@ -810,9 +819,10 @@ class IdentityApi(object):
         """
         List the available endpoint templates.
 
-        Reference: http://developer.openstack.org/api-ref-identity-v2-ext.html
-
         .. note:: Marker/Limit capability not implemented here.
+
+        `OpenStack Identity v2 OS-KSCATALOG List Endpoint Templates
+        <http://developer.openstack.org/api-ref-identity-v2-ext.html>`_
         """
         x_auth_token = request.getHeader(b"x-auth-token")
         if x_auth_token is None:
@@ -856,8 +866,6 @@ class IdentityApi(object):
         Add an API endpoint template to the system. By default the API
         described by the template will disabled for all users.
 
-        Reference: http://developer.openstack.org/api-ref-identity-v2-ext.html
-
         .. note:: Either the service-id must be specified in the header or
             a Service Name by the same name must already exist. Otherwise
             a Not Found (404) will be returned.
@@ -866,6 +874,9 @@ class IdentityApi(object):
             id, name, type, and region parameters are required. See
             EndpointTemplateStore.required_mapping for details. Other
             implementations may have different requirements.
+
+        `OpenStack Identity v2 OS-KSCATALOG Create Endpoint Template
+        <http://developer.openstack.org/api-ref-identity-v2-ext.html>`_
         """
         x_auth_token = request.getHeader(b"x-auth-token")
         if x_auth_token is None:
@@ -947,13 +958,14 @@ class IdentityApi(object):
         """
         Update an API endpoint template already in the system.
 
-        Reference: http://developer.openstack.org/api-ref-identity-v2-ext.html
-
         .. note:: A template by the same id must already exist in the system.
 
         .. note:: Either the service-id must be specified in the header or
             a Service Name by the same name must already exist. Otherwise
             a Not Found (404) will be returned.
+
+        `OpenStack Identity v2 OS-KSCATALOG Update Endpoint Template
+        <http://developer.openstack.org/api-ref-identity-v2-ext.html>`_
         """
         x_auth_token = request.getHeader(b"x-auth-token")
         if x_auth_token is None:
@@ -1036,11 +1048,12 @@ class IdentityApi(object):
         """
         Delete an endpoint API template from the system.
 
-        Reference: http://developer.openstack.org/api-ref-identity-v2-ext.html
-
         .. note:: Either the service-id must be specified in the header or
             a Service Name by the same name must already exist. Otherwise
             a Not Found (404) will be returned.
+
+        `OpenStack Identity v2 OS-KSCATALOG Delete Endpoint Template
+        <http://developer.openstack.org/api-ref-identity-v2-ext.html>`_
         """
         x_auth_token = request.getHeader(b"x-auth-token")
         if x_auth_token is None:
@@ -1074,9 +1087,10 @@ class IdentityApi(object):
         """
         List the available endpoints for a given tenant-id.
 
-        Reference: http://developer.openstack.org/api-ref-identity-v2-ext.html
-
         .. note:: Marker/Limit capability not implemented here.
+
+        `OpenStack Identity v2 OS-KSCATALOG List Endpoints for Tenant
+        <http://developer.openstack.org/api-ref-identity-v2-ext.html>`_
         """
         x_auth_token = request.getHeader(b"x-auth-token")
         if x_auth_token is None:
@@ -1124,7 +1138,8 @@ class IdentityApi(object):
         """
         Enable a given endpoint template for a given tenantid.
 
-        Reference: http://developer.openstack.org/api-ref-identity-v2-ext.html
+        `OpenStack Identity v2 OS-KSCATALOG Create Endpoint for Tenant
+        <http://developer.openstack.org/api-ref-identity-v2-ext.html>`_
         """
         x_auth_token = request.getHeader(b"x-auth-token")
         if x_auth_token is None:
@@ -1171,7 +1186,8 @@ class IdentityApi(object):
         enabled. This does not affect an endpoint template that has been
         globally enabled.
 
-        Reference: http://developer.openstack.org/api-ref-identity-v2-ext.html
+        `OpenStack Identity v2 OS-KSCATALOG Delete Endpoint for Tenant
+        <http://developer.openstack.org/api-ref-identity-v2-ext.html>`_
         """
         x_auth_token = request.getHeader(b"x-auth-token")
         if x_auth_token is None:

--- a/mimic/rest/identity_api.py
+++ b/mimic/rest/identity_api.py
@@ -9,6 +9,7 @@ import binascii
 import json
 import os
 import time
+import uuid
 
 import attr
 from six import text_type
@@ -30,7 +31,12 @@ from mimic.model.identity import (
     PasswordCredentials,
     TokenCredentials)
 from mimic.model.identity_objects import (
+    bad_request,
+    conflict,
+    EndpointTemplateStore,
+    ExternalApiStore,
     not_found,
+    unauthorized
 )
 from mimic.rest.mimicapp import MimicApp
 from mimic.session import NonMatchingTenantError
@@ -860,17 +866,14 @@ class IdentityApi(object):
             )
 
         try:
-            endpoint_template_instance = EndpointTemplateStore(
-                template_dict=content
+            endpoint_template_instance = EndpointTemplateStore.deserialize(
+                content
             )
-        except KeyError:
+        except KeyError as ex:
             return json.dumps(
                 bad_request(
                     "JSON body does not contain the required parameters: "
-                    + text_type(
-                        [key
-                         for key, _ in EndpointTemplateStore.required_mapping]
-                    ),
+                    + text_type(ex),
                     request
                 )
             )
@@ -958,17 +961,14 @@ class IdentityApi(object):
                     )
                 )
 
-            endpoint_template_instance = EndpointTemplateStore(
-                template_dict=content
+            endpoint_template_instance = EndpointTemplateStore.deserialize(
+                content
             )
-        except KeyError:
+        except KeyError as ex:
             return json.dumps(
                 bad_request(
                     "JSON body does not contain the required parameters: "
-                    + text_type(
-                        [key
-                         for key, _ in EndpointTemplateStore.required_mapping]
-                    ),
+                    + text_type(ex),
                     request
                 )
             )

--- a/mimic/rest/identity_api.py
+++ b/mimic/rest/identity_api.py
@@ -979,6 +979,7 @@ class IdentityApi(object):
                 content
             )
         except (InvalidEndpointTemplateMissingKey, KeyError) as ex:
+            # KeyError is for the content['id'] line
             return json.dumps(
                 bad_request(
                     "JSON body does not contain the required parameters: "

--- a/mimic/rest/identity_api.py
+++ b/mimic/rest/identity_api.py
@@ -694,8 +694,8 @@ class IdentityApi(object):
         List the available external services that endpoint templates
         may be added to.
 
-        Note: Part of the OS-KSADM extension.
-        Note: Does not implement the limits or markers.
+        .. note:: Part of the OS-KSADM extension.
+        .. note:: Does not implement the limits or markers.
         """
         x_auth_token = request.getHeader(b"x-auth-token")
         if x_auth_token is None:
@@ -720,8 +720,8 @@ class IdentityApi(object):
         Create a new external api service that endpoint templates
         may be added to.
 
-        Note: Part of the OS-KSADM extensions.
-        Note: Only requires 'name' and 'type' fields in the JSON. If the 'id'
+        .. note:: Part of the OS-KSADM extensions.
+        .. note:: Only requires 'name' and 'type' fields in the JSON. If the 'id'
             or 'description' fields are present, then they will be used;
             otherwise a UUID4 will be assigned to the 'id' field and the
             'description' will be given a generic value.
@@ -781,7 +781,7 @@ class IdentityApi(object):
         Delete/Remove an existing  external service api. It must not have
         any endpoint templates assigned to it for success.
 
-        Note: Part of the OS-KSADM extension.
+        .. note:: Part of the OS-KSADM extension.
         """
         x_auth_token = request.getHeader(b"x-auth-token")
         if x_auth_token is None:
@@ -812,7 +812,7 @@ class IdentityApi(object):
 
         Reference: http://developer.openstack.org/api-ref-identity-v2-ext.html
 
-        Note: Marker/Limit capability not implemented here.
+        .. note:: Marker/Limit capability not implemented here.
         """
         x_auth_token = request.getHeader(b"x-auth-token")
         if x_auth_token is None:
@@ -858,11 +858,11 @@ class IdentityApi(object):
 
         Reference: http://developer.openstack.org/api-ref-identity-v2-ext.html
 
-        Note: Either the service-id must be specified in the header or
+        .. note:: Either the service-id must be specified in the header or
             a Service Name by the same name must already exist. Otherwise
             a Not Found (404) will be returned.
 
-        Note: A template has certain required parametes. For Mimic the
+        .. note:: A template has certain required parametes. For Mimic the
             id, name, type, and region parameters are required. See
             EndpointTemplateStore.required_mapping for details. Other
             implementations may have different requirements.
@@ -949,9 +949,9 @@ class IdentityApi(object):
 
         Reference: http://developer.openstack.org/api-ref-identity-v2-ext.html
 
-        Note: A template by the same id must already exist in the system.
+        .. note:: A template by the same id must already exist in the system.
 
-        Note: Either the service-id must be specified in the header or
+        .. note:: Either the service-id must be specified in the header or
             a Service Name by the same name must already exist. Otherwise
             a Not Found (404) will be returned.
         """
@@ -1038,7 +1038,7 @@ class IdentityApi(object):
 
         Reference: http://developer.openstack.org/api-ref-identity-v2-ext.html
 
-        Note: Either the service-id must be specified in the header or
+        .. note:: Either the service-id must be specified in the header or
             a Service Name by the same name must already exist. Otherwise
             a Not Found (404) will be returned.
         """
@@ -1076,7 +1076,7 @@ class IdentityApi(object):
 
         Reference: http://developer.openstack.org/api-ref-identity-v2-ext.html
 
-        Note: Marker/Limit capability not implemented here.
+        .. note:: Marker/Limit capability not implemented here.
         """
         x_auth_token = request.getHeader(b"x-auth-token")
         if x_auth_token is None:

--- a/mimic/test/dummy.py
+++ b/mimic/test/dummy.py
@@ -192,7 +192,7 @@ def make_example_external_api(case, name=u"example",
     :param text_type service_type: type of the service. If none, the type
         is extracted from the first entry in the endpoint_template list.
 
-    Note: The service-type of the first endpoint template is used as the
+    .. note:: The service-type of the first endpoint template is used as the
         service type for the entire :obj:`ExternalApiStore`, and is enforced
         that all endpoint templates have the same service-type.
 

--- a/mimic/test/mixins.py
+++ b/mimic/test/mixins.py
@@ -1,0 +1,42 @@
+"""
+Mixins for various tests that repeat
+"""
+from mimic.test.helpers import json_request
+
+
+class IdentityAuthMixin(object):
+    """
+    Common Auth Failure Tests
+    """
+
+    def test_auth_fail(self):
+        """
+        HTTP Verb with no X-Auth-Token header results in 401.
+        """
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri))
+
+        self.assertEqual(response.code, 401)
+        self.assertEqual(json_body['unauthorized']['code'], 401)
+
+
+class InvalidJsonMixin(object):
+    """
+    Common JSON Body Failure Tests
+    """
+
+    def test_invalid_json_body(self):
+        """
+        HTTP Verb will generate 400 when an invalid JSON body is provided.
+        """
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=b'<xml>ensure json failure',
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 400)
+        self.assertEqual(json_body['badRequest']['code'], 400)
+        self.assertEqual(json_body['badRequest']['message'],
+                         'Invalid JSON request body')

--- a/mimic/test/mixins.py
+++ b/mimic/test/mixins.py
@@ -40,3 +40,24 @@ class InvalidJsonMixin(object):
         self.assertEqual(json_body['badRequest']['code'], 400)
         self.assertEqual(json_body['badRequest']['message'],
                          'Invalid JSON request body')
+
+
+class ServiceIdHeaderMixin(object):
+    """
+    Common Tests for the Service-ID Header
+    """
+
+    def test_invalid_service_id(self):
+        """
+        HTTP Verb must have a valid service id otherwise 404.
+        """
+        self.headers.update({
+            'serviceid': [b'some-id']
+        })
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 404)
+        self.assertEqual(json_body['itemNotFound']['code'], 404)

--- a/mimic/test/test_core.py
+++ b/mimic/test/test_core.py
@@ -11,7 +11,14 @@ from twisted.plugin import IPlugin
 from twisted.python.filepath import FilePath
 from twisted.web.resource import IResource
 
-from mimic.core import MimicCore
+from mimic.core import (
+    MimicCore,
+    ServiceBadInterface,
+    ServiceDoesNotExist,
+    ServiceExists,
+    ServiceHasTemplates,
+    ServiceNameExists
+)
 from mimic.plugins import (nova_plugin, loadbalancer_plugin, swift_plugin,
                            queue_plugin, maas_plugin, rackconnect_v3_plugin,
                            glance_plugin, cloudfeeds_plugin, heat_plugin,
@@ -139,7 +146,7 @@ class CoreApiBuildingTests(SynchronousTestCase):
         class brokenApiMock(object):
             pass
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ServiceBadInterface):
             MimicCore(Clock(), [brokenApiMock()])
 
     def test_load_duplicate_api_uuid(self):
@@ -157,7 +164,7 @@ class CoreApiBuildingTests(SynchronousTestCase):
         )
         eeapi2.uuid_key = eeapi.uuid_key
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ServiceExists):
             MimicCore(Clock(), [eeapi, eeapi2])
 
     def test_load_duplicate_api_name(self):
@@ -177,7 +184,7 @@ class CoreApiBuildingTests(SynchronousTestCase):
         # to be uuid-<name> so we need to change it for eeapi2
         eeapi2.uuid_key = str(uuid.uuid4())
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ServiceNameExists):
             MimicCore(Clock(), [eeapi, eeapi2])
 
     def test_remove_api(self):
@@ -206,7 +213,7 @@ class CoreApiBuildingTests(SynchronousTestCase):
         api name in the listing
         """
         core = MimicCore(Clock(), [])
-        with self.assertRaises(IndexError):
+        with self.assertRaises(ServiceDoesNotExist):
             core.remove_external_api(
                 'some-id'
             )
@@ -223,7 +230,7 @@ class CoreApiBuildingTests(SynchronousTestCase):
         )
         self.assertIsNotNone(eeapi)
         core = MimicCore(Clock(), [eeapi])
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ServiceHasTemplates):
             core.remove_external_api(
                 eeapi.uuid_key
             )
@@ -268,7 +275,7 @@ class CoreApiBuildingTests(SynchronousTestCase):
         `IndexError` exception.
         """
         core = MimicCore(Clock(), [])
-        with self.assertRaises(IndexError):
+        with self.assertRaises(ServiceDoesNotExist):
             core.get_external_api(self.eeapi_name)
 
     def test_service_with_region_external(self):

--- a/mimic/test/test_core.py
+++ b/mimic/test/test_core.py
@@ -180,7 +180,7 @@ class CoreApiBuildingTests(SynchronousTestCase):
             self,
             name=self.eeapi_name
         )
-        # Note: make_example_external_api makes the UUID
+        # .. note:: make_example_external_api makes the UUID
         # to be uuid-<name> so we need to change it for eeapi2
         eeapi2.uuid_key = str(uuid.uuid4())
 

--- a/mimic/test/test_decorators.py
+++ b/mimic/test/test_decorators.py
@@ -1,0 +1,100 @@
+"""
+Test Decorators
+"""
+from __future__ import absolute_import, division, unicode_literals
+
+import json
+
+import ddt
+from twisted.trial.unittest import SynchronousTestCase
+
+from mimic.rest.decorators import require_auth_token
+
+
+class RequestMock(object):
+    """
+    Mock extremely simple request object for decorator testing
+    """
+
+    def __init__(self, key_value=None):
+        """
+        :param key_value: value to be returned by getHeader
+        """
+        self.key_value = key_value
+        self.response_code = None
+
+    def getHeader(self, key):
+        """
+        :parameter key: ignored parameter of the key to be looked up
+        :returns: key value provided to constructor
+        """
+        return self.key_value
+
+    def setResponseCode(self, code):
+        """
+        :param code: response code set by request handler
+        """
+        self.response_code = code
+
+
+@ddt.ddt
+class RequireAuthTokenTest(SynchronousTestCase):
+    """
+    Decorator test for extracting the auth token from a rquest object.
+    """
+
+    @require_auth_token
+    def without_keyword_parameter(self, request):
+        """
+        Request mock without auth_token in arg spec
+        """
+        return json.dumps({ 'msg': 'hello'})
+
+    @require_auth_token
+    def with_keyword_parameter(self, request, auth_token=None):
+        """
+        Request mock with auth_token in arg spec
+        """
+        return json.dumps({ 'msg': 'hello', 'token': auth_token})
+
+    @ddt.data(
+        b'Some Value',
+        None
+    )
+    def test_without_keyword(self, auth_token_value):
+        """
+        Call the decorator without the token in the arg spec.
+        """
+        request = RequestMock(key_value=auth_token_value)
+
+        json_content = self.without_keyword_parameter(request)
+        message = json.loads(json_content)
+        if auth_token_value is None:
+            self.assertIn('unauthorized', message)
+            self.assertIn('code', message['unauthorized'])
+            self.assertEqual(message['unauthorized']['code'], 401)
+        else:
+            self.assertIn('msg', message)
+            self.assertEqual(message['msg'], 'hello')
+
+    @ddt.data(
+        b'Some Value',
+        None
+    )
+    def test_with_keyword(self, auth_token_value):
+        """
+        Call the decorator with the token in the arg spec.
+        """
+        request = RequestMock(key_value=auth_token_value)
+
+        json_content = self.with_keyword_parameter(request)
+        message = json.loads(json_content)
+        if auth_token_value is None:
+            self.assertIn('unauthorized', message)
+            self.assertIn('code', message['unauthorized'])
+            self.assertEqual(message['unauthorized']['code'], 401)
+        else:
+            self.assertIn('msg', message)
+            self.assertEqual(message['msg'], 'hello')
+            self.assertIn('token', message)
+            self.assertEqual(message['token'], auth_token_value.decode('utf-8'))

--- a/mimic/test/test_decorators.py
+++ b/mimic/test/test_decorators.py
@@ -48,14 +48,14 @@ class RequireAuthTokenTest(SynchronousTestCase):
         """
         Request mock without auth_token in arg spec
         """
-        return json.dumps({ 'msg': 'hello'})
+        return json.dumps({'msg': 'hello'})
 
     @require_auth_token
     def with_keyword_parameter(self, request, auth_token=None):
         """
         Request mock with auth_token in arg spec
         """
-        return json.dumps({ 'msg': 'hello', 'token': auth_token})
+        return json.dumps({'msg': 'hello', 'token': auth_token})
 
     @ddt.data(
         b'Some Value',

--- a/mimic/test/test_identity_auth.py
+++ b/mimic/test/test_identity_auth.py
@@ -937,7 +937,7 @@ class GetEndpointsForTokenTests(SynchronousTestCase):
         provided using the argument `belongsTo` and a different token
         is provided via the `x-auth-token` header.
 
-        Note: This is how authentication validators like Repose operate.
+        .. note:: This is how authentication validators like Repose operate.
         """
         core, root = core_and_root([make_example_internal_api(self)])
 

--- a/mimic/test/test_identity_objects.py
+++ b/mimic/test/test_identity_objects.py
@@ -4,6 +4,15 @@ import ddt
 
 from twisted.trial.unittest import SynchronousTestCase
 
+from mimic.model.identity_errors import (
+    EndpointTemplateAlreadyExists,
+    EndpointTemplateDisabledForTenant,
+    EndpointTemplateDoesNotExist,
+    InvalidEndpointTemplateId,
+    InvalidEndpointTemplateInterface,
+    InvalidEndpointTemplateMissingKey,
+    InvalidEndpointTemplateServiceType
+)
 from mimic.model.identity_objects import (
     EndpointTemplateStore,
     bad_request,
@@ -138,7 +147,7 @@ class EndpointTemplateInstanceTests(SynchronousTestCase):
         else:
             # validate that the keys must be present
             del data[key_to_remove]
-            with self.assertRaises(KeyError):
+            with self.assertRaises(InvalidEndpointTemplateMissingKey):
                 EndpointTemplateStore.deserialize(data)
 
     def test_deserialization(self):
@@ -375,7 +384,7 @@ class EndpointTemplatesTests(SynchronousTestCase):
         class InvalidTemplate(object):
             pass
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(InvalidEndpointTemplateInterface):
             eeapi.add_template(InvalidTemplate())
 
     def test_duplicate_api_insertion_fails(self):
@@ -402,7 +411,7 @@ class EndpointTemplatesTests(SynchronousTestCase):
         eeapi.add_template(new_eeapi_template)
 
         # second time fails
-        with self.assertRaises(ValueError):
+        with self.assertRaises(EndpointTemplateAlreadyExists):
             eeapi.add_template(new_eeapi_template)
 
     def test_add_template_with_mismatching_service_type(self):
@@ -425,7 +434,7 @@ class EndpointTemplatesTests(SynchronousTestCase):
         )
         new_eeapi_template.type_key = "random-type"
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(InvalidEndpointTemplateServiceType):
             eeapi.add_template(new_eeapi_template)
 
     def test_update_with_invalid_template(self):
@@ -442,7 +451,7 @@ class EndpointTemplatesTests(SynchronousTestCase):
             set_enabled=True,
         )
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(InvalidEndpointTemplateInterface):
             eeapi.update_template(InvalidTemplate())
 
     def test_update_endpoint_template(self):
@@ -499,7 +508,7 @@ class EndpointTemplatesTests(SynchronousTestCase):
             set_enabled=True,
         )
 
-        with self.assertRaises(IndexError):
+        with self.assertRaises(EndpointTemplateDoesNotExist):
             eeapi.update_template(new_eeapi_template)
 
     def test_update_endpoint_template_invalid_type_value(self):
@@ -523,7 +532,7 @@ class EndpointTemplatesTests(SynchronousTestCase):
         )
         new_eeapi_template.type_key = "some-other-type"
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(InvalidEndpointTemplateServiceType):
             eeapi.update_template(new_eeapi_template)
 
     def test_update_endpoint_template_invalid_id_value(self):
@@ -550,7 +559,7 @@ class EndpointTemplatesTests(SynchronousTestCase):
         eeapi.endpoint_templates[old_eeapi_template_id].id_key = \
             new_eeapi_template_id
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(InvalidEndpointTemplateId):
             eeapi.update_template(new_eeapi_template)
 
     @ddt.data(
@@ -604,7 +613,7 @@ class EndpointTemplatesTests(SynchronousTestCase):
             eeapi.remove_template(eeapi_template_id)
             self.assertNotIn(eeapi_template_id, eeapi.endpoint_templates)
         else:
-            with self.assertRaises(IndexError):
+            with self.assertRaises(InvalidEndpointTemplateId):
                 eeapi.remove_template(eeapi_template_id)
 
     def test_remove_endpoint_template_with_user_registration(self):
@@ -690,7 +699,7 @@ class EndpointsForTenantsTests(SynchronousTestCase):
             set_enabled=True
         )
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(InvalidEndpointTemplateId):
             eeapi.enable_endpoint_for_tenant(
                 'some_tenant',
                 'some-invalid-template-id'
@@ -707,7 +716,7 @@ class EndpointsForTenantsTests(SynchronousTestCase):
             set_enabled=True
         )
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(EndpointTemplateDisabledForTenant):
             eeapi.disable_endpoint_for_tenant(
                 'some_tenant',
                 'some-invalid-template-id'

--- a/mimic/test/test_identity_objects.py
+++ b/mimic/test/test_identity_objects.py
@@ -15,41 +15,12 @@ from mimic.model.identity_errors import (
 )
 from mimic.model.identity_objects import (
     EndpointTemplateStore,
-    bad_request,
-    conflict,
-    not_found,
-    unauthorized,
 )
 from mimic.test.dummy import (
     exampleEndpointTemplate,
     make_example_external_api,
 )
 from mimic.test.helpers import get_template_id
-
-
-@ddt.ddt
-class YetToBeDone(SynchronousTestCase):
-    """
-    Test that are a placeholder for necessary functionality that will be needed
-    when the full functionality is implemented.
-    """
-
-    @ddt.data(
-        bad_request,
-        conflict,
-        not_found,
-        unauthorized
-    )
-    def test_stuff_todo(self, cls_http_response):
-        """
-        Temporary for code-coverage until endpoints are implemented that will
-        actually use these.
-        """
-        class reqMock(object):
-            def setResponseCode(self, code):
-                pass
-
-        cls_http_response("testing {0}".format(cls_http_response.__name__), reqMock())
 
 
 @ddt.ddt

--- a/mimic/test/test_identity_osksadm.py
+++ b/mimic/test/test_identity_osksadm.py
@@ -1,0 +1,344 @@
+"""
+Tests for mimic identity :mod:`mimic.rest.identity_api`
+"""
+
+from __future__ import absolute_import, division, unicode_literals
+
+import json
+import uuid
+
+from six import text_type
+
+from twisted.trial.unittest import SynchronousTestCase
+from twisted.internet.task import Clock
+
+from mimic.core import MimicCore
+from mimic.resource import MimicRoot
+from mimic.test.dummy import make_example_external_api, ExternalApiStore
+from mimic.test.helpers import json_request, request
+
+
+class TestIdentityMimicOSKSCatalogAdminListExternalServices(SynchronousTestCase):
+    """
+    Tests for ``/identity/v2.0/services``, provided by
+    :obj:`mimic.rest.idenity_api.IdentityApi`
+    """
+    def setUp(self):
+        self.core = MimicCore(Clock(), [])
+        self.root = MimicRoot(self.core).app.resource()
+        self.uri = "/identity/v2.0/services"
+        self.eeapi_name = u"externalServiceName"
+        self.eeapi = make_example_external_api(
+            self,
+            name=self.eeapi_name,
+            set_enabled=True
+        )
+        self.headers = {
+            b'X-Auth-Token': [b'ABCDEF987654321']
+        }
+        self.verb = b"GET"
+
+    def test_auth_fail(self):
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri))
+
+        self.assertEqual(response.code, 401)
+        self.assertEqual(json_body['unauthorized']['code'], 401)
+
+    def test_list_empty(self):
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 200)
+        self.assertEqual(len(json_body["OS-KSADM:services"]), 0)
+
+    def test_list_single(self):
+        self.core.add_api(self.eeapi)
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 200)
+        self.assertEqual(len(json_body["OS-KSADM:services"]), 1)
+        self.assertEqual(json_body["OS-KSADM:services"][0]['id'],
+                         self.eeapi.uuid_key)
+        self.assertEqual(json_body["OS-KSADM:services"][0]['type'],
+                         self.eeapi.type_key)
+        self.assertEqual(json_body["OS-KSADM:services"][0]['name'],
+                         self.eeapi.name_key)
+
+    def test_list_multiple(self):
+        api_list = [self.eeapi]
+        for _ in range(10):
+            api_list.append(
+                ExternalApiStore(
+                    text_type(uuid.uuid4()),
+                    self.eeapi_name + text_type(uuid.uuid4()),
+                    'service-' + text_type(uuid.uuid4()),
+                )
+            )
+        for api in api_list:
+            self.core.add_api(api)
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         headers=self.headers))
+
+        def validate_api(api_id, api_type, api_name):
+            for api in api_list:
+                if api.uuid_key == api_id:
+                    self.assertEqual(api_id, api.uuid_key)
+                    self.assertEqual(api_type, api.type_key)
+                    self.assertEqual(api_name, api.name_key)
+
+        self.assertEqual(response.code, 200)
+        self.assertEqual(len(json_body["OS-KSADM:services"]), len(api_list))
+        for entry in json_body["OS-KSADM:services"]:
+            validate_api(entry['id'], entry['type'], entry['name'])
+
+
+class TestIdentityMimicOSKSCatalogAdminCreateExternalService(SynchronousTestCase):
+    """
+    Tests for ``/identity/v2.0/services``, provided by
+    :obj:`mimic.rest.idenity_api.IdentityApi`
+    """
+    def setUp(self):
+        self.core = MimicCore(Clock(), [])
+        self.root = MimicRoot(self.core).app.resource()
+        self.uri = "/identity/v2.0/services"
+        self.eeapi_name = u"externalServiceName"
+        self.eeapi = make_example_external_api(
+            self,
+            name=self.eeapi_name,
+            set_enabled=True
+        )
+        self.headers = {
+            b'X-Auth-Token': [b'ABCDEF987654321']
+        }
+        self.verb = b"POST"
+
+    def test_auth_fail(self):
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri))
+
+        self.assertEqual(response.code, 401)
+        self.assertEqual(json_body['unauthorized']['code'], 401)
+
+    def test_invalid_json_body(self):
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=b'<xml>ensure json failure',
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 400)
+        self.assertEqual(json_body['badRequest']['code'], 400)
+        self.assertEqual(json_body['badRequest']['message'],
+                         'Invalid JSON request body')
+
+    def test_json_body_missing_required_field_name(self):
+        data = {
+            'type': 'some-type'
+        }
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=data,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 400)
+        self.assertEqual(json_body['badRequest']['code'], 400)
+        self.assertEqual(json_body['badRequest']['message'],
+                         "Invalid Content. 'name' and 'type' fields are "
+                         "required.")
+
+    def test_json_body_missing_required_field_type(self):
+        data = {
+            'name': 'some-name'
+        }
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=data,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 400)
+        self.assertEqual(json_body['badRequest']['code'], 400)
+        self.assertEqual(json_body['badRequest']['message'],
+                         "Invalid Content. 'name' and 'type' fields are "
+                         "required.")
+
+    def test_service_uuid_already_exists(self):
+        self.core.add_api(self.eeapi)
+        data = {
+            'id': self.eeapi.uuid_key,
+            'name': self.eeapi.name_key,
+            'type': self.eeapi.type_key
+        }
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=data,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 409)
+        self.assertEqual(json_body['conflict']['code'], 409)
+        self.assertEqual(json_body['conflict']['message'],
+                         "Conflict: Service with the same uuid already "
+                         "exists.")
+
+    def test_service_name_already_exists(self):
+        self.core.add_api(self.eeapi)
+        data = {
+            'id': str(uuid.uuid4()),
+            'name': self.eeapi.name_key,
+            'type': self.eeapi.type_key
+        }
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=data,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 409)
+        self.assertEqual(json_body['conflict']['code'], 409)
+        self.assertEqual(json_body['conflict']['message'],
+                         "Conflict: Service with the same name already "
+                         "exists.")
+
+    def test_successfully_add_service_no_id(self):
+        data = {
+            'name': self.eeapi.name_key,
+            'type': self.eeapi.type_key
+        }
+        req = request(self, self.root, self.verb,
+                      "/identity/v2.0/services",
+                      body=json.dumps(data).encode("utf-8"),
+                      headers=self.headers)
+
+        response = self.successResultOf(req)
+        self.assertEqual(response.code, 201)
+
+    def test_successfully_add_service_with_id(self):
+        data = {
+            'name': self.eeapi.name_key,
+            'type': self.eeapi.type_key,
+            'id': text_type(uuid.uuid4())
+        }
+        req = request(self, self.root, self.verb,
+                      self.uri,
+                      body=json.dumps(data).encode("utf-8"),
+                      headers=self.headers)
+
+        response = self.successResultOf(req)
+        self.assertEqual(response.code, 201)
+
+    def test_successfully_add_service_with_description(self):
+        data = {
+            'name': self.eeapi.name_key,
+            'type': self.eeapi.type_key,
+            'description': 'testing external API'
+        }
+        req = request(self, self.root, self.verb,
+                      self.uri,
+                      body=json.dumps(data).encode("utf-8"),
+                      headers=self.headers)
+
+        response = self.successResultOf(req)
+        self.assertEqual(response.code, 201)
+
+
+class TestIdentityMimicOSKSCatalogAdminDeleteExternalService(SynchronousTestCase):
+    """
+    Tests for ``/identity/v2.0/services/<service-id>``, provided by
+    :obj:`mimic.rest.idenity_api.IdentityApi`
+    """
+    def setUp(self):
+        self.core = MimicCore(Clock(), [])
+        self.root = MimicRoot(self.core).app.resource()
+        self.eeapi_id = u"some-id"
+        self.uri = "/identity/v2.0/services/" + self.eeapi_id
+        self.eeapi_name = u"externalServiceName"
+        self.eeapi = make_example_external_api(
+            self,
+            name=self.eeapi_name,
+            set_enabled=True
+        )
+        self.eeapi2 = make_example_external_api(
+            self,
+            name=self.eeapi_name + " alternate"
+        )
+        self.eeapi.uuid_key = self.eeapi_id
+        self.headers = {
+            b'X-Auth-Token': [b'ABCDEF987654321']
+        }
+        self.verb = b"DELETE"
+
+    def test_auth_fail(self):
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri))
+
+        self.assertEqual(response.code, 401)
+        self.assertEqual(json_body['unauthorized']['code'], 401)
+
+    def test_invalid_service(self):
+        data = {
+            'name': 'some-name',
+            'type': 'some-type',
+            'id': 'some-id'
+        }
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=data,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 404)
+        self.assertEqual(json_body['itemNotFound']['code'], 404)
+        self.assertEqual(json_body['itemNotFound']['message'],
+                         "Service not found. Unable to remove.")
+
+    def test_service_has_template(self):
+        self.core.add_api(self.eeapi)
+        data = {
+            'name': self.eeapi.name_key,
+            'type': self.eeapi.type_key,
+            'id': self.eeapi.uuid_key
+        }
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=data,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 409)
+        self.assertEqual(json_body['conflict']['code'], 409)
+        self.assertEqual(json_body['conflict']['message'],
+                         "Service still has endpoint templates.")
+
+    def test_remove_service(self):
+        templates_to_remove = list(self.eeapi.endpoint_templates.keys())
+        for template_id in templates_to_remove:
+            self.eeapi.remove_template(template_id)
+
+        self.core.add_api(self.eeapi)
+        self.core.add_api(self.eeapi2)
+        data = {
+            'name': self.eeapi.name_key,
+            'type': self.eeapi.type_key,
+            'id': self.eeapi.uuid_key
+        }
+
+        req = request(self, self.root, self.verb,
+                      self.uri,
+                      body=json.dumps(data).encode("utf-8"),
+                      headers=self.headers)
+
+        response = self.successResultOf(req)
+        self.assertEqual(response.code, 204)

--- a/mimic/test/test_identity_osksadm.py
+++ b/mimic/test/test_identity_osksadm.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, unicode_literals
 import json
 import uuid
 
+import ddt
 from six import text_type
 
 from twisted.trial.unittest import SynchronousTestCase
@@ -18,6 +19,7 @@ from mimic.test.dummy import make_example_external_api, ExternalApiStore
 from mimic.test.helpers import json_request, request
 
 
+@ddt.ddt
 class TestIdentityMimicOSKSCatalogAdminListExternalServices(SynchronousTestCase):
     """
     Tests for ``/identity/v2.0/services``, provided by
@@ -28,17 +30,15 @@ class TestIdentityMimicOSKSCatalogAdminListExternalServices(SynchronousTestCase)
         self.root = MimicRoot(self.core).app.resource()
         self.uri = "/identity/v2.0/services"
         self.eeapi_name = u"externalServiceName"
-        self.eeapi = make_example_external_api(
-            self,
-            name=self.eeapi_name,
-            set_enabled=True
-        )
         self.headers = {
             b'X-Auth-Token': [b'ABCDEF987654321']
         }
         self.verb = b"GET"
 
     def test_auth_fail(self):
+        """
+        GET with no X-Auth-Token header results in 401.
+        """
         (response, json_body) = self.successResultOf(
             json_request(self, self.root, self.verb,
                          self.uri))
@@ -46,34 +46,17 @@ class TestIdentityMimicOSKSCatalogAdminListExternalServices(SynchronousTestCase)
         self.assertEqual(response.code, 401)
         self.assertEqual(json_body['unauthorized']['code'], 401)
 
-    def test_list_empty(self):
-        (response, json_body) = self.successResultOf(
-            json_request(self, self.root, self.verb,
-                         self.uri,
-                         headers=self.headers))
+    @ddt.data(
+        0, 1, 10
+    )
+    def test_listing(self, api_entry_count):
+        """
+        GET will list the registered services.
+        """
+        api_list = []
 
-        self.assertEqual(response.code, 200)
-        self.assertEqual(len(json_body["OS-KSADM:services"]), 0)
-
-    def test_list_single(self):
-        self.core.add_api(self.eeapi)
-        (response, json_body) = self.successResultOf(
-            json_request(self, self.root, self.verb,
-                         self.uri,
-                         headers=self.headers))
-
-        self.assertEqual(response.code, 200)
-        self.assertEqual(len(json_body["OS-KSADM:services"]), 1)
-        self.assertEqual(json_body["OS-KSADM:services"][0]['id'],
-                         self.eeapi.uuid_key)
-        self.assertEqual(json_body["OS-KSADM:services"][0]['type'],
-                         self.eeapi.type_key)
-        self.assertEqual(json_body["OS-KSADM:services"][0]['name'],
-                         self.eeapi.name_key)
-
-    def test_list_multiple(self):
-        api_list = [self.eeapi]
-        for _ in range(10):
+        # create the desired number of services per test parameter
+        for _ in range(api_entry_count):
             api_list.append(
                 ExternalApiStore(
                     text_type(uuid.uuid4()),
@@ -81,26 +64,44 @@ class TestIdentityMimicOSKSCatalogAdminListExternalServices(SynchronousTestCase)
                     'service-' + text_type(uuid.uuid4()),
                 )
             )
+
+        # add the services
         for api in api_list:
             self.core.add_api(api)
+
+        # retrieve the listing using the REST interface
         (response, json_body) = self.successResultOf(
             json_request(self, self.root, self.verb,
                          self.uri,
                          headers=self.headers))
 
         def validate_api(api_id, api_type, api_name):
+            """
+            Lookup the API in the test's set of APIs  and match the values
+            """
             for api in api_list:
                 if api.uuid_key == api_id:
+                    # service found, check values and return
                     self.assertEqual(api_id, api.uuid_key)
                     self.assertEqual(api_type, api.type_key)
                     self.assertEqual(api_name, api.name_key)
+                    return
+
+            # no service found, raise assertion error
+            self.assertFalse(
+                True,
+                "Unknown service: {0} - {1} - {2}".format(
+                    api_id, api_type, api_name))
 
         self.assertEqual(response.code, 200)
         self.assertEqual(len(json_body["OS-KSADM:services"]), len(api_list))
+        # ensure all services in the response match one in the generated
+        # initially generated set
         for entry in json_body["OS-KSADM:services"]:
             validate_api(entry['id'], entry['type'], entry['name'])
 
 
+@ddt.ddt
 class TestIdentityMimicOSKSCatalogAdminCreateExternalService(SynchronousTestCase):
     """
     Tests for ``/identity/v2.0/services``, provided by
@@ -122,6 +123,9 @@ class TestIdentityMimicOSKSCatalogAdminCreateExternalService(SynchronousTestCase
         self.verb = b"POST"
 
     def test_auth_fail(self):
+        """
+        POST with no X-Auth-Token header results in 401.
+        """
         (response, json_body) = self.successResultOf(
             json_request(self, self.root, self.verb,
                          self.uri))
@@ -130,6 +134,9 @@ class TestIdentityMimicOSKSCatalogAdminCreateExternalService(SynchronousTestCase
         self.assertEqual(json_body['unauthorized']['code'], 401)
 
     def test_invalid_json_body(self):
+        """
+        POST will generate 400 when an invalid JSON body is provided.
+        """
         (response, json_body) = self.successResultOf(
             json_request(self, self.root, self.verb,
                          self.uri,
@@ -141,32 +148,29 @@ class TestIdentityMimicOSKSCatalogAdminCreateExternalService(SynchronousTestCase
         self.assertEqual(json_body['badRequest']['message'],
                          'Invalid JSON request body')
 
-    def test_json_body_missing_required_field_name(self):
+    @ddt.data(
+        'type', 'name'
+    )
+    def test_json_body_missing_required_field(self, remove_field):
+        """
+        POST requires 'name' field otherwise 400 is generated.
+        """
+        # normal JSON body
         data = {
-            'type': 'some-type'
-        }
-        (response, json_body) = self.successResultOf(
-            json_request(self, self.root, self.verb,
-                         self.uri,
-                         body=data,
-                         headers=self.headers))
-
-        self.assertEqual(response.code, 400)
-        self.assertEqual(json_body['badRequest']['code'], 400)
-        self.assertEqual(json_body['badRequest']['message'],
-                         "Invalid Content. 'name' and 'type' fields are "
-                         "required.")
-
-    def test_json_body_missing_required_field_type(self):
-        data = {
+            'type': 'some-type',
             'name': 'some-name'
         }
+        # remove a portion of the body per the DDT data
+        del data[remove_field]
+
+        # POST the resulting JSON to the REST API
         (response, json_body) = self.successResultOf(
             json_request(self, self.root, self.verb,
                          self.uri,
                          body=data,
                          headers=self.headers))
 
+        # API should return 400 since a required field is missing
         self.assertEqual(response.code, 400)
         self.assertEqual(json_body['badRequest']['code'], 400)
         self.assertEqual(json_body['badRequest']['message'],
@@ -174,6 +178,9 @@ class TestIdentityMimicOSKSCatalogAdminCreateExternalService(SynchronousTestCase
                          "required.")
 
     def test_service_uuid_already_exists(self):
+        """
+        POST requires a unique UUID for the Service ID.
+        """
         self.core.add_api(self.eeapi)
         data = {
             'id': self.eeapi.uuid_key,
@@ -193,6 +200,9 @@ class TestIdentityMimicOSKSCatalogAdminCreateExternalService(SynchronousTestCase
                          "exists.")
 
     def test_service_name_already_exists(self):
+        """
+        POST requires a unique name for the service Name.
+        """
         self.core.add_api(self.eeapi)
         data = {
             'id': str(uuid.uuid4()),
@@ -211,11 +221,22 @@ class TestIdentityMimicOSKSCatalogAdminCreateExternalService(SynchronousTestCase
                          "Conflict: Service with the same name already "
                          "exists.")
 
-    def test_successfully_add_service_no_id(self):
+    @ddt.data(
+        True, False
+    )
+    def test_successfully_add_service(self, has_id_field):
+        """
+        POST accepts the service type and name regardless of whether
+        an ID field is provided.
+        """
         data = {
             'name': self.eeapi.name_key,
-            'type': self.eeapi.type_key
+            'type': self.eeapi.type_key,
+            'id': text_type(uuid.uuid4())
         }
+        if not has_id_field:
+            del data['id']
+
         req = request(self, self.root, self.verb,
                       "/identity/v2.0/services",
                       body=json.dumps(data).encode("utf-8"),
@@ -224,21 +245,10 @@ class TestIdentityMimicOSKSCatalogAdminCreateExternalService(SynchronousTestCase
         response = self.successResultOf(req)
         self.assertEqual(response.code, 201)
 
-    def test_successfully_add_service_with_id(self):
-        data = {
-            'name': self.eeapi.name_key,
-            'type': self.eeapi.type_key,
-            'id': text_type(uuid.uuid4())
-        }
-        req = request(self, self.root, self.verb,
-                      self.uri,
-                      body=json.dumps(data).encode("utf-8"),
-                      headers=self.headers)
-
-        response = self.successResultOf(req)
-        self.assertEqual(response.code, 201)
-
     def test_successfully_add_service_with_description(self):
+        """
+        POST accepts a Service Description.
+        """
         data = {
             'name': self.eeapi.name_key,
             'type': self.eeapi.type_key,
@@ -280,6 +290,9 @@ class TestIdentityMimicOSKSCatalogAdminDeleteExternalService(SynchronousTestCase
         self.verb = b"DELETE"
 
     def test_auth_fail(self):
+        """
+        DELETE with no X-Auth-Token header results in 401.
+        """
         (response, json_body) = self.successResultOf(
             json_request(self, self.root, self.verb,
                          self.uri))
@@ -288,6 +301,9 @@ class TestIdentityMimicOSKSCatalogAdminDeleteExternalService(SynchronousTestCase
         self.assertEqual(json_body['unauthorized']['code'], 401)
 
     def test_invalid_service(self):
+        """
+        DELETE an unknown service will generate a 404.
+        """
         data = {
             'name': 'some-name',
             'type': 'some-type',
@@ -305,6 +321,9 @@ class TestIdentityMimicOSKSCatalogAdminDeleteExternalService(SynchronousTestCase
                          "Service not found. Unable to remove.")
 
     def test_service_has_template(self):
+        """
+        DELETE a service that still has a template results in 409.
+        """
         self.core.add_api(self.eeapi)
         data = {
             'name': self.eeapi.name_key,
@@ -323,6 +342,9 @@ class TestIdentityMimicOSKSCatalogAdminDeleteExternalService(SynchronousTestCase
                          "Service still has endpoint templates.")
 
     def test_remove_service(self):
+        """
+        DELETE a service.
+        """
         templates_to_remove = list(self.eeapi.endpoint_templates.keys())
         for template_id in templates_to_remove:
             self.eeapi.remove_template(template_id)

--- a/mimic/test/test_identity_oskscatalog.py
+++ b/mimic/test/test_identity_oskscatalog.py
@@ -1,0 +1,875 @@
+"""
+Tests for mimic identity :mod:`mimic.rest.identity_api`
+"""
+
+from __future__ import absolute_import, division, unicode_literals
+
+import json
+import uuid
+
+from six import text_type
+
+from twisted.trial.unittest import SynchronousTestCase
+from twisted.internet.task import Clock
+
+from mimic.core import MimicCore
+from mimic.resource import MimicRoot
+from mimic.test.dummy import (
+    make_example_internal_api,
+    make_example_external_api
+)
+from mimic.test.helpers import json_request, request, get_template_id
+
+
+class TestIdentityOSKSCatalogAdminEndpointTemplatesList(SynchronousTestCase):
+    """
+    Tests for ``/identity/v2.0/OS-KSCATALOG/endpointTemplates``, provided by
+    :obj:`mimic.rest.idenity_api.IdentityApi`
+    """
+    def setUp(self):
+        self.core = MimicCore(Clock(), [])
+        self.root = MimicRoot(self.core).app.resource()
+        self.uri = "/identity/v2.0/OS-KSCATALOG/endpointTemplates"
+        self.eeapi_name = u"externalServiceName"
+        self.eeapi = make_example_external_api(
+            self,
+            name=self.eeapi_name,
+            set_enabled=True
+        )
+        self.headers = {
+            b'X-Auth-Token': [b'ABCDEF987654321']
+        }
+        self.verb = b"GET"
+
+    def test_auth_fail(self):
+        """
+        Validate X-Auth-Token required to access endpoint.
+        """
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri))
+
+        self.assertEqual(response.code, 401)
+        self.assertEqual(json_body['unauthorized']['code'], 401)
+
+    def test_invalid_service_id(self):
+        """
+        Validate a service-id that does not map to an actual service generates
+        a 404 failure.
+        """
+        self.headers.update({
+            'serviceid': [b'some-id']
+        })
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 404)
+        self.assertEqual(json_body['itemNotFound']['code'], 404)
+
+    def test_list_only_internal_apis_available(self):
+        """
+        Validate that if only Internal APIs are available that no templates are
+        listed; only an empty list is returned.
+        """
+        self.core.add_api(make_example_internal_api(self))
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 200)
+        self.assertEqual(len(json_body['OS-KSCATALOG']), 0)
+        self.assertEqual(
+            len(json_body['OS-KSCATALOG:endpointsTemplates_links']),
+            0)
+
+    def test_list_single_template(self):
+        """
+        Validate that if an external API is present that its template will show
+        up in the listing.
+        """
+        self.core.add_api(self.eeapi)
+
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 200)
+        self.assertEqual(len(json_body['OS-KSCATALOG']), 1)
+        self.assertEqual(
+            len(json_body['OS-KSCATALOG:endpointsTemplates_links']),
+            0)
+
+    def test_list_single_template_external_and_internal_apis(self):
+        """
+        Validate that if both an internal and and external API are present that
+        only the External API shows up in the template listing.
+        """
+        self.core.add_api(self.eeapi)
+        self.core.add_api(make_example_internal_api(self))
+
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 200)
+        self.assertEqual(len(json_body['OS-KSCATALOG']), 1)
+        self.assertEqual(
+            len(json_body['OS-KSCATALOG:endpointsTemplates_links']),
+            0)
+
+    def test_multiple_external_apis(self):
+        """
+        """
+        api_list = [self.eeapi]
+        for _ in range(10):
+            api_list.append(
+                make_example_external_api(
+                    self,
+                    name=self.eeapi_name + text_type(uuid.uuid4()),
+                    service_type='service-' + text_type(uuid.uuid4())
+                )
+            )
+        for api in api_list:
+            self.core.add_api(api)
+
+        self.assertEqual(len(self.core._uuid_to_api_external),
+                         len(api_list))
+
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         headers=self.headers))
+
+        def get_header(header_name):
+            return response.headers.getRawHeaders(header_name)[0].decode("utf-8")
+
+        self.assertEqual(response.code, 200)
+
+        self.assertEqual(len(json_body['OS-KSCATALOG']),
+                         len(api_list))
+        self.assertEqual(
+            len(json_body['OS-KSCATALOG:endpointsTemplates_links']),
+            0)
+
+
+class TestIdentityOSKSCatalogAdminEndpointTemplatesAdd(SynchronousTestCase):
+    """
+    Tests for ``/identity/v2.0/OS-KSCATALOG/endpointTemplates``, provided by
+    :obj:`mimic.rest.idenity_api.IdentityApi`
+    """
+    def setUp(self):
+        self.core = MimicCore(Clock(), [])
+        self.root = MimicRoot(self.core).app.resource()
+        self.uri = "/identity/v2.0/OS-KSCATALOG/endpointTemplates"
+        self.eeapi_name = u"externalServiceName"
+        self.eeapi = make_example_external_api(
+            self,
+            name=self.eeapi_name,
+            set_enabled=True
+        )
+        self.headers = {
+            b'X-Auth-Token': [b'ABCDEF987654321']
+        }
+        self.verb = b"POST"
+
+    def test_auth_fail(self):
+        """
+        Validate X-Auth-Token required to access endpoint.
+        """
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri))
+
+        self.assertEqual(response.code, 401)
+        self.assertEqual(json_body['unauthorized']['code'], 401)
+
+    def test_invalid_json_body(self):
+        """
+        Validate that a JSON message body is required.
+        """
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=b'<xml>ensure json failure',
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 400)
+        self.assertEqual(json_body['badRequest']['code'], 400)
+        self.assertEqual(json_body['badRequest']['message'],
+                         'Invalid JSON request body')
+
+    def test_json_body_missing_required_field_name(self):
+        """
+        Validate that the name field in the JSON body is required.
+        """
+        data = {
+            'id': text_type(uuid.uuid4()),
+            'type': 'some-type',
+            'region': 'some-region'
+        }
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=data,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 400)
+        self.assertEqual(json_body['badRequest']['code'], 400)
+        self.assertTrue(
+            json_body['badRequest']['message'].startswith(
+                "JSON body does not contain the required parameters:"
+            )
+        )
+
+    def test_json_body_missing_required_field_id(self):
+        """
+        Validate that the id field in the JSON body is required.
+        """
+        data = {
+            'name': 'some-name',
+            'type': 'some-type',
+            'region': 'some-region'
+        }
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=data,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 400)
+        self.assertEqual(json_body['badRequest']['code'], 400)
+        self.assertTrue(
+            json_body['badRequest']['message'].startswith(
+                "JSON body does not contain the required parameters:"
+            )
+        )
+
+    def test_json_body_missing_required_field_type(self):
+        """
+        Validate that the type field in the JSON body is required.
+        """
+        data = {
+            'id': text_type(uuid.uuid4()),
+            'name': 'some-name',
+            'region': 'some-region'
+        }
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=data,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 400)
+        self.assertEqual(json_body['badRequest']['code'], 400)
+        self.assertTrue(
+            json_body['badRequest']['message'].startswith(
+                "JSON body does not contain the required parameters:"
+            )
+        )
+
+    def test_json_body_missing_required_field_region(self):
+        """
+        Validate that the region field in the JSON body is required.
+        """
+        data = {
+            'id': text_type(uuid.uuid4()),
+            'name': 'some-name',
+            'type': 'some-type'
+        }
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=data,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 400)
+        self.assertEqual(json_body['badRequest']['code'], 400)
+        self.assertTrue(
+            json_body['badRequest']['message'].startswith(
+                "JSON body does not contain the required parameters:"
+            )
+        )
+
+    def test_invalid_service_name(self):
+        """
+        Validate a service-id that does not map to an actual service
+        generates a 404 failure.
+        """
+        # Add a second API
+        eeapi2 = make_example_external_api(
+            self,
+            name='d' + self.eeapi_name + text_type(uuid.uuid4()),
+            service_type='service-' + text_type(uuid.uuid4())
+        )
+        eeapi2.id_key = '0'
+
+        # ensure only one instance of the API has the template
+        eeapi2.remove_template(get_template_id(self, self.eeapi))
+        self.core.add_api(eeapi2)
+        self.core.add_api(self.eeapi)
+
+        data = {
+            'id': text_type(uuid.uuid4()),
+            'name': 'some-name',
+            'type': 'some-type',
+            'region': 'some-region'
+        }
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=data,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 404)
+        self.assertEqual(json_body['itemNotFound']['code'], 404)
+        self.assertEqual(
+            json_body['itemNotFound']['message'],
+            "Service API for endoint template not found"
+        )
+
+    def test_existing_endpoint_template(self):
+        """
+        Validate adding an endpoint template that matches an existing
+        endpoint template generates a 409 failure.
+        """
+        self.core.add_api(self.eeapi)
+        id_key = get_template_id(self, self.eeapi)
+
+        data = {
+            'id': id_key,
+            'name': self.eeapi_name,
+            'type': 'some-type',
+            'region': 'some-region'
+        }
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=data,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 409)
+        self.assertEqual(json_body['conflict']['code'], 409)
+        self.assertEqual(
+            json_body['conflict']['message'],
+            "ID value is already assigned to an existing template"
+        )
+
+    def test_new_endpoint_template_wrong_service_type(self):
+        """
+        Validate that the service type must match between
+        the service and the endpoint template.
+        """
+        self.core.add_api(self.eeapi)
+        id_key = get_template_id(self, self.eeapi)
+
+        data = {
+            'id': text_type(uuid.uuid4()),
+            'name': self.eeapi_name,
+            'type': 'some-type',
+            'region': 'some-region'
+        }
+        self.assertNotEqual(id_key, data['id'])
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=data,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 409)
+        self.assertEqual(json_body['conflict']['code'], 409)
+        self.assertEqual(
+            json_body['conflict']['message'],
+            "Endpoint already exists or service type does not match."
+        )
+
+    def test_new_endpoint_template(self):
+        """
+        Validate that a new endpoint template can be added without
+        the service-id header field specified.
+        """
+        self.core.add_api(self.eeapi)
+        id_key = get_template_id(self, self.eeapi)
+
+        eeapi2 = make_example_external_api(
+            self,
+            name=self.eeapi_name + text_type(uuid.uuid4()),
+            service_type='service-' + text_type(uuid.uuid4())
+        )
+        eeapi2.remove_template(id_key)
+        self.core.add_api(eeapi2)
+
+        data = {
+            'id': text_type(uuid.uuid4()),
+            'name': self.eeapi_name,
+            'type': self.eeapi.type_key,
+            'region': 'some-region'
+        }
+        self.assertNotEqual(id_key, data['id'])
+
+        req = request(self, self.root, self.verb,
+                      self.uri,
+                      body=json.dumps(data).encode("utf-8"),
+                      headers=self.headers)
+
+        response = self.successResultOf(req)
+        self.assertEqual(response.code, 201)
+
+    def test_new_endpoint_template_with_service_id_header(self):
+        """
+        Validate that a new endpoint template can be added with
+        the service-id header field specified.
+        """
+        self.core.add_api(self.eeapi)
+        id_key = get_template_id(self, self.eeapi)
+
+        eeapi2 = make_example_external_api(
+            self,
+            name=self.eeapi_name + text_type(uuid.uuid4()),
+            service_type='service-' + text_type(uuid.uuid4())
+        )
+        eeapi2.remove_template(id_key)
+        self.core.add_api(eeapi2)
+
+        data = {
+            'id': text_type(uuid.uuid4()),
+            'name': self.eeapi_name,
+            'type': self.eeapi.type_key,
+            'region': 'some-region'
+        }
+        self.assertNotEqual(id_key, data['id'])
+
+        self.headers[b'serviceid'] = [self.eeapi.uuid_key.encode('utf8')]
+
+        req = request(self, self.root, self.verb,
+                      self.uri,
+                      body=json.dumps(data).encode("utf-8"),
+                      headers=self.headers)
+
+        response = self.successResultOf(req)
+        self.assertEqual(response.code, 201)
+
+
+class TestIdentityOSKSCatalogAdminEndpointTemplatesUpdate(SynchronousTestCase):
+    """
+    Tests for ``/identity/v2.0/OS-KSCATALOG/endpointTemplates``, provided by
+    :obj:`mimic.rest.idenity_api.IdentityApi`
+    """
+    def setUp(self):
+        self.core = MimicCore(Clock(), [])
+        self.root = MimicRoot(self.core).app.resource()
+        self.eeapi_name = u"externalServiceName"
+        self.eeapi = make_example_external_api(
+            self,
+            name=self.eeapi_name,
+            set_enabled=True
+        )
+        self.headers = {
+            b'X-Auth-Token': [b'ABCDEF987654321']
+        }
+        self.verb = b"PUT"
+        self.ept_template_id = get_template_id(self, self.eeapi)
+        self.uri = (
+            "/identity/v2.0/OS-KSCATALOG/endpointTemplates/" +
+            self.ept_template_id
+        )
+
+    def test_auth_fail(self):
+        """
+        Validate X-Auth-Token required to access endpoint
+        """
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri))
+
+        self.assertEqual(response.code, 401)
+        self.assertEqual(json_body['unauthorized']['code'], 401)
+
+    def test_invalid_json_body(self):
+        """
+        Validate that a JSON message body is required.
+        """
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=b'<xml>ensure json failure',
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 400)
+        self.assertEqual(json_body['badRequest']['code'], 400)
+        self.assertEqual(json_body['badRequest']['message'],
+                         'Invalid JSON request body')
+
+    def test_json_body_missing_required_field_name(self):
+        """
+        Validate that the name field in the JSON body is required.
+        """
+        data = {
+            'id': self.ept_template_id,
+            'type': 'some-type',
+            'region': 'some-region'
+        }
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=data,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 400)
+        self.assertEqual(json_body['badRequest']['code'], 400)
+        self.assertTrue(
+            json_body['badRequest']['message'].startswith(
+                "JSON body does not contain the required parameters:"
+            )
+        )
+
+    def test_json_body_missing_required_field_id(self):
+        """
+        Validate that the id field in the JSON body is required.
+        """
+        data = {
+            'name': 'some-name',
+            'type': 'some-type',
+            'region': 'some-region'
+        }
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=data,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 400)
+        self.assertEqual(json_body['badRequest']['code'], 400)
+        self.assertTrue(
+            json_body['badRequest']['message'].startswith(
+                "JSON body does not contain the required parameters:"
+            )
+        )
+
+    def test_json_body_missing_required_field_type(self):
+        """
+        Validate that the type field in the JSON body is required.
+        """
+        data = {
+            'id': self.ept_template_id,
+            'name': 'some-name',
+            'region': 'some-region'
+        }
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=data,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 400)
+        self.assertEqual(json_body['badRequest']['code'], 400)
+        self.assertTrue(
+            json_body['badRequest']['message'].startswith(
+                "JSON body does not contain the required parameters:"
+            )
+        )
+
+    def test_json_body_missing_required_field_region(self):
+        """
+        Validate that the region field in the JSON body is required.
+        """
+        data = {
+            'id': self.ept_template_id,
+            'name': 'some-name',
+            'type': 'some-type'
+        }
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=data,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 400)
+        self.assertEqual(json_body['badRequest']['code'], 400)
+        self.assertTrue(
+            json_body['badRequest']['message'].startswith(
+                "JSON body does not contain the required parameters:"
+            )
+        )
+
+    def test_invalid_service_id(self):
+        """
+        Validate a service-id that does not map to an actual service
+        generates a 404 failure.
+        """
+        data = {
+            'id': self.ept_template_id,
+            'name': 'some-name',
+            'type': 'some-type',
+            'region': 'some-region'
+        }
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=data,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 404)
+        self.assertEqual(json_body['itemNotFound']['code'], 404)
+        self.assertEqual(
+            json_body['itemNotFound']['message'],
+            "Service API for endoint template not found"
+        )
+
+    def test_new_endpoint_template_wrong_service_type(self):
+        """
+        Validate that the service type must match between
+        the service and the endpoint template.
+        """
+        self.core.add_api(self.eeapi)
+
+        data = {
+            'id': self.ept_template_id,
+            'name': self.eeapi_name,
+            'type': 'some-type',
+            'region': 'some-region'
+        }
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=data,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 409)
+        self.assertEqual(json_body['conflict']['code'], 409)
+        self.assertEqual(
+            json_body['conflict']['message'],
+            "Endpoint already exists and service id or service type does not "
+            "match."
+        )
+
+    def test_json_body_id_value_not_matching_url(self):
+        """
+        Validate that the template id in the URL and the
+        template ID in the JSON body must match
+        """
+        self.core.add_api(self.eeapi)
+        id_key = get_template_id(self, self.eeapi)
+
+        eeapi2 = make_example_external_api(
+            self,
+            name=self.eeapi_name + text_type(uuid.uuid4()),
+            service_type='service-' + text_type(uuid.uuid4())
+        )
+        eeapi2.remove_template(id_key)
+        self.core.add_api(eeapi2)
+
+        data = {
+            'id': 'some-random-key',
+            'name': self.eeapi_name,
+            'type': self.eeapi.type_key,
+            'region': 'some-region'
+        }
+
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=data,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 409)
+        self.assertEqual(json_body['conflict']['code'], 409)
+        self.assertEqual(
+            json_body['conflict']['message'],
+            "Template ID in URL does not match that of the JSON body"
+        )
+
+    def test_invalid_template_id(self):
+        """
+        Validate that a new endpoint template can be updated.
+        """
+        self.core.add_api(self.eeapi)
+        id_key = get_template_id(self, self.eeapi)
+        self.eeapi.remove_template(id_key)
+
+        data = {
+            'id': id_key,
+            'name': self.eeapi_name,
+            'type': self.eeapi.type_key,
+            'region': 'some-region'
+        }
+
+        self.headers[b'serviceid'] = [self.eeapi.uuid_key.encode('utf8')]
+
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=data,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 404)
+        self.assertEqual(json_body['itemNotFound']['code'], 404)
+        self.assertEqual(
+            json_body['itemNotFound']['message'],
+            "Unable to update non-existent template. Template must "
+            "first be added before it can be updated.",
+        )
+
+    def test_update_endpoint_template(self):
+        """
+        Validate that a new endpoint template can be updated.
+        """
+        self.core.add_api(self.eeapi)
+        id_key = get_template_id(self, self.eeapi)
+
+        eeapi2 = make_example_external_api(
+            self,
+            name=self.eeapi_name + text_type(uuid.uuid4()),
+            service_type='service-' + text_type(uuid.uuid4())
+        )
+        eeapi2.remove_template(id_key)
+        self.core.add_api(eeapi2)
+
+        data = {
+            'id': id_key,
+            'name': self.eeapi_name,
+            'type': self.eeapi.type_key,
+            'region': 'some-region'
+        }
+
+        req = request(self, self.root, self.verb,
+                      self.uri,
+                      body=json.dumps(data).encode("utf-8"),
+                      headers=self.headers)
+
+        response = self.successResultOf(req)
+        self.assertEqual(response.code, 201)
+
+    def test_update_endpoint_template_with_serviceid_header(self):
+        """
+        Validate that a new endpoint template can be updated.
+        """
+        self.core.add_api(self.eeapi)
+        id_key = get_template_id(self, self.eeapi)
+
+        eeapi2 = make_example_external_api(
+            self,
+            name=self.eeapi_name + text_type(uuid.uuid4()),
+            service_type='service-' + text_type(uuid.uuid4())
+        )
+        eeapi2.remove_template(id_key)
+        self.core.add_api(eeapi2)
+
+        data = {
+            'id': id_key,
+            'name': self.eeapi_name,
+            'type': self.eeapi.type_key,
+            'region': 'some-region'
+        }
+
+        self.headers[b'serviceid'] = [self.eeapi.uuid_key.encode('utf8')]
+
+        req = request(self, self.root, self.verb,
+                      self.uri,
+                      body=json.dumps(data).encode("utf-8"),
+                      headers=self.headers)
+
+        response = self.successResultOf(req)
+        self.assertEqual(response.code, 201)
+
+
+class TestIdentityOSKSCatalogAdminEndpointTemplatesDelete(SynchronousTestCase):
+    """
+    Tests for ``/identity/v2.0/OS-KSCATALOG/endpointTemplates``, provided by
+    :obj:`mimic.rest.idenity_api.IdentityApi`
+    """
+    def setUp(self):
+        self.core = MimicCore(Clock(), [])
+        self.root = MimicRoot(self.core).app.resource()
+        self.eeapi_name = u"externalServiceName"
+        self.eeapi = make_example_external_api(
+            self,
+            name=self.eeapi_name,
+            set_enabled=True
+        )
+        self.headers = {
+            b'X-Auth-Token': [b'ABCDEF987654321']
+        }
+        self.verb = b"DELETE"
+        self.ept_template_id = get_template_id(self, self.eeapi)
+        self.uri = (
+            "/identity/v2.0/OS-KSCATALOG/endpointTemplates/" +
+            self.ept_template_id
+        )
+
+    def test_auth_fail(self):
+        """
+        Validate X-Auth-Token required to access endpoint.
+        """
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri))
+
+        self.assertEqual(response.code, 401)
+        self.assertEqual(json_body['unauthorized']['code'], 401)
+
+    def test_invalid_template_id(self):
+        """
+        Validate that removing a non-existent template will
+        return a 404.
+        """
+        self.eeapi.remove_template(self.ept_template_id)
+        self.core.add_api(self.eeapi)
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 404)
+        self.assertEqual(json_body['itemNotFound']['code'], 404)
+        self.assertEqual(
+            json_body['itemNotFound']['message'],
+            "Unable to locate an External API with the given Template ID."
+        )
+
+    def test_invalid_template_id_with_service_header(self):
+        """
+        Validate that removing a non-existent template will
+        return a 404.
+        """
+        self.eeapi.remove_template(self.ept_template_id)
+        self.core.add_api(self.eeapi)
+        self.headers[b'serviceid'] = [self.eeapi.uuid_key.encode('utf8')]
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 404)
+        self.assertEqual(json_body['itemNotFound']['code'], 404)
+        self.assertEqual(
+            json_body['itemNotFound']['message'],
+            "Unable to locate an External API with the given Template ID."
+        )
+
+    def test_remove_template_id(self):
+        """
+        Validate removing an existing template will return a 204.
+        """
+        self.core.add_api(self.eeapi)
+        req = request(self, self.root, self.verb,
+                      self.uri,
+                      headers=self.headers)
+        response = self.successResultOf(req)
+        self.assertEqual(response.code, 204)
+
+    def test_remove_template_id_with_service_header(self):
+        """
+        Validate removing an existing template will return a 204.
+        """
+        self.core.add_api(self.eeapi)
+        self.headers[b'serviceid'] = [self.eeapi.uuid_key.encode('utf8')]
+        req = request(self, self.root, self.verb,
+                      self.uri,
+                      headers=self.headers)
+        response = self.successResultOf(req)
+        self.assertEqual(response.code, 204)

--- a/mimic/test/test_identity_oskscatalog.py
+++ b/mimic/test/test_identity_oskscatalog.py
@@ -309,7 +309,7 @@ class TestIdentityOSKSCatalogAdminEndpointTemplatesAdd(SynchronousTestCase):
         eeapi2.id_key = '0'
 
         # ensure only one instance of the API has the template
-        eeapi2.remove_template(get_template_id(self, self.eeapi))
+        eeapi2.remove_template(get_template_id(self, eeapi2))
         self.core.add_api(eeapi2)
         self.core.add_api(self.eeapi)
 
@@ -400,7 +400,7 @@ class TestIdentityOSKSCatalogAdminEndpointTemplatesAdd(SynchronousTestCase):
             name=self.eeapi_name + text_type(uuid.uuid4()),
             service_type='service-' + text_type(uuid.uuid4())
         )
-        eeapi2.remove_template(id_key)
+        eeapi2.remove_template(get_template_id(self, eeapi2))
         self.core.add_api(eeapi2)
 
         data = {
@@ -432,7 +432,7 @@ class TestIdentityOSKSCatalogAdminEndpointTemplatesAdd(SynchronousTestCase):
             name=self.eeapi_name + text_type(uuid.uuid4()),
             service_type='service-' + text_type(uuid.uuid4())
         )
-        eeapi2.remove_template(id_key)
+        eeapi2.remove_template(get_template_id(self, eeapi2))
         self.core.add_api(eeapi2)
 
         data = {
@@ -660,7 +660,7 @@ class TestIdentityOSKSCatalogAdminEndpointTemplatesUpdate(SynchronousTestCase):
             name=self.eeapi_name + text_type(uuid.uuid4()),
             service_type='service-' + text_type(uuid.uuid4())
         )
-        eeapi2.remove_template(id_key)
+        eeapi2.remove_template(get_template_id(self, eeapi2))
         self.core.add_api(eeapi2)
 
         data = {
@@ -726,7 +726,7 @@ class TestIdentityOSKSCatalogAdminEndpointTemplatesUpdate(SynchronousTestCase):
             name=self.eeapi_name + text_type(uuid.uuid4()),
             service_type='service-' + text_type(uuid.uuid4())
         )
-        eeapi2.remove_template(id_key)
+        eeapi2.remove_template(get_template_id(self, eeapi2))
         self.core.add_api(eeapi2)
 
         data = {
@@ -756,7 +756,7 @@ class TestIdentityOSKSCatalogAdminEndpointTemplatesUpdate(SynchronousTestCase):
             name=self.eeapi_name + text_type(uuid.uuid4()),
             service_type='service-' + text_type(uuid.uuid4())
         )
-        eeapi2.remove_template(id_key)
+        eeapi2.remove_template(get_template_id(self, eeapi2))
         self.core.add_api(eeapi2)
 
         data = {

--- a/mimic/test/test_identity_oskscatalog.py
+++ b/mimic/test/test_identity_oskscatalog.py
@@ -20,10 +20,11 @@ from mimic.test.dummy import (
     make_example_external_api
 )
 from mimic.test.helpers import json_request, request, get_template_id
-from mimic.test.mixins import IdentityAuthMixin, InvalidJsonMixin
+from mimic.test.mixins import IdentityAuthMixin, InvalidJsonMixin, ServiceIdHeaderMixin
 
 
-class TestIdentityOSKSCatalogAdminEndpointTemplatesList(SynchronousTestCase, IdentityAuthMixin):
+class TestIdentityOSKSCatalogAdminEndpointTemplatesList(
+        SynchronousTestCase, IdentityAuthMixin, ServiceIdHeaderMixin):
     """
     Tests for ``/identity/v2.0/OS-KSCATALOG/endpointTemplates``, provided by
     :obj:`mimic.rest.idenity_api.IdentityApi`
@@ -42,21 +43,6 @@ class TestIdentityOSKSCatalogAdminEndpointTemplatesList(SynchronousTestCase, Ide
             b'X-Auth-Token': [b'ABCDEF987654321']
         }
         self.verb = b"GET"
-
-    def test_invalid_service_id(self):
-        """
-        GET must have a valid service id otherwise 404.
-        """
-        self.headers.update({
-            'serviceid': [b'some-id']
-        })
-        (response, json_body) = self.successResultOf(
-            json_request(self, self.root, self.verb,
-                         self.uri,
-                         headers=self.headers))
-
-        self.assertEqual(response.code, 404)
-        self.assertEqual(json_body['itemNotFound']['code'], 404)
 
     def test_list_only_internal_apis_available(self):
         """
@@ -197,7 +183,7 @@ class TestIdentityOSKSCatalogAdminEndpointTemplatesAdd(
             )
         )
 
-    def test_invalid_service_id(self):
+    def test_invalid_service_id_in_json_body(self):
         """
         POST - Service ID must be valid, otherwise results in 404.
         """
@@ -382,7 +368,7 @@ class TestIdentityOSKSCatalogAdminEndpointTemplatesUpdate(
             )
         )
 
-    def test_invalid_service_id(self):
+    def test_invalid_service_id_in_json_body(self):
         """
         PUT requires that the service id map to an existing service,
         otherwise results in a 404.

--- a/mimic/test/test_identity_oskscatalog_per_tenant.py
+++ b/mimic/test/test_identity_oskscatalog_per_tenant.py
@@ -19,10 +19,11 @@ from mimic.test.dummy import (
     make_example_external_api
 )
 from mimic.test.helpers import json_request, request, get_template_id
-from mimic.test.mixins import IdentityAuthMixin, InvalidJsonMixin
+from mimic.test.mixins import IdentityAuthMixin, InvalidJsonMixin, ServiceIdHeaderMixin
 
 
-class TestIdentityOSKSCatalogTenantAdminEndpointTemplatesList(SynchronousTestCase, IdentityAuthMixin):
+class TestIdentityOSKSCatalogTenantAdminEndpointTemplatesList(
+        SynchronousTestCase, IdentityAuthMixin, ServiceIdHeaderMixin):
     """
     Tests for ``/identity/v2.0/<tenant-id>/OS-KSCATALOG/endpointTemplates``,
     provided by :obj:`mimic.rest.idenity_api.IdentityApi`
@@ -45,22 +46,6 @@ class TestIdentityOSKSCatalogTenantAdminEndpointTemplatesList(SynchronousTestCas
             b'X-Auth-Token': [b'ABCDEF987654321']
         }
         self.verb = b"GET"
-
-    def test_invalid_service_id(self):
-        """
-        GET with service-id must map to an actual service otherwise
-        results in 404.
-        """
-        self.headers.update({
-            'serviceid': [b'some-id']
-        })
-        (response, json_body) = self.successResultOf(
-            json_request(self, self.root, self.verb,
-                         self.uri,
-                         headers=self.headers))
-
-        self.assertEqual(response.code, 404)
-        self.assertEqual(json_body['itemNotFound']['code'], 404)
 
     def test_list_only_internal_apis_available(self):
         """

--- a/mimic/test/test_identity_oskscatalog_per_tenant.py
+++ b/mimic/test/test_identity_oskscatalog_per_tenant.py
@@ -1,0 +1,407 @@
+"""
+Tests for mimic identity :mod:`mimic.rest.identity_api`
+"""
+
+from __future__ import absolute_import, division, unicode_literals
+
+import json
+import uuid
+
+from six import text_type
+
+from twisted.trial.unittest import SynchronousTestCase
+from twisted.internet.task import Clock
+
+from mimic.core import MimicCore
+from mimic.resource import MimicRoot
+from mimic.test.dummy import (
+    make_example_internal_api,
+    make_example_external_api
+)
+from mimic.test.helpers import json_request, request, get_template_id
+
+
+class TestIdentityOSKSCatalogTenantAdminEndpointTemplatesList(SynchronousTestCase):
+    """
+    Tests for ``/identity/v2.0/<tenant-id>/OS-KSCATALOG/endpointTemplates``,
+    provided by :obj:`mimic.rest.idenity_api.IdentityApi`
+    """
+    def setUp(self):
+        self.tenant_id = 'some_tenant'
+        self.core = MimicCore(Clock(), [])
+        self.root = MimicRoot(self.core).app.resource()
+        self.uri = (
+            "/identity/v2.0/tenants/" + self.tenant_id +
+            "/OS-KSCATALOG/endpoints"
+        )
+        self.eeapi_name = u"externalServiceName"
+        self.eeapi = make_example_external_api(
+            self,
+            name=self.eeapi_name,
+            set_enabled=True
+        )
+        self.headers = {
+            b'X-Auth-Token': [b'ABCDEF987654321']
+        }
+        self.verb = b"GET"
+
+    def test_auth_fail(self):
+        """
+        Validate X-Auth-Token required to access endpoint.
+        """
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri))
+
+        self.assertEqual(response.code, 401)
+        self.assertEqual(json_body['unauthorized']['code'], 401)
+
+    def test_invalid_service_id(self):
+        """
+        Validate a service-id that does not map to an actual service generates
+        a 404 failure.
+        """
+        self.headers.update({
+            'serviceid': [b'some-id']
+        })
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 404)
+        self.assertEqual(json_body['itemNotFound']['code'], 404)
+
+    def test_list_only_internal_apis_available(self):
+        """
+        Validate that if only Internal APIs are available that no templates are
+        listed; only an empty list is returned.
+        """
+        self.core.add_api(make_example_internal_api(self))
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 200)
+        self.assertEqual(len(json_body['endpoints']), 0)
+        self.assertEqual(len(json_body['endpoints_links']), 0)
+
+    def test_list_single_template(self):
+        """
+        Validate that if an external API is present that its template will show
+        up in the listing.
+        """
+        self.core.add_api(self.eeapi)
+
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 200)
+        self.assertEqual(len(json_body['endpoints']), 1)
+        self.assertEqual(len(json_body['endpoints_links']), 0)
+
+    def test_list_template_all_disabled(self):
+        """
+        Validate that if an external API is present that its template will show
+        up in the listing only if it is enabled.
+        """
+        self.core.add_api(self.eeapi)
+        id_key = get_template_id(self, self.eeapi)
+        self.eeapi.endpoint_templates[id_key].enabled_key = False
+
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 200)
+        self.assertEqual(len(json_body['endpoints']), 0)
+        self.assertEqual(len(json_body['endpoints_links']), 0)
+
+    def test_list_single_template_external_and_internal_apis(self):
+        """
+        Validate that if both an internal and and external API are present that
+        only the External API shows up in the template listing.
+        """
+        self.core.add_api(self.eeapi)
+        self.core.add_api(make_example_internal_api(self))
+
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 200)
+        self.assertEqual(len(json_body['endpoints']), 1)
+        self.assertEqual(len(json_body['endpoints_links']), 0)
+
+    def test_multiple_external_apis(self):
+        """
+        """
+        api_list = [self.eeapi]
+        for _ in range(10):
+            api_list.append(
+                make_example_external_api(
+                    self,
+                    name=self.eeapi_name + text_type(uuid.uuid4()),
+                    service_type='service-' + text_type(uuid.uuid4()),
+                    set_enabled=True
+                )
+            )
+        for api in api_list:
+            self.core.add_api(api)
+
+        self.assertEqual(len(self.core._uuid_to_api_external),
+                         len(api_list))
+
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         headers=self.headers))
+
+        def get_header(header_name):
+            return response.headers.getRawHeaders(header_name)[0].decode("utf-8")
+
+        self.assertEqual(response.code, 200)
+
+        self.assertEqual(len(json_body['endpoints']),
+                         len(api_list))
+        self.assertEqual(len(json_body['endpoints_links']), 0)
+
+
+class TestIdentityOSKSCatalogTenantAdminEndpointTemplatesCreate(SynchronousTestCase):
+    """
+    Tests for ``/identity/v2.0/<tenant-id>/OS-KSCATALOG/endpointTemplates``,
+    provided by :obj:`mimic.rest.idenity_api.IdentityApi`
+    """
+    def setUp(self):
+        self.tenant_id = 'some_tenant'
+        self.core = MimicCore(Clock(), [])
+        self.root = MimicRoot(self.core).app.resource()
+        self.uri = (
+            "/identity/v2.0/tenants/" + self.tenant_id +
+            "/OS-KSCATALOG/endpoints"
+        )
+        self.eeapi_name = u"externalServiceName"
+        self.eeapi = make_example_external_api(
+            self,
+            name=self.eeapi_name,
+            set_enabled=False
+        )
+        self.headers = {
+            b'X-Auth-Token': [b'ABCDEF987654321']
+        }
+        self.verb = b"POST"
+
+    def test_auth_fail(self):
+        """
+        Validate X-Auth-Token required to access endpoint.
+        """
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri))
+
+        self.assertEqual(response.code, 401)
+        self.assertEqual(json_body['unauthorized']['code'], 401)
+
+    def test_invalid_json_body(self):
+        """
+        Validate that a JSON message body is required.
+        """
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=b'<xml>ensure json failure',
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 400)
+        self.assertEqual(json_body['badRequest']['code'], 400)
+        self.assertEqual(json_body['badRequest']['message'],
+                         'Invalid JSON request body')
+
+    def test_json_body_missing_required_field_oskscatalog(self):
+        """
+        Validate that the name field in the JSON body is required.
+        """
+        data = {
+            'id': text_type(uuid.uuid4()),
+        }
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=data,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 400)
+        self.assertEqual(json_body['badRequest']['code'], 400)
+        self.assertTrue(
+            json_body['badRequest']['message'].startswith(
+                "Invalid Content. OS-KSCATALOG:endpointTemplate:id is "
+                "required."
+            )
+        )
+
+    def test_json_body_missing_required_field_template_id(self):
+        """
+        Validate that the name field in the JSON body is required.
+        """
+        data = {
+            "OS-KSCATALOG:endpointTemplate": {
+            }
+        }
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=data,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 400)
+        self.assertEqual(json_body['badRequest']['code'], 400)
+        self.assertTrue(
+            json_body['badRequest']['message'].startswith(
+                "Invalid Content. OS-KSCATALOG:endpointTemplate:id is "
+                "required."
+            )
+        )
+
+    def test_invalid_template_id(self):
+        """
+        Validate that the name field in the JSON body is required.
+        """
+        self.core.add_api(self.eeapi)
+        data = {
+            "OS-KSCATALOG:endpointTemplate": {
+                "id": "some-id"
+            }
+        }
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         body=data,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 404)
+        self.assertEqual(json_body['itemNotFound']['code'], 404)
+        self.assertTrue(
+            json_body['itemNotFound']['message'].startswith(
+                "Unable to locate an External API with the given Template ID."
+            )
+        )
+
+    def test_enable_template(self):
+        """
+        Validate that a new endpoint template can be updated.
+        """
+        self.core.add_api(self.eeapi)
+        id_key = get_template_id(self, self.eeapi)
+        data = {
+            "OS-KSCATALOG:endpointTemplate": {
+                "id": id_key
+            }
+        }
+
+        req = request(self, self.root, self.verb,
+                      self.uri,
+                      body=json.dumps(data).encode("utf-8"),
+                      headers=self.headers)
+
+        response = self.successResultOf(req)
+        self.assertEqual(response.code, 201)
+
+
+class TestIdentityOSKSCatalogTenantAdminEndpointTemplatesDelete(SynchronousTestCase):
+    """
+    Tests for ``/identity/v2.0/<tenant-id>/OS-KSCATALOG/endpointTemplates``,
+    provided by :obj:`mimic.rest.idenity_api.IdentityApi`
+    """
+    def setUp(self):
+        self.tenant_id = 'some_tenant'
+        self.core = MimicCore(Clock(), [])
+        self.root = MimicRoot(self.core).app.resource()
+        self.eeapi_name = u"externalServiceName"
+        self.eeapi = make_example_external_api(
+            self,
+            name=self.eeapi_name
+        )
+        self.template_id = get_template_id(self, self.eeapi)
+        self.assertIsNotNone(self.template_id)
+        self.uri = (
+            "/identity/v2.0/tenants/" + self.tenant_id +
+            "/OS-KSCATALOG/endpoints/" + self.template_id
+        )
+        self.headers = {
+            b'X-Auth-Token': [b'ABCDEF987654321']
+        }
+        self.verb = b"DELETE"
+
+    def test_auth_fail(self):
+        """
+        Validate X-Auth-Token required to access endpoint.
+        """
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri))
+
+        self.assertEqual(response.code, 401)
+        self.assertEqual(json_body['unauthorized']['code'], 401)
+
+    def test_invalid_template_id(self):
+        """
+        Validate that the name field in the JSON body is required.
+        """
+        self.eeapi.remove_template(self.template_id)
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 404)
+        self.assertEqual(json_body['itemNotFound']['code'], 404)
+        self.assertTrue(
+            json_body['itemNotFound']['message'].startswith(
+                "Unable to locate an External API with the given Template ID."
+            )
+        )
+
+    def test_template_id_not_enabled_for_tenant(self):
+        """
+        Validate that the name field in the JSON body is required.
+        """
+        self.core.add_api(self.eeapi)
+        (response, json_body) = self.successResultOf(
+            json_request(self, self.root, self.verb,
+                         self.uri,
+                         headers=self.headers))
+
+        self.assertEqual(response.code, 404)
+        self.assertEqual(json_body['itemNotFound']['code'], 404)
+        self.assertEqual(
+            json_body['itemNotFound']['message'],
+            "Template not enabled for tenant"
+        )
+
+    def test_disable_template(self):
+        """
+        Validate that a new endpoint template can be updated.
+        """
+        self.core.add_api(self.eeapi)
+        self.eeapi.enable_endpoint_for_tenant(
+            self.tenant_id,
+            self.template_id
+        )
+        eeapi2 = make_example_external_api(
+            self,
+            name="alternate " + self.eeapi_name
+        )
+        ept_id2 = get_template_id(self, eeapi2)
+        eeapi2.remove_template(ept_id2)
+        self.core.add_api(eeapi2)
+        req = request(self, self.root, self.verb,
+                      self.uri,
+                      headers=self.headers)
+
+        response = self.successResultOf(req)
+        self.assertEqual(response.code, 204)


### PR DESCRIPTION
This restore the RESTful API that was originally part of #647, and fixed per changes in related PRs that resulted in #647 getting merged.

This PR consists of two things:
1) The RESTful interface
2) The related tests

Tests are broken into separate files for each division of the interface (f.e OSKS-CATALOG vs OSKS-ADM). All tests pass.

Note: As this is only 3 commits (no I didn't squash anything), I hate the size but I have no good way of breaking this down in a good time constraint. I don't want to repeat the process of #647 and #648 that lead to this one - which will just be a messy merge/delete/commit/merge/delete commit.