### PR TITLE
Add Cinder "List volumes with details" endpoint

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,2 +1,7 @@
 Change Logs
 ===========
+
+Next Version
+------------
+
+* The Cinder V2 API now has limited support for the `List volumes with details <http://developer.openstack.org/api-ref-blockstorage-v2.html#listVolumesDetail>`_ endpoint.

--- a/mimic/rest/cinder_api.py
+++ b/mimic/rest/cinder_api.py
@@ -49,7 +49,7 @@ class CinderApi(object):
 
 class CinderMock(object):
     """
-    DNS Mock
+    Cinder Mock
     """
     def __init__(self, api_mock, uri_prefix, session_store, name):
         """
@@ -65,8 +65,19 @@ class CinderMock(object):
     @app.route('/v2/<string:tenant_id>/volumes', methods=['GET'])
     def get_volumes(self, request, tenant_id):
         """
-        Lists summary information for all Block Storage volumes that the tenant can access.
-        http://developer.openstack.org/api-ref-blockstorage-v2.html#getVolumesSimple
+        Lists summary information for all Block Storage volumes that the tenant
+        can access.
+        http://developer.openstack.org/api-ref-blockstorage-v2.html#listVolumes
+        """
+        request.setResponseCode(200)
+        return json.dumps({'volumes': []})
+
+    @app.route('/v2/<string:tenant_id>/volumes/detail', methods=['GET'])
+    def get_volumes_detail(self, request, tenant_id):
+        """
+        Lists detailed information for all Block Storage volumes that the
+        tenant can access.
+        http://developer.openstack.org/api-ref-blockstorage-v2.html#listVolumesDetail
         """
         request.setResponseCode(200)
         return json.dumps({'volumes': []})

--- a/mimic/rest/cinder_api.py
+++ b/mimic/rest/cinder_api.py
@@ -3,6 +3,7 @@
 Defines a mock for Cinder
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
 import json
 from uuid import uuid4
 from six import text_type

--- a/mimic/test/test_cinder.py
+++ b/mimic/test/test_cinder.py
@@ -26,9 +26,20 @@ class CinderTests(SynchronousTestCase):
         """
         Requesting block storage volumes for a tenant returns 200 and an empty list
         if no volumes are available for the given tenant
-        http://developer.openstack.org/api-ref-blockstorage-v2.html#getVolumesSimple
+        http://developer.openstack.org/api-ref-blockstorage-v2.html#listVolumes
         """
         (response, content) = self.successResultOf(json_request(
             self, self.root, b"GET", self.uri + '/volumes'))
+        self.assertEqual(200, response.code)
+        self.assertEqual(content, {'volumes': []})
+
+    def test_get_blockstorage_volume_list_detail(self):
+        """
+        Requesting block storage volume details for a tenant returns 200 and an
+        empty list if no volumes are available for the given tenant
+        http://developer.openstack.org/api-ref-blockstorage-v2.html#listVolumesDetail
+        """
+        (response, content) = self.successResultOf(json_request(
+            self, self.root, b"GET", self.uri + '/volumes/detail'))
         self.assertEqual(200, response.code)
         self.assertEqual(content, {'volumes': []})


### PR DESCRIPTION
http://developer.openstack.org/api-ref-blockstorage-v2.html#listVolumesDetail

In https://github.com/ClusterHQ/flocker/pull/2861 I introduced Mimic to our Flocker tests but turned off the detailed volume list, because it wasn't supported by Mimic and because it didn't seem necessary.
Turns out I was wrong. 
Cinder V1 detailed volume list includes volume metadata but the Cinder V2 detailed volume list doesn't....and hence our Flocker Cinder backend is broken on  Openstacks offering the Cinder v2 API.

This builds on #489 and another small step toward full Cinder mock API #218