### PR TITLE
Specify listen port in required format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .DS_Store
 *.pyc
 dropin.cache
+twistd.log
 twistd.pid
 docs/_build
 _tmp

--- a/mimic/tap.py
+++ b/mimic/tap.py
@@ -16,7 +16,7 @@ class Options(usage.Options):
     """
     Options for Mimic
     """
-    optParameters = [['listen', 'l', '8900', 'The endpoint to listen on.']]
+    optParameters = [['listen', 'l', 'tcp:8900', 'The endpoint to listen on.']]
     optFlags = [['realtime', 'r',
                  'Make mimic advance time as real time advances; '
                  'disable the "tick" endpoint.'],


### PR DESCRIPTION
Fixes a current issue on master, in which the twistd server will not start up, but instead gives the following error. Note that `pip freeze` shows `Twisted==17.1.0`.

```  
File "/Users/foo/.virtualenvs/venv/bin/twistd", line 11, in <module>
    sys.exit(run())
  File "/Users/foo/.virtualenvs/venv/lib/python3.6/site-packages/twisted/scripts/twistd.py", line 29, in run
    app.run(runApp, ServerOptions)
  File "/Users/foo/.virtualenvs/venv/lib/python3.6/site-packages/twisted/application/app.py", line 662, in run
    runApp(config)
  File "/Users/foo/.virtualenvs/venv/lib/python3.6/site-packages/twisted/scripts/twistd.py", line 25, in runApp
    _SomeApplicationRunner(config).run()
  File "/Users/foo/.virtualenvs/venv/lib/python3.6/site-packages/twisted/application/app.py", line 380, in run
    self.application = self.createOrGetApplication()
  File "/Users/foo/.virtualenvs/venv/lib/python3.6/site-packages/twisted/application/app.py", line 440, in createOrGetApplication
    ser = plg.makeService(self.config.subOptions)
  File "/Users/foo/repos/mimic/mimic/tap.py", line 39, in makeService
    service(config['listen'], site).setServiceParent(s)
  File "/Users/foo/.virtualenvs/venv/lib/python3.6/site-packages/twisted/application/strports.py", line 40, in service
    endpoints.serverFromString(reactor, description), factory)
  File "/Users/foo/.virtualenvs/venv/lib/python3.6/site-packages/twisted/internet/endpoints.py", line 1569, in serverFromString
    nameOrPlugin, args, kw = _parseServer(description, None)
  File "/Users/foo/.virtualenvs/venv/lib/python3.6/site-packages/twisted/internet/endpoints.py", line 1487, in _parseServer
    getPlugins(IStreamServerEndpointStringParser), endpointType
  File "/Users/foo/.virtualenvs/venv/lib/python3.6/site-packages/twisted/internet/endpoints.py", line 1503, in _matchPluginToPrefix
    raise ValueError("Unknown endpoint type: '%s'" % (endpointType,))
ValueError: Unknown endpoint type: '8900'
```

