### PR TITLE
don't depend on implicit behavior, removed in recent twisted

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,8 @@ FROM python:2.7
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-COPY requirements/production.txt /usr/src/app/requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt
-
 COPY . /usr/src/app
+RUN pip install --no-cache-dir . -r requirements/production.txt
 
 EXPOSE 8900
 CMD ["twistd", "-n", "mimic"]


### PR DESCRIPTION
Fix the Dockerfile to actually *install* the software.