### PR TITLE
Add Cinder catalog entries that match devstack

### DIFF
--- a/mimic/rest/cinder_api.py
+++ b/mimic/rest/cinder_api.py
@@ -31,7 +31,14 @@ class CinderApi(object):
         """
         return [
             Entry(
-                tenant_id, "volume", "cloudBlockStorage",
+                tenant_id, "volume", "cinder",
+                [
+                    Endpoint(tenant_id, region, text_type(uuid4()), prefix="v2")
+                    for region in self._regions
+                ]
+            ),
+            Entry(
+                tenant_id, "volumev2", "cinderv2",
                 [
                     Endpoint(tenant_id, region, text_type(uuid4()), prefix="v2")
                     for region in self._regions

--- a/mimic/test/test_core.py
+++ b/mimic/test/test_core.py
@@ -63,7 +63,7 @@ class CoreBuildingPluginsTests(SynchronousTestCase):
             dns_plugin.dns,
             cinder_plugin.cinder
         ))
-        # all plugsin should be on the internal listing
+        # all plugins should be on the internal listing
         self.assertEqual(
             plugin_apis,
             set(core._uuid_to_api_internal.values()))
@@ -71,10 +71,6 @@ class CoreBuildingPluginsTests(SynchronousTestCase):
         self.assertEqual(
             set([]),
             set(core._uuid_to_api_external.values()))
-        self.assertEqual(
-            len(plugin_apis),
-            len(list(core.entries_for_tenant('any_tenant', {},
-                                             'http://mimic'))))
 
     def test_load_domain_plugin_includes_all_domain_plugins(self):
         """


### PR DESCRIPTION
I've got some code which needs to work with Rackspace Cinder V1 and with OpenStack Cinder v1 and it attempts to detect whether Cinder v2 is available by performing a volume list using the v2 API and then the v1 API if the first results in an EndpointNotFound error.

In the absence of a permanent devstack testing environment, I'm testing this with Mimic, but mimic's cinder API doesn't use the same service catalog as devstack.

It *only* provides the default "cinder" endpoint which provides a Cinder v2 API.

Here I've added an additional v2 endpoint which seems to be in accordance with this specification:

* https://specs.openstack.org/openstack/openstack-specs/specs/service-catalog.html

For reference, the devstack mitaka service list looks like this:

```
stack@server-03:~$ keystone service-list
...
+----------------------------------+-------------+----------------+-----------------------------------+
|                id                |     name    |      type      |            description            |
+----------------------------------+-------------+----------------+-----------------------------------+
| 7e8eafced3ed4cb8a28a9e48ecf93ef2 |    cinder   |     volume     |       Cinder Volume Service       |
| 26461032e2584578a82a954a25626a37 |   cinderv2  |    volumev2    |      Cinder Volume Service V2     |
| 54bd719bbf1d406b904585c75827e6d7 |    glance   |     image      |        Glance Image Service       |
| eeb8b5d0ee044d74b3d0dcd7f7af9cd0 |   keystone  |    identity    |                                   |
| 05bdfbaf73054c4aa1c16e565ad09e60 |   neutron   |    network     |          Neutron Service          |
| 5772bcce97d0422d9506a4d935ca6597 |     nova    |    compute     |        Nova Compute Service       |
| df370717d4a644ac8d03b9a33259af13 | nova_legacy | compute_legacy | Nova Compute Service (Legacy 2.0) |
+----------------------------------+-------------+----------------+-----------------------------------+
```

