### PR TITLE
work around poor interaction between whatever changed in zope.interface 4.3.3's usage of namespace packages and py2app

### DIFF
--- a/build-app.sh
+++ b/build-app.sh
@@ -24,6 +24,10 @@ pip install .;
 # install dependencies that are needed to build and run the mac application
 pip install -r requirements/mac-app.txt;
 
+# work around zope.interface's namespace module shenanigans
+# see https://github.com/zopefoundation/zope.interface/issues/67
+touch "$(dirname "$(dirname "$(python -c 'import zope.interface; print(zope.interface.__file__)')")")"/__init__.py
+
 # build the application using py2app
 python setup.py py2app;
 

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -30,4 +30,4 @@ unittest2==1.1.0
 Werkzeug==0.11.11
 wheel==0.29.0
 xmltodict==0.10.2
-zope.interface==4.3.2
+zope.interface==4.3.3

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -5,7 +5,7 @@
 attrs==16.3.0
 cffi==1.9.1
 coverage==4.2
-cryptography==1.7
+cryptography==1.7.1
 ddt==1.1.1
 enum34==1.1.6
 extras==1.0.0


### PR DESCRIPTION
Allow #700 to land

https://github.com/zopefoundation/zope.interface/issues/67

